### PR TITLE
Added result and safe functionality to support the cuFuncSetAttribute function.

### DIFF
--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -139,6 +139,28 @@ pub mod device {
     }
 }
 
+pub mod function {
+    use super::sys::{self, CUfunction_attribute_enum};
+
+    /// Sets the specific attribute of a cuda function.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EXECUTION.html#group__CUDART__EXECUTION_1g317e77d2657abf915fd9ed03e75f3eb0)
+    ///
+    /// # Safety
+    /// Function must exist.
+    pub unsafe fn set_function_attribute(
+        f: sys::CUfunction,
+        attribute: CUfunction_attribute_enum,
+        value: i32,
+    ) -> Result<(), super::DriverError> {
+        unsafe {
+            sys::cuFuncSetAttribute(f, attribute, value).result()?;
+        }
+
+        Ok(())
+    }
+}
+
 pub mod occupancy {
 
     use core::{

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -1,4 +1,7 @@
-use crate::driver::{result, sys};
+use crate::driver::{
+    result,
+    sys::{self, CUfunction_attribute_enum},
+};
 
 use super::{alloc::DeviceRepr, device_ptr::DeviceSlice};
 
@@ -386,6 +389,19 @@ impl CudaFunction {
         };
 
         Ok(cluster_size as u32)
+    }
+
+    /// Set the value of a specific attribute of this [CudaFunction].
+    pub fn set_attribute(
+        &self,
+        attribute: CUfunction_attribute_enum,
+        value: i32,
+    ) -> Result<(), result::DriverError> {
+        unsafe {
+            result::function::set_function_attribute(self.cu_function, attribute, value)?;
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I have been using this alteration in my own code base to opt in to shared dynamic memory greater than 48kb. It hasn't had any issues for me thus far. [Cuda Docs](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EXECUTION.html#group__CUDART__EXECUTION_1g317e77d2657abf915fd9ed03e75f3eb0)