### PR TITLE
rust kernel & example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /Cargo.lock
+/examples/rust-kernel/target
+/examples/rust-kernel/Cargo.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "**/Cargo.toml"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "rust-analyzer.linkedProjects": [
-        "**/Cargo.toml"
+        "./Cargo.toml",
+        "./examples/rust-kernel/Cargo.toml"
     ]
 }

--- a/examples/08-rust-kernel.rs
+++ b/examples/08-rust-kernel.rs
@@ -1,43 +1,69 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, array};
 
 use cudarc::{
     driver::{CudaDevice, DriverError, LaunchAsync, LaunchConfig},
     nvrtc::PtxCrate,
 };
 
+use std::time::Instant;
+
 fn main() -> Result<(), DriverError> {
     let dev = CudaDevice::new(0)?;
 
-    // use compile_crate_to_ptx to build and rust kernels in pure rust
+    // use compile_crate_to_ptx to build kernels in pure Rust
     // uses experimental ABI_PTX
     let kernel_path: PathBuf = "examples/rust-kernel/src/lib.rs".into();
     let kernels = PtxCrate::compile_crate_to_ptx(&kernel_path).unwrap();
     let kernel = kernels.first().unwrap();
 
     // load the ptx file...
-    println!("loading...");
     dev.load_ptx(kernel.clone(), "rust_kernel", &["square_kernel"])?;
-    println!("loaded!");
-
+    
     // and then retrieve the function with `get_func`
     let f = dev.get_func("rust_kernel", "square_kernel").unwrap();
 
-    let a_host = [1.0f32, 2., 3.];
+    const GRID: u32 = 32;
+    const BLOCK: u32 = 512;
+    const THREADS: u32 = GRID * BLOCK;
+
+    // https://developer.nvidia.com/blog/cuda-pro-tip-occupancy-api-simplifies-launch-configuration/
+    let cfg = LaunchConfig {
+        grid_dim: (GRID, 1, 1),
+        block_dim: (BLOCK, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    // or use let cfg = LaunchConfig::for_num_elems(n);
+
+    let a_host: [f32; THREADS as usize] = array::from_fn(|i| {
+        i as f32
+    });
 
     let a_dev = dev.htod_copy(a_host.into())?;
     let mut b_dev = a_dev.clone();
 
-    let n = 3;
-    let cfg = LaunchConfig::for_num_elems(n);
-    unsafe { f.launch(cfg, (&a_dev, &mut b_dev, n as i32)) }?;
-
-    let a_host_2 = dev.sync_reclaim(a_dev.clone())?;
-    let b_host = dev.sync_reclaim(b_dev.clone())?;
-
-    println!("a_host {a_host:?}");
-    println!("b_host {b_host:?}");
-    println!("a_host_2 {a_host_2:?}");
+    println!("squaring 0.0, ..., {}.0 with cuda kernels...", THREADS - 1);
     
+    let start = Instant::now();
+    unsafe { f.launch(cfg, (&a_dev, &mut b_dev, THREADS as i32)) }?;
+    let duration = start.elapsed();
+    println!("launch duration: {:?}", duration);
+    
+    let start = Instant::now();
+    let b_host = dev.sync_reclaim(b_dev.clone())?;
+    let duration = start.elapsed();
+    println!("duration to get results: {:?}", duration);
+    
+    
+    let a_host_2 = dev.sync_reclaim(a_dev.clone())?;
+    let results: Vec<_> = a_host_2.into_iter().zip(b_host.into_iter()).collect();
+    
+    println!("checking some results:");
+    let some_indices: [u32; 6] = [0, THREADS/10, THREADS/5, THREADS/4, THREADS/2, THREADS - 1];
+    for i in some_indices {
+        let (x, x_square) = results.get(i as usize).unwrap();
+        println!("\t{x}^2\t = {x_square}")
+    }
+
     // we can also manage and clean up the build ptx files with a PtxCrate
     let mut rust_ptx: PtxCrate = kernel_path.try_into().unwrap();
     rust_ptx.build_ptx().unwrap();

--- a/examples/08-rust-kernel.rs
+++ b/examples/08-rust-kernel.rs
@@ -1,0 +1,39 @@
+use cudarc::{
+    driver::{CudaDevice, DriverError, LaunchAsync, LaunchConfig},
+    nvrtc::{Ptx, RustPtx},
+};
+
+fn main() -> Result<(), DriverError> {
+    let dev = CudaDevice::new(0)?;
+
+    let rust_ptx = RustPtx::new("examples/rust-kernel/src/lib.rs".into());
+    rust_ptx.build_ptx().unwrap();
+
+    // You can load a function from a pre-compiled PTX like so:
+    println!("loading...");
+    dev.load_ptx(Ptx::from_file("examples/rust-kernel/target/nvptx64-nvidia-cuda/release/kernel.ptx"), "kernel", &["kernel"])?;
+    println!("loaded!");
+
+    // and then retrieve the function with `get_func`
+    let f = dev.get_func("kernel", "kernel").unwrap();
+
+    let a_host = [1, 2, 3];
+
+    let a_dev = dev.htod_copy(a_host.into())?;
+    let mut b_dev = a_dev.clone();
+
+    let n = 3;
+    let cfg = LaunchConfig::for_num_elems(n);
+    unsafe { f.launch(cfg, (&mut b_dev, n as i32)) }?;
+
+    let a_host_2 = dev.sync_reclaim(a_dev.clone())?;
+    let b_host = dev.sync_reclaim(b_dev.clone())?;
+
+    println!("a_host {a_host:?}");
+    
+    println!("b_host {b_host:?}");
+    
+    println!("a_host_2 {a_host_2:?}");
+    
+    Ok(())
+}

--- a/examples/08-rust-kernel.rs
+++ b/examples/08-rust-kernel.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, array};
 
 use cudarc::{
     driver::{CudaDevice, DriverError, LaunchAsync, LaunchConfig},
-    nvrtc::{Ptx, PtxCrate},
+    nvrtc::{Ptx, PtxCrate, compile_crate_to_ptx},
 };
 
 use std::time::Instant;
@@ -13,7 +13,7 @@ fn main() -> Result<(), DriverError> {
     // use compile_crate_to_ptx to build kernels in pure Rust
     // uses experimental ABI_PTX
     let kernel_path: PathBuf = "examples/rust-kernel/src/lib.rs".into();
-    let kernels: Vec<Ptx> = PtxCrate::compile_crate_to_ptx(&kernel_path).unwrap();
+    let kernels: Vec<Ptx> = compile_crate_to_ptx(&kernel_path).unwrap();
     let kernel = kernels.first().unwrap();
 
     // load the ptx file...

--- a/examples/08-rust-kernel.rs
+++ b/examples/08-rust-kernel.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, array};
 
 use cudarc::{
     driver::{CudaDevice, DriverError, LaunchAsync, LaunchConfig},
-    nvrtc::PtxCrate,
+    nvrtc::{Ptx, PtxCrate},
 };
 
 use std::time::Instant;
@@ -13,7 +13,7 @@ fn main() -> Result<(), DriverError> {
     // use compile_crate_to_ptx to build kernels in pure Rust
     // uses experimental ABI_PTX
     let kernel_path: PathBuf = "examples/rust-kernel/src/lib.rs".into();
-    let kernels = PtxCrate::compile_crate_to_ptx(&kernel_path).unwrap();
+    let kernels: Vec<Ptx> = PtxCrate::compile_crate_to_ptx(&kernel_path).unwrap();
     let kernel = kernels.first().unwrap();
 
     // load the ptx file...

--- a/examples/08-rust-kernel.rs
+++ b/examples/08-rust-kernel.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), DriverError> {
     // we can also manage and clean up the build ptx files with a PtxCrate
     let mut rust_ptx: PtxCrate = kernel_path.try_into().unwrap();
     rust_ptx.build_ptx().unwrap();
-    let _kernel = rust_ptx.ptx_files().unwrap().first().unwrap();
+    let _kernel: &Ptx = rust_ptx.peek_kernels().unwrap().first().unwrap();
     println!("cleaned successfully? {:?}", rust_ptx.clean());
 
     Ok(())

--- a/examples/08-rust-kernel.rs
+++ b/examples/08-rust-kernel.rs
@@ -16,20 +16,20 @@ fn main() -> Result<(), DriverError> {
 
     // load the ptx file...
     println!("loading...");
-    dev.load_ptx(kernel.clone(), "kernel", &["kernel"])?;
+    dev.load_ptx(kernel.clone(), "rust_kernel", &["square_kernel"])?;
     println!("loaded!");
 
     // and then retrieve the function with `get_func`
-    let f = dev.get_func("kernel", "kernel").unwrap();
+    let f = dev.get_func("rust_kernel", "square_kernel").unwrap();
 
-    let a_host = [1, 2, 3];
+    let a_host = [1.0f32, 2., 3.];
 
     let a_dev = dev.htod_copy(a_host.into())?;
     let mut b_dev = a_dev.clone();
 
     let n = 3;
     let cfg = LaunchConfig::for_num_elems(n);
-    unsafe { f.launch(cfg, (&mut b_dev, n as i32)) }?;
+    unsafe { f.launch(cfg, (&a_dev, &mut b_dev, n as i32)) }?;
 
     let a_host_2 = dev.sync_reclaim(a_dev.clone())?;
     let b_host = dev.sync_reclaim(b_dev.clone())?;

--- a/examples/08-rust-kernel.rs
+++ b/examples/08-rust-kernel.rs
@@ -1,4 +1,4 @@
-use std::path::{PathBuf, Path};
+use std::path::PathBuf;
 
 use cudarc::{
     driver::{CudaDevice, DriverError, LaunchAsync, LaunchConfig},

--- a/examples/rust-kernel/Cargo.toml
+++ b/examples/rust-kernel/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [lib]
 name = "kernel"
 path = "src/lib.rs"
-build = "cargo +nightly rustc --lib --target nvptx64-nvidia-cuda --release -- --emit asm"
+# build = "cargo +nightly rustc --lib --target nvptx64-nvidia-cuda --release -- --emit asm"
 crate-type = ["cdylib"]

--- a/examples/rust-kernel/Cargo.toml
+++ b/examples/rust-kernel/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 
 [lib]
 name = "kernel"
-path = "src/lib.rs"
 # build = "cargo +nightly rustc --lib --target nvptx64-nvidia-cuda --release -- --emit asm"
 crate-type = ["cdylib"]

--- a/examples/rust-kernel/Cargo.toml
+++ b/examples/rust-kernel/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust-kernel"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+name = "kernel"
+path = "src/lib.rs"
+build = "cargo +nightly rustc --lib --target nvptx64-nvidia-cuda --release -- --emit asm"
+crate-type = ["cdylib"]

--- a/examples/rust-kernel/src/device.rs
+++ b/examples/rust-kernel/src/device.rs
@@ -1,0 +1,6 @@
+#![no_std]
+// a no_std fn
+pub fn square(num: f32) -> f32 {
+    // your device function implementation
+    num * num
+}

--- a/examples/rust-kernel/src/lib.rs
+++ b/examples/rust-kernel/src/lib.rs
@@ -18,16 +18,23 @@ fn my_panic(_: &core::panic::PanicInfo) -> ! {
 */
 
 #[no_mangle]
-pub unsafe extern "ptx-kernel" fn square_kernel(input: *const f32, output: *mut f32, size: u32) {
+pub unsafe extern "ptx-kernel" fn square_kernel(input: *const f32, output: *mut f32, size: i32) {
     /* https://doc.rust-lang.org/stable/core/arch/nvptx/index.html */
     let thread_id: i32 = _thread_idx_x();
     let block_id: i32 = _block_idx_x();
-    let grid_dim: i32 = _grid_dim_x();
-    let n_threads: i32 = _block_dim_x() * _grid_dim_x();
     
-    let index = thread_id as usize;
-    if index < size as usize {
-        let value = device::square(*input.offset(index as isize));
-        *output.offset(index as isize) = value;
+    let block_dim: i32 = _block_dim_x();
+    let grid_dim: i32 = _grid_dim_x();
+    
+    let n_threads = (block_dim * grid_dim) as u64;
+    
+    let thread_index = 
+        thread_id + 
+        block_id * block_dim
+    ;
+
+    if thread_index < size {
+        let value = device::square(*input.offset(thread_index as isize));
+        *output.offset(thread_index as isize) = value;
     }
 }

--- a/examples/rust-kernel/src/lib.rs
+++ b/examples/rust-kernel/src/lib.rs
@@ -2,6 +2,8 @@
 #![feature(stdsimd)]        // simd instructions (unstable)
 #![no_std]                  // CUDA compatibility
 
+mod device;
+
 use core::arch::nvptx::*;   // access to thread id, etc
 
 #[panic_handler]
@@ -25,13 +27,7 @@ pub unsafe extern "ptx-kernel" fn square_kernel(input: *const f32, output: *mut 
     
     let index = thread_id as usize;
     if index < size as usize {
-        let value = square_device(*input.offset(index as isize));
+        let value = device::square(*input.offset(index as isize));
         *output.offset(index as isize) = value;
     }
-}
-
-// a no_std fn
-pub fn square_device(num: f32) -> f32 {
-    // your device function implementation
-    num * num
 }

--- a/examples/rust-kernel/src/lib.rs
+++ b/examples/rust-kernel/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]// nightly only due to experimental features (also improves linting linter)
 #![feature(abi_ptx)]        // emitting ptx (unstable)
 #![feature(stdsimd)]        // simd instructions (unstable)
 #![no_std]                  // CUDA compatibility

--- a/examples/rust-kernel/src/lib.rs
+++ b/examples/rust-kernel/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "nightly")]// nightly only due to experimental features (also improves linting linter)
 #![feature(abi_ptx)]        // emitting ptx (unstable)
 #![feature(stdsimd)]        // simd instructions (unstable)
 #![no_std]                  // CUDA compatibility

--- a/examples/rust-kernel/src/lib.rs
+++ b/examples/rust-kernel/src/lib.rs
@@ -1,0 +1,37 @@
+#![feature(abi_ptx)]        // emitting ptx (unstable)
+#![feature(stdsimd)]        // simd instructions (unstable)
+#![no_std]                  // CUDA compatibility
+
+use core::arch::nvptx::*;   // access to thread id, etc
+
+#[panic_handler]            // CUDA compatibility (required?)
+fn my_panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+/*
+    don't mangle fn name
+    array: *mut i32     shared memory for writing output
+    size: u32           size of array
+*/
+
+#[no_mangle]
+pub unsafe extern "ptx-kernel" fn kernel(array: *mut i32, size: u32) {
+    let thread_id: i32 = _thread_idx_x();
+    let block_id: i32 = _block_idx_x();
+    let grid_dim: i32 = _grid_dim_x();
+    let n_threads: i32 = _block_dim_x() * _grid_dim_x();
+    
+    let index = thread_id as usize;
+    if index < size as usize {
+        let value: i32 = device(thread_id, block_id, n_threads, grid_dim);
+        *array.offset(index as isize) = value;
+    }
+}
+
+// an ordinary (no_std?) Rust fn that calculates using only thread info
+pub fn device(thread_id: i32, block_id: i32, n_threads: i32, grid_dim: i32) -> i32 {
+    // your device function implementation
+    // use tid, ctaid, ntid, and nctaid to determine what to write to the array
+    thread_id + block_id + n_threads + grid_dim + 100000
+}

--- a/src/nvrtc/safe.rs
+++ b/src/nvrtc/safe.rs
@@ -6,7 +6,8 @@ use super::{result, sys};
 
 use core::ffi::{c_char, CStr};
 use std::ffi::CString;
-use std::fs;
+use std::{fs, fs::File};
+use std::io::Read;
 use std::path::Path;
 use std::{borrow::ToOwned, path::PathBuf, string::String, vec::Vec};
 use std::process::Command;
@@ -426,7 +427,12 @@ impl PtxCrate {
                 .filter_map(|entry| {
                     let path = entry.unwrap().path();
                     if let Some("ptx") = path.extension().and_then(|ext| ext.to_str()) {
-                        Some(Ptx::from_file(path))
+                        let mut src = String::new();
+                        File::open(path)
+                            .unwrap()
+                            .read_to_string(&mut src)
+                            .unwrap();
+                        Some(Ptx::from_src(src))
                     } else {
                         None
                     }

--- a/src/nvrtc/safe.rs
+++ b/src/nvrtc/safe.rs
@@ -264,7 +264,7 @@ impl TryFrom<PathBuf> for PtxCrateKind {
 
         // if value = path/to/project/ containing Cargo.toml
         if value.join("Cargo.toml").exists() {
-            Ok( Self::Cargo { project_dir: value.into() } )
+            Ok( Self::Cargo { project_dir: value } )
         } else {
             Err(format!("{value:?}/Cargo.toml missing"))
         }
@@ -300,7 +300,11 @@ impl PtxCrate {
         let kernel_path: PathBuf = kernel_path.as_ref().into();
         let mut rust_ptx: Self = kernel_path.try_into()?;
         rust_ptx.build_ptx()?;
-        Ok(rust_ptx.ptx_files().unwrap().clone())
+        Ok(rust_ptx.take_kernels().unwrap())
+    }
+
+    pub fn take_kernels(self) -> Option<Vec<Ptx>> {
+        self.kernels
     }
     
     pub fn ptx_files(&self) -> Option<&Vec<Ptx>> {

--- a/src/nvrtc/safe.rs
+++ b/src/nvrtc/safe.rs
@@ -249,7 +249,7 @@ impl TryFrom<PathBuf> for PtxCrateKind {
                         if manifest.exists() {
                             return Ok( Self::Cargo { project_dir: project_dir.into() } )
                         } else {
-                            todo!()
+                            return Ok(Self::Standalone { standalone: value })
                         }
                     } else {
                         return Err(format!("could not find parent of {src:?}"))


### PR DESCRIPTION
Run example with

```powershell
cargo run --release --example 08-rust-kernel
```

RustPtx builds ptx from a valid lib.rs with Command and ABI_PTX (experimental, expect bugs and old PTX versions). lib.rs requires a Cargo.toml.