### PR TITLE
gemm/gemv now accept config structs and slices or views

### DIFF
--- a/src/blas.rs
+++ b/src/blas.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::cublas::{result, result::CublasError, sys};
-use crate::device::{CudaDevice, CudaSlice};
+use crate::device::{CudaDevice, DevicePtr, DevicePtrMut};
 use core::ffi::c_int;
 use std::sync::Arc;
 
@@ -42,6 +42,18 @@ impl Drop for CudaBlas {
     }
 }
 
+/// Configuration for [Gemv]
+pub struct GemvConfig<T> {
+    pub trans: sys::cublasOperation_t,
+    pub m: c_int,
+    pub n: c_int,
+    pub alpha: T,
+    pub lda: c_int,
+    pub incx: c_int,
+    pub beta: T,
+    pub incy: c_int,
+}
+
 /// Matrix vector multiplication with elements of type `T`
 pub trait Gemv<T> {
     /// Matrix vector multiplication.
@@ -49,84 +61,77 @@ pub trait Gemv<T> {
     /// # Safety
     /// This is unsafe because improper arguments may lead to invalid
     /// memory accesses.
-    unsafe fn gemv_async(
+    unsafe fn gemv_async<A: DevicePtr<T>, X: DevicePtr<T>, Y: DevicePtrMut<T>>(
         &self,
-        trans: sys::cublasOperation_t,
-        m: c_int,
-        n: c_int,
-        alpha: T,
-        a: &CudaSlice<T>,
-        lda: c_int,
-        x: &CudaSlice<T>,
-        incx: c_int,
-        beta: T,
-        y: &mut CudaSlice<T>,
-        incy: c_int,
+        cfg: GemvConfig<T>,
+        a: &A,
+        x: &X,
+        y: &mut Y,
     ) -> Result<(), CublasError>;
 }
 
 impl Gemv<f32> for CudaBlas {
-    unsafe fn gemv_async(
+    unsafe fn gemv_async<A: DevicePtr<f32>, X: DevicePtr<f32>, Y: DevicePtrMut<f32>>(
         &self,
-        trans: sys::cublasOperation_t,
-        m: c_int,
-        n: c_int,
-        alpha: f32,
-        a: &CudaSlice<f32>,
-        lda: c_int,
-        x: &CudaSlice<f32>,
-        incx: c_int,
-        beta: f32,
-        y: &mut CudaSlice<f32>,
-        incy: c_int,
+        cfg: GemvConfig<f32>,
+        a: &A,
+        x: &X,
+        y: &mut Y,
     ) -> Result<(), CublasError> {
         result::sgemv(
             self.handle,
-            trans,
-            m,
-            n,
-            (&alpha) as *const _,
-            a.cu_device_ptr as *const _,
-            lda,
-            x.cu_device_ptr as *const _,
-            incx,
-            (&beta) as *const _,
-            y.cu_device_ptr as *mut _,
-            incy,
+            cfg.trans,
+            cfg.m,
+            cfg.n,
+            (&cfg.alpha) as *const _,
+            *a.device_ptr() as *const _,
+            cfg.lda,
+            *x.device_ptr() as *const _,
+            cfg.incx,
+            (&cfg.beta) as *const _,
+            *y.device_ptr_mut() as *mut _,
+            cfg.incy,
         )
     }
 }
 
 impl Gemv<f64> for CudaBlas {
-    unsafe fn gemv_async(
+    unsafe fn gemv_async<A: DevicePtr<f64>, X: DevicePtr<f64>, Y: DevicePtrMut<f64>>(
         &self,
-        trans: sys::cublasOperation_t,
-        m: c_int,
-        n: c_int,
-        alpha: f64,
-        a: &CudaSlice<f64>,
-        lda: c_int,
-        x: &CudaSlice<f64>,
-        incx: c_int,
-        beta: f64,
-        y: &mut CudaSlice<f64>,
-        incy: c_int,
+        cfg: GemvConfig<f64>,
+        a: &A,
+        x: &X,
+        y: &mut Y,
     ) -> Result<(), CublasError> {
         result::dgemv(
             self.handle,
-            trans,
-            m,
-            n,
-            (&alpha) as *const _,
-            a.cu_device_ptr as *const _,
-            lda,
-            x.cu_device_ptr as *const _,
-            incx,
-            (&beta) as *const _,
-            y.cu_device_ptr as *mut _,
-            incy,
+            cfg.trans,
+            cfg.m,
+            cfg.n,
+            (&cfg.alpha) as *const _,
+            *a.device_ptr() as *const _,
+            cfg.lda,
+            *x.device_ptr() as *const _,
+            cfg.incx,
+            (&cfg.beta) as *const _,
+            *y.device_ptr_mut() as *mut _,
+            cfg.incy,
         )
     }
+}
+
+/// Configuration for [Gemm]
+pub struct GemmConfig<T> {
+    pub transa: sys::cublasOperation_t,
+    pub transb: sys::cublasOperation_t,
+    pub m: c_int,
+    pub n: c_int,
+    pub k: c_int,
+    pub alpha: T,
+    pub lda: c_int,
+    pub ldb: c_int,
+    pub beta: T,
+    pub ldc: c_int,
 }
 
 /// Matrix matrix multiplication with elements of type `T`
@@ -136,92 +141,65 @@ pub trait Gemm<T> {
     /// # Safety
     /// This is unsafe because improper arguments may lead to invalid
     /// memory accesses.
-    unsafe fn gemm_async(
+    unsafe fn gemm_async<A: DevicePtr<T>, B: DevicePtr<T>, C: DevicePtrMut<T>>(
         &self,
-        transa: sys::cublasOperation_t,
-        transb: sys::cublasOperation_t,
-        m: c_int,
-        n: c_int,
-        k: c_int,
-        alpha: T,
-        a: &CudaSlice<T>,
-        lda: c_int,
-        b: &CudaSlice<T>,
-        ldb: c_int,
-        beta: T,
-        c: &mut CudaSlice<T>,
-        ldc: c_int,
+        cfg: GemmConfig<T>,
+        a: &A,
+        b: &B,
+        c: &mut C,
     ) -> Result<(), CublasError>;
 }
 
 impl Gemm<f32> for CudaBlas {
-    unsafe fn gemm_async(
+    unsafe fn gemm_async<A: DevicePtr<f32>, B: DevicePtr<f32>, C: DevicePtrMut<f32>>(
         &self,
-        transa: sys::cublasOperation_t,
-        transb: sys::cublasOperation_t,
-        m: c_int,
-        n: c_int,
-        k: c_int,
-        alpha: f32,
-        a: &CudaSlice<f32>,
-        lda: c_int,
-        b: &CudaSlice<f32>,
-        ldb: c_int,
-        beta: f32,
-        c: &mut CudaSlice<f32>,
-        ldc: c_int,
+        cfg: GemmConfig<f32>,
+        a: &A,
+        b: &B,
+        c: &mut C,
     ) -> Result<(), CublasError> {
         result::sgemm(
             self.handle,
-            transa,
-            transb,
-            m,
-            n,
-            k,
-            (&alpha) as *const _,
-            a.cu_device_ptr as *const _,
-            lda,
-            b.cu_device_ptr as *const _,
-            ldb,
-            (&beta) as *const _,
-            c.cu_device_ptr as *mut _,
-            ldc,
+            cfg.transa,
+            cfg.transb,
+            cfg.m,
+            cfg.n,
+            cfg.k,
+            (&cfg.alpha) as *const _,
+            *a.device_ptr() as *const _,
+            cfg.lda,
+            *b.device_ptr() as *const _,
+            cfg.ldb,
+            (&cfg.beta) as *const _,
+            *c.device_ptr_mut() as *mut _,
+            cfg.ldc,
         )
     }
 }
 
 impl Gemm<f64> for CudaBlas {
-    unsafe fn gemm_async(
+    unsafe fn gemm_async<A: DevicePtr<f64>, B: DevicePtr<f64>, C: DevicePtrMut<f64>>(
         &self,
-        transa: sys::cublasOperation_t,
-        transb: sys::cublasOperation_t,
-        m: c_int,
-        n: c_int,
-        k: c_int,
-        alpha: f64,
-        a: &CudaSlice<f64>,
-        lda: c_int,
-        b: &CudaSlice<f64>,
-        ldb: c_int,
-        beta: f64,
-        c: &mut CudaSlice<f64>,
-        ldc: c_int,
+        cfg: GemmConfig<f64>,
+        a: &A,
+        b: &B,
+        c: &mut C,
     ) -> Result<(), CublasError> {
         result::dgemm(
             self.handle,
-            transa,
-            transb,
-            m,
-            n,
-            k,
-            (&alpha) as *const _,
-            a.cu_device_ptr as *const _,
-            lda,
-            b.cu_device_ptr as *const _,
-            ldb,
-            (&beta) as *const _,
-            c.cu_device_ptr as *mut _,
-            ldc,
+            cfg.transa,
+            cfg.transb,
+            cfg.m,
+            cfg.n,
+            cfg.k,
+            (&cfg.alpha) as *const _,
+            *a.device_ptr() as *const _,
+            cfg.lda,
+            *b.device_ptr() as *const _,
+            cfg.ldb,
+            (&cfg.beta) as *const _,
+            *c.device_ptr_mut() as *mut _,
+            cfg.ldc,
         )
     }
 }
@@ -299,17 +277,19 @@ mod tests {
         let mut c_dev = dev.alloc_zeros_async(M).unwrap();
         unsafe {
             blas.gemv_async(
-                sys::cublasOperation_t::CUBLAS_OP_T,
-                N as i32,
-                M as i32,
-                1.0,
+                GemvConfig {
+                    trans: sys::cublasOperation_t::CUBLAS_OP_T,
+                    m: N as i32,
+                    n: M as i32,
+                    alpha: 1.0,
+                    lda: N as i32,
+                    incx: 1,
+                    beta: 0.0,
+                    incy: 1,
+                },
                 &a_dev,
-                N as i32,
                 &b_dev,
-                1,
-                0.0,
                 &mut c_dev,
-                1,
             )
         }
         .unwrap();
@@ -356,17 +336,19 @@ mod tests {
         let mut c_dev = dev.alloc_zeros_async(M).unwrap();
         unsafe {
             blas.gemv_async(
-                sys::cublasOperation_t::CUBLAS_OP_T,
-                N as i32,
-                M as i32,
-                1.0,
+                GemvConfig {
+                    trans: sys::cublasOperation_t::CUBLAS_OP_T,
+                    m: N as i32,
+                    n: M as i32,
+                    alpha: 1.0,
+                    lda: N as i32,
+                    incx: 1,
+                    beta: 0.0,
+                    incy: 1,
+                },
                 &a_dev,
-                N as i32,
                 &b_dev,
-                1,
-                0.0,
                 &mut c_dev,
-                1,
             )
         }
         .unwrap();
@@ -414,19 +396,21 @@ mod tests {
         let mut c_dev = dev.alloc_zeros_async::<f32>(M * N).unwrap();
         unsafe {
             blas.gemm_async(
-                sys::cublasOperation_t::CUBLAS_OP_N,
-                sys::cublasOperation_t::CUBLAS_OP_N,
-                N as i32,
-                M as i32,
-                K as i32,
-                1.0,
+                GemmConfig {
+                    transa: sys::cublasOperation_t::CUBLAS_OP_N,
+                    transb: sys::cublasOperation_t::CUBLAS_OP_N,
+                    m: N as i32,
+                    n: M as i32,
+                    k: K as i32,
+                    alpha: 1.0,
+                    lda: N as i32,
+                    ldb: K as i32,
+                    beta: 0.0,
+                    ldc: N as i32,
+                },
                 &b_dev,
-                N as i32,
                 &a_dev,
-                K as i32,
-                0.0,
                 &mut c_dev,
-                N as i32,
             )
         }
         .unwrap();
@@ -476,19 +460,21 @@ mod tests {
         let mut c_dev = dev.alloc_zeros_async::<f64>(M * N).unwrap();
         unsafe {
             blas.gemm_async(
-                sys::cublasOperation_t::CUBLAS_OP_N,
-                sys::cublasOperation_t::CUBLAS_OP_N,
-                N as i32,
-                M as i32,
-                K as i32,
-                1.0,
+                GemmConfig {
+                    transa: sys::cublasOperation_t::CUBLAS_OP_N,
+                    transb: sys::cublasOperation_t::CUBLAS_OP_N,
+                    m: N as i32,
+                    n: M as i32,
+                    k: K as i32,
+                    alpha: 1.0,
+                    lda: N as i32,
+                    ldb: K as i32,
+                    beta: 0.0,
+                    ldc: N as i32,
+                },
                 &b_dev,
-                N as i32,
                 &a_dev,
-                K as i32,
-                0.0,
                 &mut c_dev,
-                N as i32,
             )
         }
         .unwrap();

--- a/src/cublas/result.rs
+++ b/src/cublas/result.rs
@@ -1,5 +1,5 @@
 use super::sys;
-use core::ffi::c_int;
+use core::ffi::{c_int, c_longlong};
 use core::mem::MaybeUninit;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -167,6 +167,78 @@ pub unsafe fn dgemm(
 ) -> Result<(), CublasError> {
     sys::cublasDgemm_v2(
         handle, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+    )
+    .result()
+}
+
+/// Single precision batched matmul. See
+/// [nvidia docs](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-gemmstridedbatched)
+///
+/// # Safety
+///
+/// - `a`, `b`, and `c` must be valid device pointers that have not been freed.
+/// - `alpha` and `beta` can be pointers to host memory, but must be not null
+/// - the strides and sizes must be sized correctly
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn sgemm_strided_batched(
+    handle: sys::cublasHandle_t,
+    transa: sys::cublasOperation_t,
+    transb: sys::cublasOperation_t,
+    m: c_int,
+    n: c_int,
+    k: c_int,
+    alpha: *const f32,
+    a: *const f32,
+    lda: c_int,
+    stride_a: c_longlong,
+    b: *const f32,
+    ldb: c_int,
+    stride_b: c_longlong,
+    beta: *const f32,
+    c: *mut f32,
+    ldc: c_int,
+    stride_c: c_longlong,
+    batch_size: c_int,
+) -> Result<(), CublasError> {
+    sys::cublasSgemmStridedBatched(
+        handle, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
+        stride_c, batch_size,
+    )
+    .result()
+}
+
+/// Double precision batched matmul. See
+/// [nvidia docs](https://docs.nvidia.com/cuda/cublas/index.html#cublas-t-gemmstridedbatched)
+///
+/// # Safety
+///
+/// - `a`, `b`, and `c` must be valid device pointers that have not been freed.
+/// - `alpha` and `beta` can be pointers to host memory, but must be not null
+/// - the strides and sizes must be sized correctly
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn dgemm_strided_batched(
+    handle: sys::cublasHandle_t,
+    transa: sys::cublasOperation_t,
+    transb: sys::cublasOperation_t,
+    m: c_int,
+    n: c_int,
+    k: c_int,
+    alpha: *const f64,
+    a: *const f64,
+    lda: c_int,
+    stride_a: c_longlong,
+    b: *const f64,
+    ldb: c_int,
+    stride_b: c_longlong,
+    beta: *const f64,
+    c: *mut f64,
+    ldc: c_int,
+    stride_c: c_longlong,
+    batch_size: c_int,
+) -> Result<(), CublasError> {
+    sys::cublasDgemmStridedBatched(
+        handle, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
+        stride_c, batch_size,
     )
     .result()
 }


### PR DESCRIPTION
Resolves #49 
Resolves #46 

- Moves Gemm/Gemv parameters to config structs
- Gemm/Gemv accept any of CudaSlice/CudaView/CudaViewMut 
- Adds `trait DevicePtr` and `trait DevicePtrMut`