### PR TITLE
Static linking (with feature flag).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ std = []
 no-std = ["no-std-compat/std", "dep:spin"]
 f16 = ["dep:half"]
 ci-check = []
+static-linking=[]
 
 [dependencies]
 spin = { version = "0.9.4", optional = true, features = ["rwlock"], default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -20,15 +20,29 @@ fn link_cuda() {
     #[cfg(feature = "driver")]
     println!("cargo:rustc-link-lib=dylib=cuda");
     #[cfg(feature = "driver")]
-    println!("cargo:rustc-link-lib=dylib=cudart");
+    println!("cargo:rustc-link-lib=static=cudart_static");
     #[cfg(feature = "nvrtc")]
     println!("cargo:rustc-link-lib=dylib=nvrtc");
     #[cfg(feature = "curand")]
     println!("cargo:rustc-link-lib=dylib=curand");
-    #[cfg(feature = "cublas")]
-    println!("cargo:rustc-link-lib=dylib=cublas");
-    #[cfg(feature = "cublas")]
-    println!("cargo:rustc-link-lib=dylib=cublasLt");
+
+    println!("cargo:rerun-if-env-changed=STATIC");
+    let is_static = std::env::var("STATIC").unwrap_or_else(|_| "0".to_string()) == "1";
+
+    if is_static {
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=static=cublas_static");
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=static=cublasLt_static");
+    } else {
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=dylib=cublas");
+        #[cfg(feature = "cublas")]
+        println!("cargo:rustc-link-lib=dylib=cublasLt");
+    }
+
     #[cfg(feature = "cudnn")]
     println!("cargo:rustc-link-search=native={}", std::env::var("CUDNN_LIB").expect("Failed to read environmental variable `CUDNN_LIB`. Set `CUDNN_LIB` to `path/to/cudnn/lib`."));
     #[cfg(feature = "cudnn")]

--- a/build.rs
+++ b/build.rs
@@ -19,24 +19,22 @@ fn link_cuda() {
 
     #[cfg(feature = "driver")]
     println!("cargo:rustc-link-lib=dylib=cuda");
-    #[cfg(feature = "driver")]
-    println!("cargo:rustc-link-lib=static=cudart_static");
     #[cfg(feature = "nvrtc")]
     println!("cargo:rustc-link-lib=dylib=nvrtc");
     #[cfg(feature = "curand")]
     println!("cargo:rustc-link-lib=dylib=curand");
 
-    println!("cargo:rerun-if-env-changed=STATIC");
-    let is_static = std::env::var("STATIC").unwrap_or_else(|_| "0".to_string()) == "1";
-
-    if is_static {
+    #[cfg(feature = "static-linking")]
+    {
         #[cfg(feature = "cublas")]
         println!("cargo:rustc-link-lib=dylib=stdc++");
         #[cfg(feature = "cublas")]
         println!("cargo:rustc-link-lib=static=cublas_static");
         #[cfg(feature = "cublas")]
         println!("cargo:rustc-link-lib=static=cublasLt_static");
-    } else {
+    }
+    #[cfg(not(feature = "static-linking"))]
+    {
         #[cfg(feature = "cublas")]
         println!("cargo:rustc-link-lib=dylib=cublas");
         #[cfg(feature = "cublas")]


### PR DESCRIPTION
When building binaries with cuda, the dependency on the libs is super large.

Biggest culprit is cublasLt which is 485Mb on its own.
Using static linking, shrinks everything into the binary which becomes ~130Mo (after stripping) in my case.
It also makes cublas loading much faster.
