### PR TITLE
Adding static linking potential.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ keywords = [
 features = ["ci-check", "f16"]
 
 [features]
-default = ["std", "driver", "nvrtc", "cublas", "curand"]
+default = ["std", "driver", "nvrtc", "cublas", "curand", "alloc_async"]
 nvrtc = []
 driver = ["nvrtc"]
 cublas = []
@@ -34,6 +34,7 @@ std = []
 no-std = ["no-std-compat/std", "dep:spin"]
 f16 = ["dep:half"]
 ci-check = []
+alloc_async = []
 
 [dependencies]
 spin = { version = "0.9.4", optional = true, features = ["rwlock"], default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -20,15 +20,29 @@ fn link_cuda() {
     #[cfg(feature = "driver")]
     println!("cargo:rustc-link-lib=dylib=cuda");
     #[cfg(feature = "driver")]
-    println!("cargo:rustc-link-lib=dylib=cudart");
+    println!("cargo:rustc-link-lib=static=cudart_static");
     #[cfg(feature = "nvrtc")]
     println!("cargo:rustc-link-lib=dylib=nvrtc");
     #[cfg(feature = "curand")]
     println!("cargo:rustc-link-lib=dylib=curand");
-    #[cfg(feature = "cublas")]
-    println!("cargo:rustc-link-lib=dylib=cublas");
-    #[cfg(feature = "cublas")]
-    println!("cargo:rustc-link-lib=dylib=cublasLt");
+
+    println!("cargo:rerun-if-env-changed=STATIC");
+    let is_static = std::env::var("STATIC").unwrap_or_else(|_| "0".to_string()) == "1";
+
+    if is_static {
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=static=cublas_static");
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=static=cublasLt_static");
+    } else {
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=dylib=cublas");
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=dylib=cublasLt");
+    }
+
     #[cfg(feature = "cudnn")]
     println!("cargo:rustc-link-search=native={}", std::env::var("CUDNN_LIB").expect("Failed to read environmental variable `CUDNN_LIB`. Set `CUDNN_LIB` to `path/to/cudnn/lib`."));
     #[cfg(feature = "cudnn")]

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -300,13 +300,11 @@ pub unsafe fn malloc_async(
 pub unsafe fn free_async(dptr: sys::CUdeviceptr, stream: sys::CUstream) -> Result<(), DriverError> {
     #[cfg(feature = "alloc_async")]
     {
-        println!("ASYNC");
         sys::cuMemFreeAsync(dptr, stream).result()
     }
 
     #[cfg(not(feature = "alloc_async"))]
     {
-        println!("SYNC");
         sys::cuMemFree_v2(dptr).result()
     }
 }

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -281,7 +281,11 @@ pub unsafe fn malloc_async(
     num_bytes: usize,
 ) -> Result<sys::CUdeviceptr, DriverError> {
     let mut dev_ptr = MaybeUninit::uninit();
+    #[cfg(feature = "alloc_async")]
     sys::cuMemAllocAsync(dev_ptr.as_mut_ptr(), num_bytes, stream).result()?;
+
+    #[cfg(not(feature = "alloc_async"))]
+    sys::cuMemAlloc_v2(dev_ptr.as_mut_ptr(), num_bytes).result()?;
     Ok(dev_ptr.assume_init())
 }
 
@@ -294,7 +298,17 @@ pub unsafe fn malloc_async(
 /// 2. The memory should have been allocated on this stream.
 /// 3. The memory should not have been freed already (double free)
 pub unsafe fn free_async(dptr: sys::CUdeviceptr, stream: sys::CUstream) -> Result<(), DriverError> {
-    sys::cuMemFreeAsync(dptr, stream).result()
+    #[cfg(feature = "alloc_async")]
+    {
+        println!("ASYNC");
+        sys::cuMemFreeAsync(dptr, stream).result()
+    }
+
+    #[cfg(not(feature = "alloc_async"))]
+    {
+        println!("SYNC");
+        sys::cuMemFree_v2(dptr).result()
+    }
 }
 
 /// Sets device memory with stream ordered semantics.


### PR DESCRIPTION
When building binaries with cuda, the dependency on the libs is super large.

Biggest culprit is cublasLt which is 485Mb on its own.
Using static linking, shrinks everything into the binary which becomes ~130Mo (after stripping) in my case.
It also makes cublas loading much faster.

I chose to use an env variable for the type of linking since it avoids introducing new features and bloating the code with them.

Feel free to ignore if you don't deem this worthy ! 