### PR TITLE
Support runtime names of modules

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -36,7 +36,7 @@ pub struct CudaDevice {
     pub(crate) stream: sys::CUstream,
     /// Used to synchronize with stream
     pub(crate) event: sys::CUevent,
-    pub(crate) modules: RwLock<BTreeMap<&'static str, CudaModule>>,
+    pub(crate) modules: RwLock<BTreeMap<String, CudaModule>>,
 }
 
 unsafe impl Send for CudaDevice {}
@@ -402,6 +402,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::reversed_empty_ranges)]
     fn test_bounds_helper() {
         assert_eq!((..2usize).bounds(0..usize::MAX), Some((0, 2)));
         assert_eq!((1..2usize).bounds(..usize::MAX), Some((1, 2)));

--- a/src/driver/safe/ptx.rs
+++ b/src/driver/safe/ptx.rs
@@ -17,7 +17,7 @@ impl CudaDevice {
     pub fn load_ptx(
         self: &Arc<Self>,
         ptx: Ptx,
-        module_name: &'static str,
+        module_name: &str,
         func_names: &[&'static str],
     ) -> Result<(), result::DriverError> {
         let cu_module = match ptx.0 {
@@ -48,7 +48,7 @@ impl CudaDevice {
             let mut modules = self.modules.write();
             #[cfg(not(feature = "no-std"))]
             let mut modules = modules.unwrap();
-            modules.insert(module_name, module);
+            modules.insert(module_name.into(), module);
         }
         Ok(())
     }


### PR DESCRIPTION
To support things like determining module name based on parameters. E.g. `conv2d_<width>_<height>`, where width/height are known at runtime, and therefore you don't have a `&'static str`