### PR TITLE
Fixed Test Example 07

### DIFF
--- a/examples/07-build-workflow/Cargo.toml
+++ b/examples/07-build-workflow/Cargo.toml
@@ -11,4 +11,4 @@ cc = "1.0.82"
 regex = "1.9.3"
 
 [dependencies]
-cudarc = { version = "0.9.14", path = "../.." }
+cudarc = { path = "../.." }

--- a/examples/07-build-workflow/src/main.rs
+++ b/examples/07-build-workflow/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), DriverError> {
 
     let my_structs = gpu.sync_reclaim(gpu_my_structs)?;
 
-    assert!(my_structs.iter().all(|i| i.data == [1.0; 4]));
+    assert!(my_structs.iter().all(|i| i.data == [2.0; 4]));
 
     Ok(())
 }


### PR DESCRIPTION
Test Example 07 was failing due to version mismatch of cudarc, so i made it dynamic  and the assert was failing because we were incrementing the values by 1 therefore the final values should be checked if its equal to 2 rather than 1