### PR TITLE
Add functions to interact with external memory

### DIFF
--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -587,6 +587,8 @@ pub mod external_memory {
 
     /// Imports an external memory object, in this case an OpaqueFd.
     ///
+    /// The memory should be destroyed using [`destroy_external_memory`].
+    ///
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXTRES__INTEROP.html#group__CUDA__EXTRES__INTEROP_1g52aba3a7f780157d8ba12972b2481735)
     ///
     /// # Safety
@@ -608,6 +610,8 @@ pub mod external_memory {
     }
 
     /// Imports an external memory object, in this case an OpaqueWin32 handle.
+    ///
+    /// The memory should be destroyed using [`destroy_external_memory`].
     ///
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXTRES__INTEROP.html#group__CUDA__EXTRES__INTEROP_1g52aba3a7f780157d8ba12972b2481735)
     ///
@@ -639,8 +643,8 @@ pub mod external_memory {
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXTRES__INTEROP.html#group__CUDA__EXTRES__INTEROP_1g1b586dda86565617e7e0883b956c7052)
     ///
     /// # Safety
-    /// - Any mapped buffers onto this object must already be freed.
-    /// - The external memory must only be destroyed once.
+    /// 1. Any mapped buffers onto this object must already be freed.
+    /// 2. The external memory must only be destroyed once.
     pub unsafe fn destroy_external_memory(
         external_memory: sys::CUexternalMemory,
     ) -> Result<(), DriverError> {
@@ -648,6 +652,8 @@ pub mod external_memory {
     }
 
     /// Maps a buffer onto an imported memory object.
+    ///
+    /// The buffer must be freed using [`memory_free`].
     ///
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXTRES__INTEROP.html#group__CUDA__EXTRES__INTEROP_1gb9fec33920400c70961b4e33d838da91)
     ///

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -653,7 +653,7 @@ pub mod external_memory {
 
     /// Maps a buffer onto an imported memory object.
     ///
-    /// The buffer must be freed using [`memory_free`].
+    /// The buffer must be freed using [`memory_free`](super::memory_free).
     ///
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXTRES__INTEROP.html#group__CUDA__EXTRES__INTEROP_1gb9fec33920400c70961b4e33d838da91)
     ///

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -315,6 +315,17 @@ pub unsafe fn free_async(dptr: sys::CUdeviceptr, stream: sys::CUstream) -> Resul
     sys::cuMemFreeAsync(dptr, stream).result()
 }
 
+/// Frees device memory.
+///
+/// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g89b3f154e17cc89b6eea277dbdf5c93a)
+///
+/// # Safety
+/// 1. Memory must only be freed once.
+/// 2. All async accesses to this pointer must have been completed.
+pub unsafe fn memory_free(device_ptr: sys::CUdeviceptr) -> Result<(), DriverError> {
+    sys::cuMemFree_v2(device_ptr).result()
+}
+
 /// Sets device memory with stream ordered semantics.
 ///
 /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1gaef08a7ccd61112f94e82f2b30d43627)
@@ -660,16 +671,5 @@ pub mod external_memory {
         )
         .result()?;
         Ok(device_ptr.assume_init())
-    }
-
-    /// Frees device memory.
-    ///
-    /// see [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g89b3f154e17cc89b6eea277dbdf5c93a)
-    ///
-    /// # Safety
-    /// - Memory must only be freed once.
-    /// - All async accesses to this pointer must have been completed.
-    pub unsafe fn memory_free(device_ptr: sys::CUdeviceptr) -> Result<(), DriverError> {
-        sys::cuMemFree_v2(device_ptr).result()
     }
 }

--- a/src/driver/safe/external_memory.rs
+++ b/src/driver/safe/external_memory.rs
@@ -107,7 +107,7 @@ pub struct MappedBuffer<'a> {
 
 impl Drop for MappedBuffer<'_> {
     fn drop(&mut self) {
-        unsafe { result::external_memory::memory_free(self.device_ptr) }.unwrap()
+        unsafe { result::memory_free(self.device_ptr) }.unwrap()
     }
 }
 

