### PR TITLE
Making the tests pass on single GPU platforms.

### DIFF
--- a/src/driver/safe/alloc.rs
+++ b/src/driver/safe/alloc.rs
@@ -557,6 +557,9 @@ mod tests {
     /// See https://github.com/coreylowman/cudarc/issues/160
     #[test]
     fn test_slice_is_freed_with_correct_context() {
+        if CudaDevice::count().unwrap() < 2 {
+            return;
+        }
         let dev0 = CudaDevice::new(0).unwrap();
         let slice = dev0.htod_copy(vec![1.0; 10]).unwrap();
         let dev1 = CudaDevice::new(1).unwrap();
@@ -568,6 +571,9 @@ mod tests {
     /// See https://github.com/coreylowman/cudarc/issues/161
     #[test]
     fn test_copy_uses_correct_context() {
+        if CudaDevice::count().unwrap() < 2 {
+            return;
+        }
         let dev0 = CudaDevice::new(0).unwrap();
         let _dev1 = CudaDevice::new(1).unwrap();
         let slice = dev0.htod_copy(vec![1.0; 10]).unwrap();


### PR DESCRIPTION
- These tests fail on single GPU machine (which I guess is most devs setups).
- This adds a simple device count check before running the test.


Alternatives:

- Use a feature flag (seems overengineered).
- Add `#[ignore]` (but then we're discarding those tests basically).
- Use and environment variable.

I feel like the proposed approach is simple enough we actually get the testing run on valid platforms.
If there's a need for much more multi GPU tests, then maybe the solution should evolve.