### PR TITLE
Consistent & clear naming convention

### DIFF
--- a/examples/01-allocate.rs
+++ b/examples/01-allocate.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), DriverError> {
     let _: CudaSlice<usize> = dev.htod_copy(vec![0; 10])?;
 
     // or finially, initialize with a slice. this is synchronous though.
-    let _: CudaSlice<u32> = dev.htod_copy_sync(&[1, 2, 3])?;
+    let _: CudaSlice<u32> = dev.htod_sync_copy(&[1, 2, 3])?;
 
     Ok(())
 }

--- a/examples/01-allocate.rs
+++ b/examples/01-allocate.rs
@@ -1,0 +1,19 @@
+use cudarc::driver::{CudaDeviceBuilder, CudaSlice, DriverError};
+
+fn main() -> Result<(), DriverError> {
+    let dev = CudaDeviceBuilder::new(0).build().unwrap();
+
+    // unsafe initialization of unset memory
+    let _: CudaSlice<f32> = unsafe { dev.alloc::<f32>(10) }?;
+
+    // this will have memory initialized as 0
+    let _: CudaSlice<f64> = dev.alloc_zeros::<f64>(10)?;
+
+    // initialize with a rust vec
+    let _: CudaSlice<usize> = dev.htod_copy(vec![0; 10])?;
+
+    // or finially, initialize with a slice. this is synchronous though.
+    let _: CudaSlice<u32> = dev.htod_copy_sync(&[1, 2, 3])?;
+
+    Ok(())
+}

