### PR TITLE
Reverting free stream, putting free_async calls on default stream

### DIFF
--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -156,11 +156,6 @@
 //! Multi stream is supported via [CudaStream], however it automatically
 //! synchronizes with the main stream on creation & on drop. It is still possible
 //! to be unsafe in a multi stream context though.
-//!
-//! [CudaDevice] actually has a 2nd stream, where it places all `free()`
-//! operations as well. This is transparent to the user, and are synchronized
-//! with the main stream using the [crate::driver::result::event]
-//! module and [crate::driver::result::stream::wait_event].
 
 pub(crate) mod alloc;
 pub(crate) mod core;


### PR DESCRIPTION
I believe this may be the case of the memory leak here: https://github.com/coreylowman/dfdx/issues/523

When I run a simple benchmark with using the free stream, the memory use becomes 100% of the GPU. If I remove the free stream, the memory usage only gets to about 30%, indicating that the gpu wasn't freeing memory.