--- a/src/driver/safe/external_memory.rs
+++ b/src/driver/safe/external_memory.rs
@@ -1,0 +1,98 @@
+use core::marker::PhantomData;
+use std::fs::File;
+use std::ops::Range;
+use std::sync::Arc;
+
+use super::{CudaDevice, DevicePtr, DeviceSlice};
+use crate::driver::{result, sys, DriverError};
+
+impl CudaDevice {
+    #[cfg(any(unix, windows))]
+    pub unsafe fn import_external_memory(
+        self: &Arc<Self>,
+        file: File,
+        size: u64,
+    ) -> Result<ExternalMemory, DriverError> {
+        #[cfg(unix)]
+        let external_memory = unsafe {
+            use std::os::fd::AsRawFd;
+            result::external_memory::import_external_memory_opaque_fd(file.as_raw_fd(), size)
+        }?;
+        #[cfg(windows)]
+        let external_memory = unsafe {
+            use std::os::windows::io::AsRawHandle;
+            result::external_memory::import_external_memory_opaque_win32(file.as_raw_handle(), size)
+        }?;
+        Ok(ExternalMemory {
+            external_memory,
+            size,
+            _device: self.clone(),
+            _file: file,
+        })
+    }
+}
+
+pub struct ExternalMemory {
+    external_memory: sys::CUexternalMemory,
+    size: u64,
+    _device: Arc<CudaDevice>,
+    _file: std::fs::File,
+}
+
+impl Drop for ExternalMemory {
+    fn drop(&mut self) {
+        unsafe { result::external_memory::destroy_external_memory(self.external_memory) }.unwrap();
+        // From CUDA docs, when successfully importing UNIX file descriptor:
+        // Ownership of the file descriptor is transferred to the CUDA driver when the handle is imported successfully.
+        // Performing any operations on the file descriptor after it is imported results in undefined behavior.
+        #[cfg(unix)]
+        core::mem::forget(self._file);
+    }
+}
+
+impl ExternalMemory {
+    pub fn map_all(&self) -> Result<MappedBuffer<'_>, DriverError> {
+        self.map_range(0..self.size as usize)
+    }
+
+    pub fn map_range(&self, range: Range<usize>) -> Result<MappedBuffer<'_>, DriverError> {
+        assert!(range.start as u64 <= self.size);
+        assert!(range.end as u64 <= self.size);
+        let device_ptr = unsafe {
+            result::external_memory::get_mapped_buffer(
+                self.external_memory,
+                range.start as u64,
+                range.len() as u64,
+            )
+        }?;
+        Ok(MappedBuffer {
+            device_ptr,
+            len: range.len(),
+            _marker: PhantomData,
+        })
+    }
+}
+
+pub struct MappedBuffer<'a> {
+    device_ptr: sys::CUdeviceptr,
+    len: usize,
+    _marker: PhantomData<&'a ExternalMemory>,
+}
+
+impl Drop for MappedBuffer<'_> {
+    fn drop(&mut self) {
+        unsafe { result::external_memory::memory_free(self.device_ptr) }.unwrap()
+    }
+}
+
+impl DeviceSlice<u8> for MappedBuffer<'_> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl DevicePtr<u8> for MappedBuffer<'_> {
+    fn device_ptr(&self) -> &sys::CUdeviceptr {
+        &self.device_ptr
+    }
+}

--- a/src/driver/safe/external_memory.rs
+++ b/src/driver/safe/external_memory.rs
@@ -36,6 +36,11 @@ impl CudaDevice {
     }
 }
 
+/// An abstraction for imported external memory.
+///
+/// This struct can be created via [`CudaDevice::import_external_memory`].
+/// The imported external memory will be destroyed when this struct is dropped.
+#[derive(Debug)]
 pub struct ExternalMemory {
     external_memory: sys::CUexternalMemory,
     size: u64,
@@ -89,6 +94,11 @@ impl ExternalMemory {
     }
 }
 
+/// An abstraction for a mapped buffer for some external memory.
+///
+/// This struct can be created via [`ExternalMemory::map_range`] or [`ExternalMemory::map_all`].
+/// The underlying mapped buffer will be freed when this struct is dropped.
+#[derive(Debug)]
 pub struct MappedBuffer<'a> {
     device_ptr: sys::CUdeviceptr,
     len: usize,

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod alloc;
 pub(crate) mod core;
 pub(crate) mod device_ptr;
+pub(crate) mod external_memory;
 pub(crate) mod launch;
 pub(crate) mod profile;
 pub(crate) mod ptx;
@@ -11,6 +12,7 @@ pub(crate) mod threading;
 pub use self::alloc::{DeviceRepr, ValidAsZeroBits};
 pub use self::core::{CudaDevice, CudaFunction, CudaSlice, CudaStream, CudaView, CudaViewMut};
 pub use self::device_ptr::{DevicePtr, DevicePtrMut, DeviceSlice};
+pub use self::external_memory::{ExternalMemory, MappedBuffer};
 pub use self::launch::{LaunchAsync, LaunchConfig};
 pub use self::profile::{profiler_start, profiler_stop};
 


### PR DESCRIPTION
- Add unsafe functions to `crate::driver::result` in a new `external_memory` module which wrap raw bindings for interacting with external memory.
- Add safe(?) wrapper in the form of two new types `ExternalMemory` and `MappedBuffer` which abstract away interactions with external memory and to manage cleanup on drop.

I did not add any tests because I don't yet know how to get a valid file descriptor using only CUDA. At least I confirmed that this interface works with a file descriptor exported from Vulkan (via `vulkano` crate). The code exists in my repo https://github.com/ViliamVadocz/nvidia-video-codec-sdk on the `cudarc-external-memory` branch (very experimental and unorganized).