### PR TITLE
Adding DeviceRepr, removing AsKernelParam

### DIFF
--- a/src/curand/safe.rs
+++ b/src/curand/safe.rs
@@ -102,7 +102,10 @@ mod tests {
     };
     use std::vec::Vec;
 
-    fn gen_uniform<T: ValidAsZeroBits + Clone + Default + Unpin>(seed: u64, n: usize) -> Vec<T>
+    fn gen_uniform<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
+        seed: u64,
+        n: usize,
+    ) -> Vec<T>
     where
         super::sys::curandGenerator_t: UniformFill<T>,
     {
@@ -113,7 +116,7 @@ mod tests {
         dev.sync_release(a_dev).unwrap()
     }
 
-    fn gen_normal<T: ValidAsZeroBits + Clone + Default + Unpin>(
+    fn gen_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
         seed: u64,
         n: usize,
         mean: T,
@@ -129,7 +132,7 @@ mod tests {
         dev.sync_release(a_dev).unwrap()
     }
 
-    fn gen_log_normal<T: ValidAsZeroBits + Clone + Default + Unpin>(
+    fn gen_log_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
         seed: u64,
         n: usize,
         mean: T,

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -167,11 +167,11 @@ pub(crate) mod device_ptr;
 pub(crate) mod launch;
 pub(crate) mod profile;
 
-pub use self::alloc::ValidAsZeroBits;
+pub use self::alloc::{DeviceRepr, ValidAsZeroBits};
 pub use self::build::{BuildError, CudaDeviceBuilder};
 pub use self::core::{CudaDevice, CudaFunction, CudaSlice, CudaStream, CudaView, CudaViewMut};
 pub use self::device_ptr::{DevicePtr, DevicePtrMut, DeviceSlice};
-pub use self::launch::{AsKernelParam, LaunchAsync, LaunchConfig};
+pub use self::launch::{LaunchAsync, LaunchConfig};
 pub use self::profile::{profiler_start, profiler_stop};
 
 pub use crate::driver::result::DriverError;


### PR DESCRIPTION
Resolves #70 

Currently its possible to allocate/send types that aren't actually valid cuda types. This PR reworks AsKernelParam to the more general DeviceRepr, which is used in place of AsKernelParam.

Addtionally, things that allocate CudaSlice have `T: DeviceRepr` now