### PR TITLE
Rework cuda versioning features - Users must always specify a version feature instead of having default behavior.

### DIFF
--- a/.github/workflows/cargo-check.yaml
+++ b/.github/workflows/cargo-check.yaml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features --features cuda_12020,std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl
+          args: -F cuda-12020
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features --features cuda_12020,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl
+          args: --no-default-features --features cuda-12020,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl

--- a/.github/workflows/cargo-clippy.yaml
+++ b/.github/workflows/cargo-clippy.yaml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-default-features --features cuda_12020,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl -- -D warnings
+          args: --no-default-features --features cuda-12020,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ keywords = [
 features = ["ci-check", "f16", "cudnn"]
 
 [features]
-default = ["std", "cuda_auto_version", "cublas", "cublaslt", "cudnn", "curand", "driver", "nccl", "nvrtc"]
+default = ["std", "cublas", "cublaslt", "cudnn", "curand", "driver", "nccl", "nvrtc"]
 
-cuda_auto_version = []
-cuda_11070 = []
-cuda_11080 = []
-cuda_12000 = []
-cuda_12010 = []
-cuda_12020 = []
-cuda_12030 = []
+cuda-version-from-build-system = []
+cuda-11070 = []
+cuda-11080 = []
+cuda-12000 = []
+cuda-12010 = []
+cuda-12020 = []
+cuda-12030 = []
 
 dynamic-linking = []
 

--- a/build.rs
+++ b/build.rs
@@ -6,15 +6,26 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CUDA_PATH");
     println!("cargo:rerun-if-env-changed=CUDA_TOOLKIT_ROOT_DIR");
 
-    #[cfg(feature = "cuda_auto_version")]
-    cuda_auto_version();
+    #[cfg(not(any(
+        feature = "cuda-version-from-build-system",
+        feature = "cuda-12030",
+        feature = "cuda-12020",
+        feature = "cuda-12010",
+        feature = "cuda-12000",
+        feature = "cuda-11080",
+        feature = "cuda-11070",
+    )))]
+    compile_error!("Must specify one of the following features: [cuda-version-from-build-system, cuda-12030, cuda-12020, cuda-12010, cuda-12000, cuda-11080, cuda-11070]");
+
+    #[cfg(feature = "cuda-version-from-build-system")]
+    cuda_version_from_build_system();
 
     #[cfg(feature = "dynamic-linking")]
     dynamic_linking();
 }
 
 #[allow(unused)]
