### PR TITLE
More sound CudaStream

### DIFF
--- a/examples/04-streams.rs
+++ b/examples/04-streams.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), DriverError> {
     // and we must join with the default work stream in order for copies
     // to work corrently.
     // NOTE: this is actually async with respect to the host!
-    dev.wait_for(stream)?;
+    dev.wait_for(&stream)?;
 
     let a_host_2 = dev.sync_reclaim(a_dev)?;
     let b_host = dev.sync_reclaim(b_dev)?;

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -554,6 +554,7 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
             unsafe { f.launch(cfg, (&slice, slice.len(), &mut a))? };
             let f = dev.get_func("tests", "slow_worker").unwrap();
             unsafe { f.launch_on_stream(&stream, cfg, (&slice, slice.len(), &mut b))? };
+            dev.wait_for(&stream)?;
             dev.synchronize()?;
         }
         let par_launch_s = start.elapsed().as_secs_f64();


### PR DESCRIPTION
- CudaDevice::wait_for now accepts reference to stream, so you don't have to destroy it.
- Adds CudaStream::wait_for_default so you can synchronize a stream with CudaDevice's stream.

This allows you to keep a single stream alongside CudaDevice to synchronize with, so you don't have to keep creating/destroying