### PR TITLE
Adding opt-out sync alloc for older cards.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ keywords = [
 features = ["ci-check", "f16"]
 
 [features]
-default = ["std", "driver", "nvrtc", "cublas", "curand"]
+default = ["std", "driver", "nvrtc", "cublas", "curand", "alloc_async"]
 nvrtc = []
 driver = ["nvrtc"]
 cublas = []
@@ -34,6 +34,7 @@ std = []
 no-std = ["no-std-compat/std", "dep:spin"]
 f16 = ["dep:half"]
 ci-check = []
+alloc_async = []
 
 [dependencies]
 spin = { version = "0.9.4", optional = true, features = ["rwlock"], default-features = false }


### PR DESCRIPTION
currently have an older GPU (GTX 970). With compute cap 5.2.

Those cards get Operation not supported for the alloc/free async part.

This PR should allow for this crate to work for such older cards by using sync alloc without stream.
Since it's sync and a superset it's fine. 
Since it's for old cards only (it seems) the feature is enabled by default.

Wdyt ?