--- a/examples/02-copy.rs
+++ b/examples/02-copy.rs
@@ -13,18 +13,18 @@ fn main() -> Result<(), DriverError> {
     dev.htod_copy_into(vec![2.0; 10], &mut b)?;
 
     // if you want to use slices, you can do synchronous copy
-    dev.htod_copy_into_sync(&[3.0; 10], &mut b)?;
+    dev.htod_sync_copy_into(&[3.0; 10], &mut b)?;
 
     // you can transfer back using reclaim:
-    let mut a_host: Vec<f64> = dev.reclaim_sync(a)?;
+    let mut a_host: Vec<f64> = dev.sync_reclaim(a)?;
     assert_eq!(a_host, [0.0; 10]);
 
     // or copy back without losing ownership:
-    let b_host = dev.dtoh_copy_sync(&b)?;
+    let b_host = dev.dtoh_sync_copy(&b)?;
     assert_eq!(b_host, [3.0; 10]);
 
     // or use a slice
-    dev.dtoh_copy_into_sync(&b, &mut a_host)?;
+    dev.dtoh_sync_copy_into(&b, &mut a_host)?;
     assert_eq!(a_host, b_host);
 
     Ok(())

--- a/examples/02-copy.rs
+++ b/examples/02-copy.rs
@@ -1,0 +1,31 @@
+use cudarc::driver::{CudaDeviceBuilder, CudaSlice, DriverError};
+
+fn main() -> Result<(), DriverError> {
+    let dev = CudaDeviceBuilder::new(0).build().unwrap();
+
+    let a: CudaSlice<f64> = dev.alloc_zeros::<f64>(10)?;
+    let mut b = dev.alloc_zeros::<f64>(10)?;
+
+    // you can do device to device copies of course
+    dev.dtod_copy(&a, &mut b)?;
+
+    // but also host to device copys with already allocated buffers
+    dev.htod_copy_into(vec![2.0; 10], &mut b)?;
+
+    // if you want to use slices, you can do synchronous copy
+    dev.htod_copy_into_sync(&[3.0; 10], &mut b)?;
+
+    // you can transfer back using reclaim:
+    let mut a_host: Vec<f64> = dev.reclaim_sync(a)?;
+    assert_eq!(a_host, [0.0; 10]);
+
+    // or copy back without losing ownership:
+    let b_host = dev.dtoh_copy_sync(&b)?;
+    assert_eq!(b_host, [3.0; 10]);
+
+    // or use a slice
+    dev.dtoh_copy_into_sync(&b, &mut a_host)?;
+    assert_eq!(a_host, b_host);
+
+    Ok(())
+}

--- a/examples/launch-kernel.rs
+++ b/examples/launch-kernel.rs
@@ -1,6 +1,6 @@
-use cudarc::driver::{CudaDeviceBuilder, LaunchAsync, LaunchConfig};
+use cudarc::driver::{CudaDeviceBuilder, DriverError, LaunchAsync, LaunchConfig};
 
-fn main() {
+fn main() -> Result<(), DriverError> {
     let dev = CudaDeviceBuilder::new(0)
         .with_ptx_from_file("./examples/sin.ptx", "sin_module", &["sin_kernel"])
         .build()
@@ -10,17 +10,19 @@ fn main() {
 
     let a_host = [1.0, 2.0, 3.0];
 
-    let a_dev = dev.sync_copy(&a_host).unwrap();
+    let a_dev = dev.copy_htod_async(a_host.into())?;
     let mut b_dev = a_dev.clone();
 
     let n = 3;
     let cfg = LaunchConfig::for_num_elems(n);
-    unsafe { f.launch_async(cfg, (&mut b_dev, &a_dev, n as i32)) }.unwrap();
+    unsafe { f.launch_async(cfg, (&mut b_dev, &a_dev, n as i32)) }?;
 
-    let a_host_2 = dev.sync_release(a_dev).unwrap();
-    let b_host = dev.sync_release(b_dev).unwrap();
+    let a_host_2 = dev.reclaim(a_dev)?;
+    let b_host = dev.reclaim(b_dev)?;
 
     println!("Found {:?}", b_host);
     println!("Expected {:?}", a_host.map(f32::sin));
     assert_eq!(&a_host, a_host_2.as_slice());
+
+    Ok(())
 }

--- a/examples/launch-kernel.rs
+++ b/examples/launch-kernel.rs
@@ -10,15 +10,15 @@ fn main() -> Result<(), DriverError> {
 
     let a_host = [1.0, 2.0, 3.0];
 
-    let a_dev = dev.copy_htod_async(a_host.into())?;
+    let a_dev = dev.htod_copy(a_host.into())?;
     let mut b_dev = a_dev.clone();
 
     let n = 3;
     let cfg = LaunchConfig::for_num_elems(n);
     unsafe { f.launch_async(cfg, (&mut b_dev, &a_dev, n as i32)) }?;
 
-    let a_host_2 = dev.reclaim(a_dev)?;
-    let b_host = dev.reclaim(b_dev)?;
+    let a_host_2 = dev.reclaim_sync(a_dev)?;
+    let b_host = dev.reclaim_sync(b_dev)?;
 
     println!("Found {:?}", b_host);
     println!("Expected {:?}", a_host.map(f32::sin));

--- a/examples/launch-kernel.rs
+++ b/examples/launch-kernel.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), DriverError> {
 
     let n = 3;
     let cfg = LaunchConfig::for_num_elems(n);
-    unsafe { f.launch_async(cfg, (&mut b_dev, &a_dev, n as i32)) }?;
+    unsafe { f.launch(cfg, (&mut b_dev, &a_dev, n as i32)) }?;
 
     let a_host_2 = dev.reclaim_sync(a_dev)?;
     let b_host = dev.reclaim_sync(b_dev)?;

--- a/examples/launch-kernel.rs
+++ b/examples/launch-kernel.rs
@@ -17,8 +17,8 @@ fn main() -> Result<(), DriverError> {
     let cfg = LaunchConfig::for_num_elems(n);
     unsafe { f.launch(cfg, (&mut b_dev, &a_dev, n as i32)) }?;
 
-    let a_host_2 = dev.reclaim_sync(a_dev)?;
-    let b_host = dev.reclaim_sync(b_dev)?;
+    let a_host_2 = dev.sync_reclaim(a_dev)?;
+    let b_host = dev.sync_reclaim(b_dev)?;
 
     println!("Found {:?}", b_host);
     println!("Expected {:?}", a_host.map(f32::sin));

--- a/examples/simple-matmul.rs
+++ b/examples/simple-matmul.rs
@@ -38,9 +38,9 @@ fn main() -> Result<(), CompileError> {
     let b_host = [1.0f32, 2.0, 3.0, 4.0];
     let mut c_host = [0.0f32; 4];
 
-    let a_dev = dev.copy_htod_sync(&a_host).unwrap();
-    let b_dev = dev.copy_htod_sync(&b_host).unwrap();
-    let mut c_dev = dev.copy_htod_sync(&c_host).unwrap();
+    let a_dev = dev.htod_copy_sync(&a_host).unwrap();
+    let b_dev = dev.htod_copy_sync(&b_host).unwrap();
+    let mut c_dev = dev.htod_copy_sync(&c_host).unwrap();
 
     println!("Copied in {:?}", start.elapsed());
 
@@ -51,7 +51,7 @@ fn main() -> Result<(), CompileError> {
     };
     unsafe { f.launch_async(cfg, (&a_dev, &b_dev, &mut c_dev, 2i32)) }.unwrap();
 
-    dev.copy_into_dtoh_sync(&c_dev, &mut c_host).unwrap();
+    dev.dtoh_copy_into_sync(&c_dev, &mut c_host).unwrap();
     println!("Found {:?} in {:?}", c_host, start.elapsed());
     Ok(())
 }

--- a/examples/simple-matmul.rs
+++ b/examples/simple-matmul.rs
@@ -38,9 +38,9 @@ fn main() -> Result<(), CompileError> {
     let b_host = [1.0f32, 2.0, 3.0, 4.0];
     let mut c_host = [0.0f32; 4];
 
-    let a_dev = dev.htod_copy_sync(&a_host).unwrap();
-    let b_dev = dev.htod_copy_sync(&b_host).unwrap();
-    let mut c_dev = dev.htod_copy_sync(&c_host).unwrap();
+    let a_dev = dev.htod_sync_copy(&a_host).unwrap();
+    let b_dev = dev.htod_sync_copy(&b_host).unwrap();
+    let mut c_dev = dev.htod_sync_copy(&c_host).unwrap();
 
     println!("Copied in {:?}", start.elapsed());
 
@@ -51,7 +51,7 @@ fn main() -> Result<(), CompileError> {
     };
     unsafe { f.launch(cfg, (&a_dev, &b_dev, &mut c_dev, 2i32)) }.unwrap();
 
-    dev.dtoh_copy_into_sync(&c_dev, &mut c_host).unwrap();
+    dev.dtoh_sync_copy_into(&c_dev, &mut c_host).unwrap();
     println!("Found {:?} in {:?}", c_host, start.elapsed());
     Ok(())
 }

--- a/examples/simple-matmul.rs
+++ b/examples/simple-matmul.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), CompileError> {
         grid_dim: (1, 1, 1),
         shared_mem_bytes: 0,
     };
-    unsafe { f.launch_async(cfg, (&a_dev, &b_dev, &mut c_dev, 2i32)) }.unwrap();
+    unsafe { f.launch(cfg, (&a_dev, &b_dev, &mut c_dev, 2i32)) }.unwrap();
 
     dev.dtoh_copy_into_sync(&c_dev, &mut c_host).unwrap();
     println!("Found {:?} in {:?}", c_host, start.elapsed());

--- a/examples/simple-matmul.rs
+++ b/examples/simple-matmul.rs
@@ -38,9 +38,9 @@ fn main() -> Result<(), CompileError> {
     let b_host = [1.0f32, 2.0, 3.0, 4.0];
     let mut c_host = [0.0f32; 4];
 
-    let a_dev = dev.sync_copy(&a_host).unwrap();
-    let b_dev = dev.sync_copy(&b_host).unwrap();
-    let mut c_dev = dev.sync_copy(&c_host).unwrap();
+    let a_dev = dev.copy_htod_sync(&a_host).unwrap();
+    let b_dev = dev.copy_htod_sync(&b_host).unwrap();
+    let mut c_dev = dev.copy_htod_sync(&c_host).unwrap();
 
     println!("Copied in {:?}", start.elapsed());
 
@@ -51,7 +51,7 @@ fn main() -> Result<(), CompileError> {
     };
     unsafe { f.launch_async(cfg, (&a_dev, &b_dev, &mut c_dev, 2i32)) }.unwrap();
 
-    dev.sync_copy_from(&c_dev, &mut c_host).unwrap();
+    dev.copy_into_dtoh_sync(&c_dev, &mut c_host).unwrap();
     println!("Found {:?} in {:?}", c_host, start.elapsed());
     Ok(())
 }

--- a/src/cublas/safe.rs
+++ b/src/cublas/safe.rs
@@ -439,11 +439,11 @@ mod tests {
         gemv_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.sync_copy(&[
+        let a_dev = dev.copy_htod_sync(&[
             0.9314776, 0.10300648, -0.620774, 1.527075, 0.0259804,
             0.16820757, -0.94463515, -1.3850101, 1.0600523, 1.5124008,
         ]).unwrap();
-        let b_dev = dev.sync_copy(&b).unwrap();
+        let b_dev = dev.copy_htod_sync(&b).unwrap();
         let mut c_dev = dev.alloc_zeros_async(M).unwrap();
         unsafe {
             blas.gemv_async(
@@ -464,7 +464,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.sync_release(c_dev).unwrap();
+        let c_host = dev.reclaim(c_dev).unwrap();
         for i in 0..M {
             assert!((c_host[i] - c[i]).abs() <= 1e-6);
         }
@@ -492,7 +492,7 @@ mod tests {
         gemv_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.sync_copy(&[
+        let a_dev = dev.copy_htod_sync(&[
             0.96151888, -0.36771390, 0.94069099,
             2.20621538, -0.16479775, -1.78425562,
             0.41080803, -0.56567699, -0.72781092,
@@ -502,7 +502,7 @@ mod tests {
             -1.84258616, 0.24096519, -0.04563522,
             -0.53364468, -1.07902217, 0.46823528,
         ]).unwrap();
-        let b_dev = dev.sync_copy(&b).unwrap();
+        let b_dev = dev.copy_htod_sync(&b).unwrap();
         let mut c_dev = dev.alloc_zeros_async(M).unwrap();
         unsafe {
             blas.gemv_async(
@@ -523,7 +523,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.sync_release(c_dev).unwrap();
+        let c_host = dev.reclaim(c_dev).unwrap();
         for i in 0..M {
             assert!((c_host[i] - c[i]).abs() <= 1e-8);
         }
@@ -560,13 +560,13 @@ mod tests {
         );
 
         #[rustfmt::skip]
-        let a_dev = dev.sync_copy::<half::f16>(&[
+        let a_dev = dev.copy_htod_sync::<half::f16>(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ].map(half::f16::from_f32)).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.sync_copy::<half::f16>(&[
+        let b_dev = dev.copy_htod_sync::<half::f16>(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
@@ -594,7 +594,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.sync_release(c_dev).unwrap();
+        let c_host = dev.reclaim(c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];
@@ -629,13 +629,13 @@ mod tests {
         gemm_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.sync_copy::<f32>(&[
+        let a_dev = dev.copy_htod_sync::<f32>(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ]).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.sync_copy::<f32>(&[
+        let b_dev = dev.copy_htod_sync::<f32>(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
@@ -663,7 +663,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.sync_release(c_dev).unwrap();
+        let c_host = dev.reclaim(c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 assert!((c_host[m * N + n] - c[m][n]) <= 1e-6);
@@ -693,14 +693,14 @@ mod tests {
         gemm_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.sync_copy::<f64>(&[
+        let a_dev = dev.copy_htod_sync::<f64>(&[
             -0.70925030, -1.01357541, -0.64827034,
             2.18493467, -0.61584842, -1.43844327,
             -1.34792593, 0.68840750, -0.48057214,
             1.22180992, 1.16245157, 0.01253436,
         ]).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.sync_copy::<f64>(&[
+        let b_dev = dev.copy_htod_sync::<f64>(&[
             -0.72735474, 1.35931170,
             1.71798307, -0.13296247,
             0.26855612, -1.95189980,
@@ -727,7 +727,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.sync_release(c_dev).unwrap();
+        let c_host = dev.reclaim(c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 assert!((c_host[m * N + n] - c[m][n]) <= 1e-10);

--- a/src/cublas/safe.rs
+++ b/src/cublas/safe.rs
@@ -439,11 +439,11 @@ mod tests {
         gemv_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.htod_copy_sync(&[
+        let a_dev = dev.htod_sync_copy(&[
             0.9314776, 0.10300648, -0.620774, 1.527075, 0.0259804,
             0.16820757, -0.94463515, -1.3850101, 1.0600523, 1.5124008,
         ]).unwrap();
-        let b_dev = dev.htod_copy_sync(&b).unwrap();
+        let b_dev = dev.htod_sync_copy(&b).unwrap();
         let mut c_dev = dev.alloc_zeros(M).unwrap();
         unsafe {
             blas.gemv_async(
@@ -464,7 +464,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim_sync(c_dev).unwrap();
+        let c_host = dev.sync_reclaim(c_dev).unwrap();
         for i in 0..M {
             assert!((c_host[i] - c[i]).abs() <= 1e-6);
         }
@@ -492,7 +492,7 @@ mod tests {
         gemv_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.htod_copy_sync(&[
+        let a_dev = dev.htod_sync_copy(&[
             0.96151888, -0.36771390, 0.94069099,
             2.20621538, -0.16479775, -1.78425562,
             0.41080803, -0.56567699, -0.72781092,
@@ -502,7 +502,7 @@ mod tests {
             -1.84258616, 0.24096519, -0.04563522,
             -0.53364468, -1.07902217, 0.46823528,
         ]).unwrap();
-        let b_dev = dev.htod_copy_sync(&b).unwrap();
+        let b_dev = dev.htod_sync_copy(&b).unwrap();
         let mut c_dev = dev.alloc_zeros(M).unwrap();
         unsafe {
             blas.gemv_async(
@@ -523,7 +523,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim_sync(c_dev).unwrap();
+        let c_host = dev.sync_reclaim(c_dev).unwrap();
         for i in 0..M {
             assert!((c_host[i] - c[i]).abs() <= 1e-8);
         }
@@ -560,13 +560,13 @@ mod tests {
         );
 
         #[rustfmt::skip]
-        let a_dev = dev.htod_copy_sync::<half::f16>(&[
+        let a_dev = dev.htod_sync_copy::<half::f16>(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ].map(half::f16::from_f32)).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.htod_copy_sync::<half::f16>(&[
+        let b_dev = dev.htod_sync_copy::<half::f16>(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
@@ -594,7 +594,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim_sync(c_dev).unwrap();
+        let c_host = dev.sync_reclaim(c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];
@@ -629,13 +629,13 @@ mod tests {
         gemm_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.htod_copy_sync::<f32>(&[
+        let a_dev = dev.htod_sync_copy::<f32>(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ]).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.htod_copy_sync::<f32>(&[
+        let b_dev = dev.htod_sync_copy::<f32>(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
@@ -663,7 +663,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim_sync(c_dev).unwrap();
+        let c_host = dev.sync_reclaim(c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 assert!((c_host[m * N + n] - c[m][n]) <= 1e-6);
@@ -693,14 +693,14 @@ mod tests {
         gemm_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.htod_copy_sync::<f64>(&[
+        let a_dev = dev.htod_sync_copy::<f64>(&[
             -0.70925030, -1.01357541, -0.64827034,
             2.18493467, -0.61584842, -1.43844327,
             -1.34792593, 0.68840750, -0.48057214,
             1.22180992, 1.16245157, 0.01253436,
         ]).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.htod_copy_sync::<f64>(&[
+        let b_dev = dev.htod_sync_copy::<f64>(&[
             -0.72735474, 1.35931170,
             1.71798307, -0.13296247,
             0.26855612, -1.95189980,
@@ -727,7 +727,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim_sync(c_dev).unwrap();
+        let c_host = dev.sync_reclaim(c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 assert!((c_host[m * N + n] - c[m][n]) <= 1e-10);

--- a/src/cublas/safe.rs
+++ b/src/cublas/safe.rs
@@ -439,12 +439,12 @@ mod tests {
         gemv_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.copy_htod_sync(&[
+        let a_dev = dev.htod_copy_sync(&[
             0.9314776, 0.10300648, -0.620774, 1.527075, 0.0259804,
             0.16820757, -0.94463515, -1.3850101, 1.0600523, 1.5124008,
         ]).unwrap();
-        let b_dev = dev.copy_htod_sync(&b).unwrap();
-        let mut c_dev = dev.alloc_zeros_async(M).unwrap();
+        let b_dev = dev.htod_copy_sync(&b).unwrap();
+        let mut c_dev = dev.alloc_zeros(M).unwrap();
         unsafe {
             blas.gemv_async(
                 GemvConfig {
@@ -464,7 +464,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim(c_dev).unwrap();
+        let c_host = dev.reclaim_sync(c_dev).unwrap();
         for i in 0..M {
             assert!((c_host[i] - c[i]).abs() <= 1e-6);
         }
@@ -492,7 +492,7 @@ mod tests {
         gemv_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.copy_htod_sync(&[
+        let a_dev = dev.htod_copy_sync(&[
             0.96151888, -0.36771390, 0.94069099,
             2.20621538, -0.16479775, -1.78425562,
             0.41080803, -0.56567699, -0.72781092,
@@ -502,8 +502,8 @@ mod tests {
             -1.84258616, 0.24096519, -0.04563522,
             -0.53364468, -1.07902217, 0.46823528,
         ]).unwrap();
-        let b_dev = dev.copy_htod_sync(&b).unwrap();
-        let mut c_dev = dev.alloc_zeros_async(M).unwrap();
+        let b_dev = dev.htod_copy_sync(&b).unwrap();
+        let mut c_dev = dev.alloc_zeros(M).unwrap();
         unsafe {
             blas.gemv_async(
                 GemvConfig {
@@ -523,7 +523,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim(c_dev).unwrap();
+        let c_host = dev.reclaim_sync(c_dev).unwrap();
         for i in 0..M {
             assert!((c_host[i] - c[i]).abs() <= 1e-8);
         }
@@ -560,19 +560,19 @@ mod tests {
         );
 
         #[rustfmt::skip]
-        let a_dev = dev.copy_htod_sync::<half::f16>(&[
+        let a_dev = dev.htod_copy_sync::<half::f16>(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ].map(half::f16::from_f32)).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.copy_htod_sync::<half::f16>(&[
+        let b_dev = dev.htod_copy_sync::<half::f16>(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
             3.4746711, -1.0930681, 0.16502666, -0.59988785, 0.41375792,
         ].map(half::f16::from_f32)).unwrap();
-        let mut c_dev = dev.alloc_zeros_async::<half::f16>(M * N).unwrap();
+        let mut c_dev = dev.alloc_zeros::<half::f16>(M * N).unwrap();
         unsafe {
             blas.gemm_async(
                 GemmConfig {
@@ -594,7 +594,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim(c_dev).unwrap();
+        let c_host = dev.reclaim_sync(c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];
@@ -629,19 +629,19 @@ mod tests {
         gemm_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.copy_htod_sync::<f32>(&[
+        let a_dev = dev.htod_copy_sync::<f32>(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ]).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.copy_htod_sync::<f32>(&[
+        let b_dev = dev.htod_copy_sync::<f32>(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
             3.4746711, -1.0930681, 0.16502666, -0.59988785, 0.41375792,
         ]).unwrap();
-        let mut c_dev = dev.alloc_zeros_async::<f32>(M * N).unwrap();
+        let mut c_dev = dev.alloc_zeros::<f32>(M * N).unwrap();
         unsafe {
             blas.gemm_async(
                 GemmConfig {
@@ -663,7 +663,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim(c_dev).unwrap();
+        let c_host = dev.reclaim_sync(c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 assert!((c_host[m * N + n] - c[m][n]) <= 1e-6);
@@ -693,19 +693,19 @@ mod tests {
         gemm_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = dev.copy_htod_sync::<f64>(&[
+        let a_dev = dev.htod_copy_sync::<f64>(&[
             -0.70925030, -1.01357541, -0.64827034,
             2.18493467, -0.61584842, -1.43844327,
             -1.34792593, 0.68840750, -0.48057214,
             1.22180992, 1.16245157, 0.01253436,
         ]).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.copy_htod_sync::<f64>(&[
+        let b_dev = dev.htod_copy_sync::<f64>(&[
             -0.72735474, 1.35931170,
             1.71798307, -0.13296247,
             0.26855612, -1.95189980,
         ]).unwrap();
-        let mut c_dev = dev.alloc_zeros_async::<f64>(M * N).unwrap();
+        let mut c_dev = dev.alloc_zeros::<f64>(M * N).unwrap();
         unsafe {
             blas.gemm_async(
                 GemmConfig {
@@ -727,7 +727,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.reclaim(c_dev).unwrap();
+        let c_host = dev.reclaim_sync(c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 assert!((c_host[m * N + n] - c[m][n]) <= 1e-10);

--- a/src/curand/safe.rs
+++ b/src/curand/safe.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 /// # use cudarc::{driver::*, curand::*};
 /// # let device = CudaDeviceBuilder::new(0).build().unwrap();
 /// # let rng = CudaRng::new(0, device.clone()).unwrap();
-/// let mut a_dev = device.alloc_zeros_async::<f32>(10).unwrap();
+/// let mut a_dev = device.alloc_zeros::<f32>(10).unwrap();
 /// rng.fill_with_uniform(&mut a_dev).unwrap();
 /// ```
 ///
@@ -110,10 +110,10 @@ mod tests {
         super::sys::curandGenerator_t: UniformFill<T>,
     {
         let dev = CudaDeviceBuilder::new(0).build().unwrap();
-        let mut a_dev = dev.alloc_zeros_async::<T>(n).unwrap();
+        let mut a_dev = dev.alloc_zeros::<T>(n).unwrap();
         let rng = CudaRng::new(seed, dev.clone()).unwrap();
         rng.fill_with_uniform(&mut a_dev).unwrap();
-        dev.reclaim(a_dev).unwrap()
+        dev.reclaim_sync(a_dev).unwrap()
     }
 
     fn gen_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
@@ -126,10 +126,10 @@ mod tests {
         super::sys::curandGenerator_t: NormalFill<T>,
     {
         let dev = CudaDeviceBuilder::new(0).build().unwrap();
-        let mut a_dev = dev.alloc_zeros_async::<T>(n).unwrap();
+        let mut a_dev = dev.alloc_zeros::<T>(n).unwrap();
         let rng = CudaRng::new(seed, dev.clone()).unwrap();
         rng.fill_with_normal(&mut a_dev, mean, std).unwrap();
-        dev.reclaim(a_dev).unwrap()
+        dev.reclaim_sync(a_dev).unwrap()
     }
 
     fn gen_log_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
@@ -142,10 +142,10 @@ mod tests {
         super::sys::curandGenerator_t: LogNormalFill<T>,
     {
         let dev = CudaDeviceBuilder::new(0).build().unwrap();
-        let mut a_dev = dev.alloc_zeros_async::<T>(n).unwrap();
+        let mut a_dev = dev.alloc_zeros::<T>(n).unwrap();
         let rng = CudaRng::new(seed, dev.clone()).unwrap();
         rng.fill_with_log_normal(&mut a_dev, mean, std).unwrap();
-        dev.reclaim(a_dev).unwrap()
+        dev.reclaim_sync(a_dev).unwrap()
     }
 
     #[test]
@@ -154,7 +154,7 @@ mod tests {
         assert_eq!(Arc::strong_count(&dev), 1);
         let a_rng = CudaRng::new(0, dev.clone()).unwrap();
         assert_eq!(Arc::strong_count(&dev), 2);
-        let a_dev = dev.alloc_zeros_async::<f32>(10).unwrap();
+        let a_dev = dev.alloc_zeros::<f32>(10).unwrap();
         assert_eq!(Arc::strong_count(&dev), 3);
         drop(a_rng);
         assert_eq!(Arc::strong_count(&dev), 2);
@@ -166,7 +166,7 @@ mod tests {
     fn test_seed_reproducible() {
         let dev = CudaDeviceBuilder::new(0).build().unwrap();
 
-        let mut a_dev = dev.alloc_zeros_async::<f32>(10).unwrap();
+        let mut a_dev = dev.alloc_zeros::<f32>(10).unwrap();
         let mut b_dev = a_dev.clone();
 
         let a_rng = CudaRng::new(0, dev.clone()).unwrap();
@@ -175,8 +175,8 @@ mod tests {
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
         b_rng.fill_with_uniform(&mut b_dev).unwrap();
 
-        let a_host = dev.reclaim(a_dev).unwrap();
-        let b_host = dev.reclaim(b_dev).unwrap();
+        let a_host = dev.reclaim_sync(a_dev).unwrap();
+        let b_host = dev.reclaim_sync(b_dev).unwrap();
         assert_eq!(a_host, b_host);
     }
 
@@ -184,7 +184,7 @@ mod tests {
     fn test_different_seeds_neq() {
         let dev = CudaDeviceBuilder::new(0).build().unwrap();
 
-        let mut a_dev = dev.alloc_zeros_async::<f32>(10).unwrap();
+        let mut a_dev = dev.alloc_zeros::<f32>(10).unwrap();
         let mut b_dev = a_dev.clone();
 
         let a_rng = CudaRng::new(0, dev.clone()).unwrap();
@@ -193,8 +193,8 @@ mod tests {
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
         b_rng.fill_with_uniform(&mut b_dev).unwrap();
 
-        let a_host = dev.reclaim(a_dev).unwrap();
-        let b_host = dev.reclaim(b_dev).unwrap();
+        let a_host = dev.reclaim_sync(a_dev).unwrap();
+        let b_host = dev.reclaim_sync(b_dev).unwrap();
         assert_ne!(a_host, b_host);
     }
 

--- a/src/curand/safe.rs
+++ b/src/curand/safe.rs
@@ -113,7 +113,7 @@ mod tests {
         let mut a_dev = dev.alloc_zeros::<T>(n).unwrap();
         let rng = CudaRng::new(seed, dev.clone()).unwrap();
         rng.fill_with_uniform(&mut a_dev).unwrap();
-        dev.reclaim_sync(a_dev).unwrap()
+        dev.sync_reclaim(a_dev).unwrap()
     }
 
     fn gen_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
@@ -129,7 +129,7 @@ mod tests {
         let mut a_dev = dev.alloc_zeros::<T>(n).unwrap();
         let rng = CudaRng::new(seed, dev.clone()).unwrap();
         rng.fill_with_normal(&mut a_dev, mean, std).unwrap();
-        dev.reclaim_sync(a_dev).unwrap()
+        dev.sync_reclaim(a_dev).unwrap()
     }
 
     fn gen_log_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
@@ -145,7 +145,7 @@ mod tests {
         let mut a_dev = dev.alloc_zeros::<T>(n).unwrap();
         let rng = CudaRng::new(seed, dev.clone()).unwrap();
         rng.fill_with_log_normal(&mut a_dev, mean, std).unwrap();
-        dev.reclaim_sync(a_dev).unwrap()
+        dev.sync_reclaim(a_dev).unwrap()
     }
 
     #[test]
@@ -175,8 +175,8 @@ mod tests {
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
         b_rng.fill_with_uniform(&mut b_dev).unwrap();
 
-        let a_host = dev.reclaim_sync(a_dev).unwrap();
-        let b_host = dev.reclaim_sync(b_dev).unwrap();
+        let a_host = dev.sync_reclaim(a_dev).unwrap();
+        let b_host = dev.sync_reclaim(b_dev).unwrap();
         assert_eq!(a_host, b_host);
     }
 
@@ -193,8 +193,8 @@ mod tests {
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
         b_rng.fill_with_uniform(&mut b_dev).unwrap();
 
-        let a_host = dev.reclaim_sync(a_dev).unwrap();
-        let b_host = dev.reclaim_sync(b_dev).unwrap();
+        let a_host = dev.sync_reclaim(a_dev).unwrap();
+        let b_host = dev.sync_reclaim(b_dev).unwrap();
         assert_ne!(a_host, b_host);
     }
 

--- a/src/curand/safe.rs
+++ b/src/curand/safe.rs
@@ -113,7 +113,7 @@ mod tests {
         let mut a_dev = dev.alloc_zeros_async::<T>(n).unwrap();
         let rng = CudaRng::new(seed, dev.clone()).unwrap();
         rng.fill_with_uniform(&mut a_dev).unwrap();
-        dev.sync_release(a_dev).unwrap()
+        dev.reclaim(a_dev).unwrap()
     }
 
     fn gen_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
@@ -129,7 +129,7 @@ mod tests {
         let mut a_dev = dev.alloc_zeros_async::<T>(n).unwrap();
         let rng = CudaRng::new(seed, dev.clone()).unwrap();
         rng.fill_with_normal(&mut a_dev, mean, std).unwrap();
-        dev.sync_release(a_dev).unwrap()
+        dev.reclaim(a_dev).unwrap()
     }
 
     fn gen_log_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
@@ -145,7 +145,7 @@ mod tests {
         let mut a_dev = dev.alloc_zeros_async::<T>(n).unwrap();
         let rng = CudaRng::new(seed, dev.clone()).unwrap();
         rng.fill_with_log_normal(&mut a_dev, mean, std).unwrap();
-        dev.sync_release(a_dev).unwrap()
+        dev.reclaim(a_dev).unwrap()
     }
 
     #[test]
@@ -175,8 +175,8 @@ mod tests {
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
         b_rng.fill_with_uniform(&mut b_dev).unwrap();
 
-        let a_host = dev.sync_release(a_dev).unwrap();
-        let b_host = dev.sync_release(b_dev).unwrap();
+        let a_host = dev.reclaim(a_dev).unwrap();
+        let b_host = dev.reclaim(b_dev).unwrap();
         assert_eq!(a_host, b_host);
     }
 
@@ -193,8 +193,8 @@ mod tests {
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
         b_rng.fill_with_uniform(&mut b_dev).unwrap();
 
-        let a_host = dev.sync_release(a_dev).unwrap();
-        let b_host = dev.sync_release(b_dev).unwrap();
+        let a_host = dev.reclaim(a_dev).unwrap();
+        let b_host = dev.reclaim(b_dev).unwrap();
         assert_ne!(a_host, b_host);
     }
 

--- a/src/driver/safe/alloc.rs
+++ b/src/driver/safe/alloc.rs
@@ -181,7 +181,7 @@ impl CudaDevice {
 
     /// Allocates new device memory and synchronously copies data from `src` into the new allocation.
     ///
-    /// If you want an asynchronous copy, see [CudaDevice::copy_htod_async()].
+    /// If you want an asynchronous copy, see [CudaDevice::htod_copy()].
     ///
     /// # Safety
     ///
@@ -198,7 +198,7 @@ impl CudaDevice {
 
     /// Synchronously copies data from `src` into the new allocation.
     ///
-    /// If you want an asynchronous copy, see [CudaDevice::copy_htod_async()].
+    /// If you want an asynchronous copy, see [CudaDevice::htod_copy()].
     ///
     /// # Panics
     ///
@@ -218,7 +218,7 @@ impl CudaDevice {
     }
 
     /// Synchronously copies device memory into host memory.
-    /// Unlike [`CudaDevice::copy_into_dtoh_sync`] this returns a [`Vec<T>`].
+    /// Unlike [`CudaDevice::dtoh_copy_into_sync`] this returns a [`Vec<T>`].
     ///
     /// # Safety
     /// 1. Since this function doesn't own `dst` (after returning) it is executed synchronously.
@@ -236,7 +236,7 @@ impl CudaDevice {
 
     /// Synchronously copies device memory into host memory
     ///
-    /// Use [`CudaDevice::copy_dtoh_sync`] if you need [`Vec<T>`] and can't provide
+    /// Use [`CudaDevice::dtoh_copy_sync`] if you need [`Vec<T>`] and can't provide
     /// a correctly sized slice.
     ///
     /// # Panics

--- a/src/driver/safe/alloc.rs
+++ b/src/driver/safe/alloc.rs
@@ -112,22 +112,6 @@ impl CudaDevice {
         unsafe { result::memset_d8_async(*dst.device_ptr_mut(), 0, dst.num_bytes(), self.stream) }
     }
 
-    /// Takes ownership of the host data and copies it to device data asynchronously.
-    ///
-    /// # Safety
-    ///
-    /// 1. Since `src` is owned by this funcion, it is safe to copy data. Any actions executed
-    ///    after this will take place after the data has been successfully copied.
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn take_async<T: Unpin + DeviceRepr>(
-        self: &Arc<Self>,
-        src: Vec<T>,
-    ) -> Result<CudaSlice<T>, result::DriverError> {
-        let mut dst = unsafe { self.alloc_async(src.len()) }?;
-        self.copy_into_async(src, &mut dst)?;
-        Ok(dst)
-    }
-
     /// Device to device copy (safe version of [result::memcpy_dtod_async]).
     ///
     /// # Panics
@@ -139,7 +123,7 @@ impl CudaDevice {
     ///     type `T`
     /// 2. Since they are both references, they can't have been freed
     /// 3. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn device_copy_async<T: DeviceRepr, Src: DevicePtr<T>, Dst: DevicePtrMut<T>>(
+    pub fn copy_dtod_async<T: DeviceRepr, Src: DevicePtr<T>, Dst: DevicePtrMut<T>>(
         self: &Arc<Self>,
         src: &Src,
         dst: &mut Dst,
@@ -155,42 +139,20 @@ impl CudaDevice {
         }
     }
 
-    /// Allocates new device memory and synchronously copies data from `src` into the new allocation.
-    ///
-    /// If you want an asynchronous copy, see [CudaDevice::take_async()].
+    /// Takes ownership of the host data and copies it to device data asynchronously.
     ///
     /// # Safety
     ///
-    /// 1. Since this function doesn't own `src` it is executed synchronously.
+    /// 1. Since `src` is owned by this funcion, it is safe to copy data. Any actions executed
+    ///    after this will take place after the data has been successfully copied.
     /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn sync_copy<T: DeviceRepr>(
+    pub fn copy_htod_async<T: Unpin + DeviceRepr>(
         self: &Arc<Self>,
-        src: &[T],
+        src: Vec<T>,
     ) -> Result<CudaSlice<T>, result::DriverError> {
         let mut dst = unsafe { self.alloc_async(src.len()) }?;
-        self.sync_copy_into(src, &mut dst)?;
+        self.copy_into_htod_async(src, &mut dst)?;
         Ok(dst)
-    }
-
-    /// Synchronously copies data from `src` into the new allocation.
-    ///
-    /// If you want an asynchronous copy, see [CudaDevice::take_async()].
-    ///
-    /// # Panics
-    ///
-    /// If the lengths of slices are not equal, this method panics.
-    ///
-    /// # Safety
-    /// 1. Since this function doesn't own `src` it is executed synchronously.
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn sync_copy_into<T: DeviceRepr>(
-        self: &Arc<Self>,
-        src: &[T],
-        dst: &mut CudaSlice<T>,
-    ) -> Result<(), result::DriverError> {
-        assert_eq!(src.len(), dst.len());
-        unsafe { result::memcpy_htod_async(dst.cu_device_ptr, src, self.stream) }?;
-        self.synchronize()
     }
 
     /// Takes ownership of the host data and copies it to device data asynchronously.
@@ -200,7 +162,7 @@ impl CudaDevice {
     /// 1. Since `src` is owned by this funcion, it is safe to copy data. Any actions executed
     ///    after this will take place after the data has been successfully copied.
     /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn copy_into_async<T: DeviceRepr + Unpin>(
+    pub fn copy_into_htod_async<T: DeviceRepr + Unpin>(
         self: &Arc<Self>,
         src: Vec<T>,
         dst: &mut CudaSlice<T>,
@@ -217,9 +179,64 @@ impl CudaDevice {
         Ok(())
     }
 
+    /// Allocates new device memory and synchronously copies data from `src` into the new allocation.
+    ///
+    /// If you want an asynchronous copy, see [CudaDevice::copy_htod_async()].
+    ///
+    /// # Safety
+    ///
+    /// 1. Since this function doesn't own `src` it is executed synchronously.
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn copy_htod_sync<T: DeviceRepr>(
+        self: &Arc<Self>,
+        src: &[T],
+    ) -> Result<CudaSlice<T>, result::DriverError> {
+        let mut dst = unsafe { self.alloc_async(src.len()) }?;
+        self.copy_into_htod_sync(src, &mut dst)?;
+        Ok(dst)
+    }
+
+    /// Synchronously copies data from `src` into the new allocation.
+    ///
+    /// If you want an asynchronous copy, see [CudaDevice::copy_htod_async()].
+    ///
+    /// # Panics
+    ///
+    /// If the lengths of slices are not equal, this method panics.
+    ///
+    /// # Safety
+    /// 1. Since this function doesn't own `src` it is executed synchronously.
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn copy_into_htod_sync<T: DeviceRepr>(
+        self: &Arc<Self>,
+        src: &[T],
+        dst: &mut CudaSlice<T>,
+    ) -> Result<(), result::DriverError> {
+        assert_eq!(src.len(), dst.len());
+        unsafe { result::memcpy_htod_async(dst.cu_device_ptr, src, self.stream) }?;
+        self.synchronize()
+    }
+
+    /// Synchronously copies device memory into host memory.
+    /// Unlike [`CudaDevice::copy_into_dtoh_sync`] this returns a [`Vec<T>`].
+    ///
+    /// # Safety
+    /// 1. Since this function doesn't own `dst` (after returning) it is executed synchronously.
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    #[allow(clippy::uninit_vec)]
+    pub fn copy_dtoh_sync<T: DeviceRepr>(
+        self: &Arc<Self>,
+        src: &CudaSlice<T>,
+    ) -> Result<Vec<T>, result::DriverError> {
+        let mut dst = Vec::with_capacity(src.len());
+        unsafe { dst.set_len(src.len()) };
+        self.copy_into_dtoh_sync(src, &mut dst)?;
+        Ok(dst)
+    }
+
     /// Synchronously copies device memory into host memory
     ///
-    /// Use [`CudaDevice::sync_copy_into_vec`] if you need [`Vec<T>`] and can't provide
+    /// Use [`CudaDevice::copy_dtoh_sync`] if you need [`Vec<T>`] and can't provide
     /// a correctly sized slice.
     ///
     /// # Panics
@@ -229,7 +246,7 @@ impl CudaDevice {
     /// # Safety
     /// 1. Since this function doesn't own `dst` it is executed synchronously.
     /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn sync_copy_from<T: DeviceRepr>(
+    pub fn copy_into_dtoh_sync<T: DeviceRepr>(
         self: &Arc<Self>,
         src: &CudaSlice<T>,
         dst: &mut [T],
@@ -239,31 +256,12 @@ impl CudaDevice {
         self.synchronize()
     }
 
-    /// Synchronously copies device memory into host memory.
-    /// Unlike [`CudaDevice::sync_copy_from`] this returns a [`Vec<T>`].
-    ///
-    /// # Safety
-    /// 1. Since this function doesn't own `dst` (after returning) it is executed synchronously.
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn sync_copy_into_vec<T: DeviceRepr>(
-        self: &Arc<Self>,
-        src: &CudaSlice<T>,
-    ) -> Result<Vec<T>, result::DriverError> {
-        let mut dst = Vec::with_capacity(src.len());
-        unsafe {
-            dst.set_len(src.len());
-            result::memcpy_dtoh_async(dst.as_mut_slice(), src.cu_device_ptr, self.stream)
-        }?;
-        self.synchronize()?;
-        Ok(dst)
-    }
-
-    /// De-allocates `src` and converts it into it's host value. You can just drop the slice if you don't
-    /// need the host data.
+    /// Synchronously de-allocates `src` and converts it into it's host value.
+    /// You can just [drop] the slice if you don't need the host data.
     ///
     /// # Safety
     /// 1. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn sync_release<T: Clone + Default + DeviceRepr + Unpin>(
+    pub fn reclaim<T: Clone + Default + DeviceRepr + Unpin>(
         self: &Arc<Self>,
         mut src: CudaSlice<T>,
     ) -> Result<Vec<T>, result::DriverError> {
@@ -273,7 +271,7 @@ impl CudaDevice {
             b.resize(src.len, Default::default());
             Pin::new(b)
         });
-        self.sync_copy_from(&src, &mut buf)?;
+        self.copy_into_dtoh_sync(&src, &mut buf)?;
         Ok(Pin::into_inner(buf))
     }
 
@@ -352,7 +350,7 @@ mod tests {
     #[test]
     fn test_post_take_arc_counts() {
         let device = CudaDeviceBuilder::new(0).build().unwrap();
-        let t = device.take_async([0.0f32; 5].to_vec()).unwrap();
+        let t = device.copy_htod_async([0.0f32; 5].to_vec()).unwrap();
         assert!(t.host_buf.is_some());
         assert_eq!(Arc::strong_count(&device), 2);
         drop(t);
@@ -362,7 +360,7 @@ mod tests {
     #[test]
     fn test_post_clone_counts() {
         let device = CudaDeviceBuilder::new(0).build().unwrap();
-        let t = device.take_async([0.0f64; 10].to_vec()).unwrap();
+        let t = device.copy_htod_async([0.0f64; 10].to_vec()).unwrap();
         let r = t.clone();
         assert_eq!(Arc::strong_count(&device), 3);
         drop(t);
@@ -374,7 +372,7 @@ mod tests {
     #[test]
     fn test_post_clone_arc_slice_counts() {
         let device = CudaDeviceBuilder::new(0).build().unwrap();
-        let t = Arc::new(device.take_async::<f64>([0.0; 10].to_vec()).unwrap());
+        let t = Arc::new(device.copy_htod_async::<f64>([0.0; 10].to_vec()).unwrap());
         let r = t.clone();
         assert_eq!(Arc::strong_count(&device), 2);
         drop(t);
@@ -386,12 +384,12 @@ mod tests {
     #[test]
     fn test_post_release_counts() {
         let device = CudaDeviceBuilder::new(0).build().unwrap();
-        let t = device.take_async([1.0f32, 2.0, 3.0].to_vec()).unwrap();
+        let t = device.copy_htod_async([1.0f32, 2.0, 3.0].to_vec()).unwrap();
         #[allow(clippy::redundant_clone)]
         let r = t.clone();
         assert_eq!(Arc::strong_count(&device), 3);
 
-        let r_host = device.sync_release(r).unwrap();
+        let r_host = device.reclaim(r).unwrap();
         assert_eq!(&r_host, &[1.0, 2.0, 3.0]);
         assert_eq!(Arc::strong_count(&device), 2);
 
@@ -405,7 +403,7 @@ mod tests {
         let device = CudaDeviceBuilder::new(0).build().unwrap();
         let (free1, total1) = result::mem_get_info().unwrap();
 
-        let t = device.take_async([0.0f32; 5].to_vec()).unwrap();
+        let t = device.copy_htod_async([0.0f32; 5].to_vec()).unwrap();
         let (free2, total2) = result::mem_get_info().unwrap();
         assert_eq!(total1, total2);
         assert!(free2 < free1);

--- a/src/driver/safe/build.rs
+++ b/src/driver/safe/build.rs
@@ -263,23 +263,23 @@ mod tests {
         let dev = CudaDeviceBuilder::new(0).build().unwrap();
 
         let smalls = [
-            dev.copy_htod_async(std::vec![-1.0f32, -0.8]).unwrap(),
-            dev.copy_htod_async(std::vec![-0.6, -0.4]).unwrap(),
-            dev.copy_htod_async(std::vec![-0.2, 0.0]).unwrap(),
-            dev.copy_htod_async(std::vec![0.2, 0.4]).unwrap(),
-            dev.copy_htod_async(std::vec![0.6, 0.8]).unwrap(),
+            dev.htod_copy(std::vec![-1.0f32, -0.8]).unwrap(),
+            dev.htod_copy(std::vec![-0.6, -0.4]).unwrap(),
+            dev.htod_copy(std::vec![-0.2, 0.0]).unwrap(),
+            dev.htod_copy(std::vec![0.2, 0.4]).unwrap(),
+            dev.htod_copy(std::vec![0.6, 0.8]).unwrap(),
         ];
-        let mut big = dev.alloc_zeros_async::<f32>(10).unwrap();
+        let mut big = dev.alloc_zeros::<f32>(10).unwrap();
 
         let mut offset = 0;
         for small in smalls.iter() {
             let mut sub = big.try_slice_mut(offset..offset + small.len()).unwrap();
-            dev.copy_dtod_async(small, &mut sub).unwrap();
+            dev.dtod_copy(small, &mut sub).unwrap();
             offset += small.len();
         }
 
         assert_eq!(
-            dev.reclaim(big).unwrap(),
+            dev.reclaim_sync(big).unwrap(),
             [-1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8]
         );
     }

--- a/src/driver/safe/build.rs
+++ b/src/driver/safe/build.rs
@@ -279,7 +279,7 @@ mod tests {
         }
 
         assert_eq!(
-            dev.reclaim_sync(big).unwrap(),
+            dev.sync_reclaim(big).unwrap(),
             [-1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8]
         );
     }

--- a/src/driver/safe/build.rs
+++ b/src/driver/safe/build.rs
@@ -263,23 +263,23 @@ mod tests {
         let dev = CudaDeviceBuilder::new(0).build().unwrap();
 
         let smalls = [
-            dev.take_async(std::vec![-1.0f32, -0.8]).unwrap(),
-            dev.take_async(std::vec![-0.6, -0.4]).unwrap(),
-            dev.take_async(std::vec![-0.2, 0.0]).unwrap(),
-            dev.take_async(std::vec![0.2, 0.4]).unwrap(),
-            dev.take_async(std::vec![0.6, 0.8]).unwrap(),
+            dev.copy_htod_async(std::vec![-1.0f32, -0.8]).unwrap(),
+            dev.copy_htod_async(std::vec![-0.6, -0.4]).unwrap(),
+            dev.copy_htod_async(std::vec![-0.2, 0.0]).unwrap(),
+            dev.copy_htod_async(std::vec![0.2, 0.4]).unwrap(),
+            dev.copy_htod_async(std::vec![0.6, 0.8]).unwrap(),
         ];
         let mut big = dev.alloc_zeros_async::<f32>(10).unwrap();
 
         let mut offset = 0;
         for small in smalls.iter() {
             let mut sub = big.try_slice_mut(offset..offset + small.len()).unwrap();
-            dev.device_copy_async(small, &mut sub).unwrap();
+            dev.copy_dtod_async(small, &mut sub).unwrap();
             offset += small.len();
         }
 
         assert_eq!(
-            dev.sync_release(big).unwrap(),
+            dev.reclaim(big).unwrap(),
             [-1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8]
         );
     }

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -76,7 +76,7 @@ impl Drop for CudaDevice {
 /// # Reclaiming host data
 ///
 /// To reclaim the host data for this device data,
-/// use [CudaDevice::reclaim_sync()]. This will
+/// use [CudaDevice::sync_reclaim()]. This will
 /// perform necessary synchronization to ensure
 /// that the device data finishes copying over.
 ///
@@ -148,7 +148,7 @@ impl<T: DeviceRepr> Clone for CudaSlice<T> {
 impl<T: Clone + Default + DeviceRepr + Unpin> TryFrom<CudaSlice<T>> for Vec<T> {
     type Error = result::DriverError;
     fn try_from(value: CudaSlice<T>) -> Result<Self, Self::Error> {
-        value.device.clone().reclaim_sync(value)
+        value.device.clone().sync_reclaim(value)
     }
 }
 

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -76,7 +76,7 @@ impl Drop for CudaDevice {
 /// # Reclaiming host data
 ///
 /// To reclaim the host data for this device data,
-/// use [CudaDevice::sync_release()]. This will
+/// use [CudaDevice::reclaim()]. This will
 /// perform necessary synchronization to ensure
 /// that the device data finishes copying over.
 ///
@@ -148,7 +148,7 @@ impl<T: DeviceRepr> Clone for CudaSlice<T> {
 impl<T: Clone + Default + DeviceRepr + Unpin> TryFrom<CudaSlice<T>> for Vec<T> {
     type Error = result::DriverError;
     fn try_from(value: CudaSlice<T>) -> Result<Self, Self::Error> {
-        value.device.clone().sync_release(value)
+        value.device.clone().reclaim(value)
     }
 }
 

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -30,7 +30,7 @@ pub struct CudaDevice {
     pub(crate) modules: RwLock<BTreeMap<&'static str, CudaModule>>,
 }
 
-unsafe impl DeviceRepr for CudaDevice {}
+unsafe impl Send for CudaDevice {}
 unsafe impl Sync for CudaDevice {}
 
 impl Drop for CudaDevice {
@@ -97,7 +97,7 @@ pub struct CudaSlice<T> {
     pub(crate) host_buf: Option<Pin<Vec<T>>>,
 }
 
-unsafe impl<T: DeviceRepr> DeviceRepr for CudaSlice<T> {}
+unsafe impl<T: Send> Send for CudaSlice<T> {}
 unsafe impl<T: Sync> Sync for CudaSlice<T> {}
 
 impl<T> Drop for CudaSlice<T> {
@@ -164,7 +164,7 @@ pub(crate) struct CudaModule {
     pub(crate) functions: BTreeMap<&'static str, sys::CUfunction>,
 }
 
-unsafe impl DeviceRepr for CudaModule {}
+unsafe impl Send for CudaModule {}
 unsafe impl Sync for CudaModule {}
 
 /// Wrapper around [sys::CUfunction]. Used by [crate::driver::LaunchAsync].
@@ -174,7 +174,7 @@ pub struct CudaFunction {
     pub(crate) device: Arc<CudaDevice>,
 }
 
-unsafe impl DeviceRepr for CudaFunction {}
+unsafe impl Send for CudaFunction {}
 unsafe impl Sync for CudaFunction {}
 
 /// A wrapper around [sys::CUstream] that safely ensures null stream is synchronized

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -126,7 +126,7 @@ impl<T> Drop for CudaSlice<T> {
 impl<T: DeviceRepr> CudaSlice<T> {
     /// Allocates copy of self and schedules a device to device copy of memory.
     pub fn clone_async(&self) -> Result<Self, result::DriverError> {
-        let dst = unsafe { self.device.alloc_async(self.len) }?;
+        let dst = unsafe { self.device.alloc(self.len) }?;
         unsafe {
             result::memcpy_dtod_async(
                 dst.cu_device_ptr,
@@ -148,7 +148,7 @@ impl<T: DeviceRepr> Clone for CudaSlice<T> {
 impl<T: Clone + Default + DeviceRepr + Unpin> TryFrom<CudaSlice<T>> for Vec<T> {
     type Error = result::DriverError;
     fn try_from(value: CudaSlice<T>) -> Result<Self, Self::Error> {
-        value.device.clone().reclaim(value)
+        value.device.clone().reclaim_sync(value)
     }
 }
 

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -76,7 +76,7 @@ impl Drop for CudaDevice {
 /// # Reclaiming host data
 ///
 /// To reclaim the host data for this device data,
-/// use [CudaDevice::reclaim()]. This will
+/// use [CudaDevice::reclaim_sync()]. This will
 /// perform necessary synchronization to ensure
 /// that the device data finishes copying over.
 ///

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn test_mut_into_kernel_param_no_inc_rc() {
         let device = CudaDeviceBuilder::new(0).build().unwrap();
-        let t = device.copy_htod_async([0.0f32; 1].to_vec()).unwrap();
+        let t = device.htod_copy([0.0f32; 1].to_vec()).unwrap();
         let _r = t.clone();
         assert_eq!(Arc::strong_count(&device), 3);
         let _ = t.as_kernel_param();
@@ -261,7 +261,7 @@ mod tests {
     #[test]
     fn test_ref_into_kernel_param_inc_rc() {
         let device = CudaDeviceBuilder::new(0).build().unwrap();
-        let t = device.copy_htod_async([0.0f32; 1].to_vec()).unwrap();
+        let t = device.htod_copy([0.0f32; 1].to_vec()).unwrap();
         let _r = t.clone();
         assert_eq!(Arc::strong_count(&device), 3);
         let _ = t.as_kernel_param();
@@ -287,7 +287,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
 
         let a_host = [-1.0f32, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8];
 
-        let a_dev = dev.copy_htod_async(a_host.clone().to_vec()).unwrap();
+        let a_dev = dev.htod_copy(a_host.clone().to_vec()).unwrap();
 
         let mut b_dev = a_dev.clone();
 
@@ -299,7 +299,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
         }
         .unwrap();
 
-        let b_host = dev.reclaim(b_dev).unwrap();
+        let b_host = dev.reclaim_sync(b_dev).unwrap();
 
         for (a_i, b_i) in a_host.iter().zip(b_host.iter()) {
             let expected = a_i.sin();
@@ -320,14 +320,14 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
             let mut a = Vec::with_capacity(numel);
             a.resize(numel, 1.0f32);
 
-            let a = dev.copy_htod_async(a).unwrap();
-            let mut b = dev.alloc_zeros_async::<f32>(numel).unwrap();
+            let a = dev.htod_copy(a).unwrap();
+            let mut b = dev.alloc_zeros::<f32>(numel).unwrap();
 
             let sin_kernel = dev.get_func("sin", "sin_kernel").unwrap();
             let cfg = LaunchConfig::for_num_elems(numel as u32);
             unsafe { sin_kernel.launch_async(cfg, (&mut b, &a, numel)) }.unwrap();
 
-            let b = dev.reclaim(b).unwrap();
+            let b = dev.reclaim_sync(b).unwrap();
             for v in b {
                 assert_eq!(v, 0.841471);
             }
@@ -343,7 +343,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
             .unwrap();
 
         let a_host = [-1.0f32, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8];
-        let a_dev = dev.copy_htod_async(a_host.clone().to_vec()).unwrap();
+        let a_dev = dev.htod_copy(a_host.clone().to_vec()).unwrap();
         let mut b_dev = a_dev.clone();
 
         for i in 0..5 {
@@ -356,7 +356,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
                 .unwrap();
         }
 
-        let b_host = dev.reclaim(b_dev).unwrap();
+        let b_host = dev.reclaim_sync(b_dev).unwrap();
 
         for (a_i, b_i) in a_host.iter().zip(b_host.iter()) {
             let expected = a_i.sin();
@@ -547,9 +547,9 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
             .with_ptx(ptx, "tests", &["slow_worker"])
             .build()
             .unwrap();
-        let slice = dev.alloc_zeros_async::<f32>(1000)?;
-        let mut a = dev.alloc_zeros_async::<f32>(1)?;
-        let mut b = dev.alloc_zeros_async::<f32>(1)?;
+        let slice = dev.alloc_zeros::<f32>(1000)?;
+        let mut a = dev.alloc_zeros::<f32>(1)?;
+        let mut b = dev.alloc_zeros::<f32>(1)?;
         let cfg = LaunchConfig::for_num_elems(1);
 
         let start = Instant::now();

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -250,7 +250,7 @@ mod tests {
         let t = device.htod_copy([0.0f32; 1].to_vec()).unwrap();
         let _r = t.clone();
         assert_eq!(Arc::strong_count(&device), 3);
-        let _ = t.as_kernel_param();
+        let _ = (&t).as_kernel_param();
         assert_eq!(Arc::strong_count(&device), 3);
     }
 
@@ -260,7 +260,7 @@ mod tests {
         let t = device.htod_copy([0.0f32; 1].to_vec()).unwrap();
         let _r = t.clone();
         assert_eq!(Arc::strong_count(&device), 3);
-        let _ = t.as_kernel_param();
+        let _ = (&t).as_kernel_param();
         assert_eq!(Arc::strong_count(&device), 3);
     }
 

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -295,7 +295,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
         }
         .unwrap();
 
-        let b_host = dev.reclaim_sync(b_dev).unwrap();
+        let b_host = dev.sync_reclaim(b_dev).unwrap();
 
         for (a_i, b_i) in a_host.iter().zip(b_host.iter()) {
             let expected = a_i.sin();
@@ -323,7 +323,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
             let cfg = LaunchConfig::for_num_elems(numel as u32);
             unsafe { sin_kernel.launch(cfg, (&mut b, &a, numel)) }.unwrap();
 
-            let b = dev.reclaim_sync(b).unwrap();
+            let b = dev.sync_reclaim(b).unwrap();
             for v in b {
                 assert_eq!(v, 0.841471);
             }
@@ -352,7 +352,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
                 .unwrap();
         }
 
-        let b_host = dev.reclaim_sync(b_dev).unwrap();
+        let b_host = dev.sync_reclaim(b_dev).unwrap();
 
         for (a_i, b_i) in a_host.iter().zip(b_host.iter()) {
             let expected = a_i.sin();

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -9,31 +9,31 @@
 //! let device = CudaDeviceBuilder::new(0).build().unwrap();
 //! ```
 //!
-//! 2. Allocate device memory with host data with [CudaDevice::copy_htod_async()], [CudaDevice::alloc_zeros_async()],
-//! or [CudaDevice::copy_htod_sync()].
+//! 2. Allocate device memory with host data with [CudaDevice::htod_copy()], [CudaDevice::alloc_zeros()],
+//! or [CudaDevice::htod_copy_sync()].
 //!
-//! You can also copy data to CudaSlice using [CudaDevice::copy_into_htod_sync()]
+//! You can also copy data to CudaSlice using [CudaDevice::htod_copy_into_sync()]
 //!
 //! ```rust
 //! # use cudarc::driver::*;
 //! # let device = CudaDeviceBuilder::new(0).build().unwrap();
-//! let a_dev: CudaSlice<f32> = device.alloc_zeros_async(10).unwrap();
-//! let b_dev: CudaSlice<f32> = device.copy_htod_async(vec![0.0; 10]).unwrap();
-//! let c_dev: CudaSlice<f32> = device.copy_htod_sync(&[1.0, 2.0, 3.0]).unwrap();
+//! let a_dev: CudaSlice<f32> = device.alloc_zeros(10).unwrap();
+//! let b_dev: CudaSlice<f32> = device.htod_copy(vec![0.0; 10]).unwrap();
+//! let c_dev: CudaSlice<f32> = device.htod_copy_sync(&[1.0, 2.0, 3.0]).unwrap();
 //! ```
 //!
-//! 3. Transfer to host memory with [CudaDevice::reclaim()], [CudaDevice::copy_dtoh_sync()],
-//! or [CudaDevice::copy_into_dtoh_sync()]
+//! 3. Transfer to host memory with [CudaDevice::reclaim_sync()], [CudaDevice::dtoh_copy_sync()],
+//! or [CudaDevice::dtoh_copy_into_sync()]
 //!
 //! ```rust
 //! # use cudarc::driver::*;
 //! # use std::rc::Rc;
 //! # let device = CudaDeviceBuilder::new(0).build().unwrap();
-//! let a_dev: CudaSlice<f32> = device.alloc_zeros_async(10).unwrap();
+//! let a_dev: CudaSlice<f32> = device.alloc_zeros(10).unwrap();
 //! let mut a_buf: [f32; 10] = [1.0; 10];
-//! device.copy_into_dtoh_sync(&a_dev, &mut a_buf);
+//! device.dtoh_copy_into_sync(&a_dev, &mut a_buf);
 //! assert_eq!(a_buf, [0.0; 10]);
-//! let a_host: Vec<f32> = device.reclaim(a_dev).unwrap();
+//! let a_host: Vec<f32> = device.reclaim_sync(a_dev).unwrap();
 //! assert_eq!(&a_host, &[0.0; 10]);
 //! ```
 //!
@@ -68,7 +68,7 @@
 //! # let ptx = compile_ptx("extern \"C\" __global__ void my_function(float *out) { }").unwrap();
 //! # let device = CudaDeviceBuilder::new(0).with_ptx(ptx, "module_key", &["my_function"]).build().unwrap();
 //! # let func: CudaFunction = device.get_func("module_key", "my_function").unwrap();
-//! let mut a = device.alloc_zeros_async::<f32>(10).unwrap();
+//! let mut a = device.alloc_zeros::<f32>(10).unwrap();
 //! let cfg = LaunchConfig::for_num_elems(10);
 //! unsafe { func.launch_async(cfg, (&mut a,)) }.unwrap();
 //! ```
@@ -91,7 +91,7 @@
 //! # use cudarc::{driver::*, nvrtc::*};
 //! # let ptx = compile_ptx("extern \"C\" __global__ void my_function(float *out) { }").unwrap();
 //! # let device = CudaDeviceBuilder::new(0).with_ptx(ptx, "module_key", &["my_function"]).build().unwrap();
-//! let mut a: CudaSlice<f32> = device.alloc_zeros_async::<f32>(3 * 10).unwrap();
+//! let mut a: CudaSlice<f32> = device.alloc_zeros::<f32>(3 * 10).unwrap();
 //! for i_batch in 0..3 {
 //!     let mut a_sub_view: CudaViewMut<f32> = a.try_slice_mut(i_batch * 10..).unwrap();
 //!     let f: CudaFunction = device.get_func("module_key", "my_function").unwrap();

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -9,20 +9,21 @@
 //! let device = CudaDeviceBuilder::new(0).build().unwrap();
 //! ```
 //!
-//! 2. Allocate device memory with host data with [CudaDevice::take_async()], [CudaDevice::alloc_zeros_async()],
-//! or [CudaDevice::sync_copy()]
+//! 2. Allocate device memory with host data with [CudaDevice::copy_htod_async()], [CudaDevice::alloc_zeros_async()],
+//! or [CudaDevice::copy_htod_sync()].
 //!
-//! You can also copy data to CudaSlice using [CudaDevice::sync_copy_into()]
+//! You can also copy data to CudaSlice using [CudaDevice::copy_into_htod_sync()]
 //!
 //! ```rust
 //! # use cudarc::driver::*;
 //! # let device = CudaDeviceBuilder::new(0).build().unwrap();
 //! let a_dev: CudaSlice<f32> = device.alloc_zeros_async(10).unwrap();
-//! let b_dev: CudaSlice<f32> = device.take_async(vec![0.0; 10]).unwrap();
-//! let c_dev: CudaSlice<f32> = device.sync_copy(&[1.0, 2.0, 3.0]).unwrap();
+//! let b_dev: CudaSlice<f32> = device.copy_htod_async(vec![0.0; 10]).unwrap();
+//! let c_dev: CudaSlice<f32> = device.copy_htod_sync(&[1.0, 2.0, 3.0]).unwrap();
 //! ```
 //!
-//! 3. Transfer to host memory with [CudaDevice::sync_release()] or [CudaDevice::sync_copy_from()]
+//! 3. Transfer to host memory with [CudaDevice::reclaim()], [CudaDevice::copy_dtoh_sync()],
+//! or [CudaDevice::copy_into_dtoh_sync()]
 //!
 //! ```rust
 //! # use cudarc::driver::*;
@@ -30,9 +31,9 @@
 //! # let device = CudaDeviceBuilder::new(0).build().unwrap();
 //! let a_dev: CudaSlice<f32> = device.alloc_zeros_async(10).unwrap();
 //! let mut a_buf: [f32; 10] = [1.0; 10];
-//! device.sync_copy_from(&a_dev, &mut a_buf);
+//! device.copy_into_dtoh_sync(&a_dev, &mut a_buf);
 //! assert_eq!(a_buf, [0.0; 10]);
-//! let a_host: Vec<f32> = device.sync_release(a_dev).unwrap();
+//! let a_host: Vec<f32> = device.reclaim(a_dev).unwrap();
 //! assert_eq!(&a_host, &[0.0; 10]);
 //! ```
 //!

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -70,7 +70,7 @@
 //! # let func: CudaFunction = device.get_func("module_key", "my_function").unwrap();
 //! let mut a = device.alloc_zeros::<f32>(10).unwrap();
 //! let cfg = LaunchConfig::for_num_elems(10);
-//! unsafe { func.launch_async(cfg, (&mut a,)) }.unwrap();
+//! unsafe { func.launch(cfg, (&mut a,)) }.unwrap();
 //! ```
 //!
 //! Note: Launching kernels is **extremely unsafe**. See [LaunchAsync] for more info.
@@ -96,7 +96,7 @@
 //!     let mut a_sub_view: CudaViewMut<f32> = a.try_slice_mut(i_batch * 10..).unwrap();
 //!     let f: CudaFunction = device.get_func("module_key", "my_function").unwrap();
 //!     let cfg = LaunchConfig::for_num_elems(10);
-//!     unsafe { f.launch_async(cfg, (&mut a_sub_view,)) }.unwrap();
+//!     unsafe { f.launch(cfg, (&mut a_sub_view,)) }.unwrap();
 //! }
 //! ```
 //!

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -10,20 +10,20 @@
 //! ```
 //!
 //! 2. Allocate device memory with host data with [CudaDevice::htod_copy()], [CudaDevice::alloc_zeros()],
-//! or [CudaDevice::htod_copy_sync()].
+//! or [CudaDevice::htod_sync_copy()].
 //!
-//! You can also copy data to CudaSlice using [CudaDevice::htod_copy_into_sync()]
+//! You can also copy data to CudaSlice using [CudaDevice::htod_sync_copy_into()]
 //!
 //! ```rust
 //! # use cudarc::driver::*;
 //! # let device = CudaDeviceBuilder::new(0).build().unwrap();
 //! let a_dev: CudaSlice<f32> = device.alloc_zeros(10).unwrap();
 //! let b_dev: CudaSlice<f32> = device.htod_copy(vec![0.0; 10]).unwrap();
-//! let c_dev: CudaSlice<f32> = device.htod_copy_sync(&[1.0, 2.0, 3.0]).unwrap();
+//! let c_dev: CudaSlice<f32> = device.htod_sync_copy(&[1.0, 2.0, 3.0]).unwrap();
 //! ```
 //!
-//! 3. Transfer to host memory with [CudaDevice::reclaim_sync()], [CudaDevice::dtoh_copy_sync()],
-//! or [CudaDevice::dtoh_copy_into_sync()]
+//! 3. Transfer to host memory with [CudaDevice::sync_reclaim()], [CudaDevice::dtoh_sync_copy()],
+//! or [CudaDevice::dtoh_sync_copy_into()]
 //!
 //! ```rust
 //! # use cudarc::driver::*;
@@ -31,9 +31,9 @@
 //! # let device = CudaDeviceBuilder::new(0).build().unwrap();
 //! let a_dev: CudaSlice<f32> = device.alloc_zeros(10).unwrap();
 //! let mut a_buf: [f32; 10] = [1.0; 10];
-//! device.dtoh_copy_into_sync(&a_dev, &mut a_buf);
+//! device.dtoh_sync_copy_into(&a_dev, &mut a_buf);
 //! assert_eq!(a_buf, [0.0; 10]);
-//! let a_host: Vec<f32> = device.reclaim_sync(a_dev).unwrap();
+//! let a_host: Vec<f32> = device.sync_reclaim(a_dev).unwrap();
 //! assert_eq!(&a_host, &[0.0; 10]);
 //! ```
 //!


### PR DESCRIPTION
resolves #55 

New names for things:
- alloc
- alloc_zeros
- memset_zeros
- launch
- launch_on_stream
- dtod_copy
- htod_copy
- htod_copy_into
- htod_sync_copy
- htod_sync_copy_into
- dtoh_sync_copy
- dtoh_sync_copy_into
- sync_reclaim