-fn cuda_auto_version() {
+fn cuda_version_from_build_system() {
     let toolkit_root = root_candidates()
             .find(|path| path.join("include").join("cuda.h").is_file())
             .unwrap_or_else(|| {
@@ -32,12 +43,12 @@ fn cuda_auto_version() {
     let key = "CUDA_VERSION ";
     let start = key.len() + contents.find(key).unwrap();
     match contents[start..].lines().next().unwrap() {
-        "12030" => println!("cargo:rustc-cfg=feature=\"cuda_12030\""),
-        "12020" => println!("cargo:rustc-cfg=feature=\"cuda_12020\""),
-        "12010" => println!("cargo:rustc-cfg=feature=\"cuda_12010\""),
-        "12000" => println!("cargo:rustc-cfg=feature=\"cuda_12000\""),
-        "11080" => println!("cargo:rustc-cfg=feature=\"cuda_11080\""),
-        "11070" => println!("cargo:rustc-cfg=feature=\"cuda_11070\""),
+        "12030" => println!("cargo:rustc-cfg=feature=\"cuda-12030\""),
+        "12020" => println!("cargo:rustc-cfg=feature=\"cuda-12020\""),
+        "12010" => println!("cargo:rustc-cfg=feature=\"cuda-12010\""),
+        "12000" => println!("cargo:rustc-cfg=feature=\"cuda-12000\""),
+        "11080" => println!("cargo:rustc-cfg=feature=\"cuda-11080\""),
+        "11070" => println!("cargo:rustc-cfg=feature=\"cuda-11070\""),
         v => panic!("Unsupported cuda toolkit version: `{v}`. Please raise a github issue."),
     }
 }

--- a/src/cublas/sys/mod.rs
+++ b/src/cublas/sys/mod.rs
@@ -1,31 +1,31 @@
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 mod sys_11070;
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 pub use sys_11070::*;
 
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 mod sys_11080;
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 pub use sys_11080::*;
 
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 mod sys_12000;
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 pub use sys_12000::*;
 
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 mod sys_12010;
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 pub use sys_12010::*;
 
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 mod sys_12020;
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 pub use sys_12020::*;
 
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 mod sys_12030;
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 pub use sys_12030::*;
 
 pub unsafe fn lib() -> &'static Lib {

--- a/src/cublaslt/sys/mod.rs
+++ b/src/cublaslt/sys/mod.rs
@@ -1,31 +1,31 @@
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 mod sys_11070;
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 pub use sys_11070::*;
 
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 mod sys_11080;
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 pub use sys_11080::*;
 
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 mod sys_12000;
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 pub use sys_12000::*;
 
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 mod sys_12010;
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 pub use sys_12010::*;
 
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 mod sys_12020;
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 pub use sys_12020::*;
 
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 mod sys_12030;
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 pub use sys_12030::*;
 
 pub unsafe fn lib() -> &'static Lib {

--- a/src/cudnn/result.rs
+++ b/src/cudnn/result.rs
@@ -46,7 +46,7 @@ pub fn get_cudart_version() -> usize {
 
 /// Runs all *VersionCheck functions.
 pub fn version_check() -> Result<(), CudnnError> {
-    #[cfg(not(feature = "cuda_12030"))]
+    #[cfg(not(feature = "cuda-12030"))]
     unsafe {
         lib().cudnnAdvInferVersionCheck().result()?;
         lib().cudnnAdvTrainVersionCheck().result()?;
@@ -55,7 +55,7 @@ pub fn version_check() -> Result<(), CudnnError> {
         lib().cudnnOpsInferVersionCheck().result()?;
         lib().cudnnOpsTrainVersionCheck().result()?;
     }
-    #[cfg(feature = "cuda_12030")]
+    #[cfg(feature = "cuda-12030")]
     unsafe {
         sys::cudnnAdvVersionCheck().result()?;
         sys::cudnnCnnVersionCheck().result()?;

--- a/src/cudnn/sys/mod.rs
+++ b/src/cudnn/sys/mod.rs
@@ -1,31 +1,31 @@
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 mod sys_11070;
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 pub use sys_11070::*;
 
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 mod sys_11080;
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 pub use sys_11080::*;
 
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 mod sys_12000;
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 pub use sys_12000::*;
 
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 mod sys_12010;
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 pub use sys_12010::*;
 
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 mod sys_12020;
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 pub use sys_12020::*;
 
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 mod sys_12030;
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 pub use sys_12030::*;
 
 pub unsafe fn lib() -> &'static Lib {

--- a/src/curand/sys/mod.rs
+++ b/src/curand/sys/mod.rs
@@ -1,31 +1,31 @@
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 mod sys_11070;
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 pub use sys_11070::*;
 
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 mod sys_11080;
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 pub use sys_11080::*;
 
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 mod sys_12000;
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 pub use sys_12000::*;
 
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 mod sys_12010;
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 pub use sys_12010::*;
 
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 mod sys_12020;
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 pub use sys_12020::*;
 
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 mod sys_12030;
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 pub use sys_12030::*;
 
 pub unsafe fn lib() -> &'static Lib {

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -311,7 +311,7 @@ impl CudaFunction {
         Ok(num_blocks as u32)
     }
 
-    #[cfg(not(feature = "cuda_11070"))]
+    #[cfg(not(feature = "cuda-11070"))]
     pub fn occupancy_max_active_clusters(
         &self,
         config: crate::driver::LaunchConfig,
@@ -369,7 +369,7 @@ impl CudaFunction {
         Ok((min_grid_size as u32, block_size as u32))
     }
 
-    #[cfg(not(feature = "cuda_11070"))]
+    #[cfg(not(feature = "cuda-11070"))]
     pub fn occupancy_max_potential_cluster_size(
         &self,
         config: crate::driver::LaunchConfig,

--- a/src/driver/sys/mod.rs
+++ b/src/driver/sys/mod.rs
@@ -1,31 +1,31 @@
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 mod sys_11070;
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 pub use sys_11070::*;
 
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 mod sys_11080;
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 pub use sys_11080::*;
 
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 mod sys_12000;
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 pub use sys_12000::*;
 
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 mod sys_12010;
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 pub use sys_12010::*;
 
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 mod sys_12020;
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 pub use sys_12020::*;
 
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 mod sys_12030;
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 pub use sys_12030::*;
 
 pub unsafe fn lib() -> &'static Lib {

--- a/src/nccl/sys/mod.rs
+++ b/src/nccl/sys/mod.rs
@@ -1,31 +1,31 @@
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 mod sys_11070;
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 pub use sys_11070::*;
 
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 mod sys_11080;
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 pub use sys_11080::*;
 
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 mod sys_12000;
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 pub use sys_12000::*;
 
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 mod sys_12010;
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 pub use sys_12010::*;
 
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 mod sys_12020;
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 pub use sys_12020::*;
 
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 mod sys_12030;
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 pub use sys_12030::*;
 
 pub unsafe fn lib() -> &'static Lib {

--- a/src/nvrtc/sys/mod.rs
+++ b/src/nvrtc/sys/mod.rs
@@ -1,31 +1,31 @@
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 mod sys_11070;
-#[cfg(feature = "cuda_11070")]
+#[cfg(feature = "cuda-11070")]
 pub use sys_11070::*;
 
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 mod sys_11080;
-#[cfg(feature = "cuda_11080")]
+#[cfg(feature = "cuda-11080")]
 pub use sys_11080::*;
 
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 mod sys_12000;
-#[cfg(feature = "cuda_12000")]
+#[cfg(feature = "cuda-12000")]
 pub use sys_12000::*;
 
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 mod sys_12010;
-#[cfg(feature = "cuda_12010")]
+#[cfg(feature = "cuda-12010")]
 pub use sys_12010::*;
 
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 mod sys_12020;
-#[cfg(feature = "cuda_12020")]
+#[cfg(feature = "cuda-12020")]
 pub use sys_12020::*;
 
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 mod sys_12030;
-#[cfg(feature = "cuda_12030")]
+#[cfg(feature = "cuda-12030")]
 pub use sys_12030::*;
 
 pub unsafe fn lib() -> &'static Lib {


### PR DESCRIPTION
Changes:
1. Rename `cuda_auto_version` -> `cuda-version-from-build-system`
2. Change underscores to hyphens for all cuda versions (e.g. `cuda_12030` -> `cuda-12030`)
3. Remove `cuda-version-from-build-system` as a default feature
4. Compiler error in build script if no version feature is specified.

This means users will get a compile error until they either enable feature `cuda-version-from-build-system` or one of the other version features.

Reasoning: Making users specify explicitly what version they expect to compile for should cut down on errors related to that. 