### PR TITLE
Implement ValidAsZeroBits for bool

### DIFF
--- a/src/driver/safe.rs
+++ b/src/driver/safe.rs
@@ -1026,6 +1026,7 @@ impl std::error::Error for BuildError {}
 /// Not all types are valid when all bits are set to 0.
 /// Be very sure when implementing this trait!
 pub unsafe trait ValidAsZeroBits {}
+unsafe impl ValidAsZeroBits for bool {}
 unsafe impl ValidAsZeroBits for i8 {}
 unsafe impl ValidAsZeroBits for i16 {}
 unsafe impl ValidAsZeroBits for i32 {}


### PR DESCRIPTION
This change is needed to implement https://github.com/coreylowman/dfdx/issues/306 because the output of comparison operations is a boolean, and for CUDA we want to initialize the output tensor beforehand.

I believe it is sound, as according to the links below, `0` is guaranteed to be interpreted as `false` in both Rust and C++.

- https://doc.rust-lang.org/reference/types/boolean.html
- https://stackoverflow.com/questions/19351483/how-is-a-bool-represented-in-memory
