### PR TITLE
Add `CudaSlice::split_at_mut` and `CudaViewMut::split_at_mut`

### DIFF
--- a/.github/workflows/cargo-check.yaml
+++ b/.github/workflows/cargo-check.yaml
@@ -20,4 +20,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features --features cuda-12020,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl
+          args: --no-default-features --features cuda-12020,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl --all-targets

--- a/.github/workflows/cargo-check.yaml
+++ b/.github/workflows/cargo-check.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: -F cuda-12020
+          args: -F cuda-12020 --all-targets
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/cargo-clippy.yaml
+++ b/.github/workflows/cargo-clippy.yaml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-default-features --features cuda-12020,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl -- -D warnings
+          args: --no-default-features --features cuda-12020,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl --all-targets -- -D warnings

--- a/src/cudnn/safe/mod.rs
+++ b/src/cudnn/safe/mod.rs
@@ -42,6 +42,8 @@ pub use super::result::CudnnError;
 mod tests {
     use super::*;
     use crate::{cudnn, driver::CudaDevice};
+    #[cfg(feature = "no-std")]
+    use no_std_compat::vec;
 
     #[test]
     fn test_create_descriptors() -> Result<(), CudnnError> {

--- a/src/cudnn/safe/mod.rs
+++ b/src/cudnn/safe/mod.rs
@@ -178,7 +178,7 @@ mod tests {
             let algo = op.pick_algorithm()?;
 
             // Get workspace size
-            let workspace_size = op.get_workspace_size(algo.clone())?;
+            let workspace_size = op.get_workspace_size(algo)?;
             let mut workspace = dev.alloc_zeros::<u8>(workspace_size).unwrap();
 
             // Launch conv operation
@@ -235,7 +235,7 @@ mod tests {
             let algo = op.pick_algorithm()?;
 
             // Get workspace size
-            let workspace_size = op.get_workspace_size(algo.clone())?;
+            let workspace_size = op.get_workspace_size(algo)?;
             let mut workspace = dev.alloc_zeros::<u8>(workspace_size).unwrap();
 
             // Launch conv operation

--- a/src/driver/safe/alloc.rs
+++ b/src/driver/safe/alloc.rs
@@ -426,6 +426,8 @@ impl_tuples!(A, B, C, D, E, F, G, H, I, J, K, L);
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "no-std")]
+    use no_std_compat::vec;
 
     #[test]
     fn test_post_build_arc_count() {

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -549,12 +549,12 @@ pub struct CudaView<'a, T> {
 impl<T> CudaSlice<T> {
     /// Creates a [CudaView] at the specified offset from the start of `self`.
     ///
-    /// Returns `None` if `range.start >= self.len`
+    /// Panics if `range.start >= self.len`.
     pub fn slice(&self, range: impl RangeBounds<usize>) -> CudaView<'_, T> {
         self.try_slice(range).unwrap()
     }
 
-    /// Fallible version of [CudaSlice::slice]
+    /// Fallible version of [CudaSlice::slice()].
     pub fn try_slice(&self, range: impl RangeBounds<usize>) -> Option<CudaView<'_, T>> {
         range.bounds(..self.len()).map(|(start, end)| CudaView {
             ptr: self.cu_device_ptr + (start * std::mem::size_of::<T>()) as u64,
@@ -582,7 +582,7 @@ impl<T> CudaSlice<T> {
 impl<'a, T> CudaView<'a, T> {
     /// Creates a [CudaView] at the specified offset from the start of `self`.
     ///
-    /// Returns `None` if `range.start >= self.len`
+    /// Panics if `range.start >= self.len`.
     pub fn slice(&self, range: impl RangeBounds<usize>) -> CudaView<'a, T> {
         self.try_slice(range).unwrap()
     }
@@ -608,7 +608,7 @@ pub struct CudaViewMut<'a, T> {
 impl<T> CudaSlice<T> {
     /// Creates a [CudaViewMut] at the specified offset from the start of `self`.
     ///
-    /// Returns `None` if `offset >= self.len`
+    /// Panics if `range` and `0...self.len()` are not overlapping.
     pub fn slice_mut(&mut self, range: impl RangeBounds<usize>) -> CudaViewMut<'_, T> {
         self.try_slice_mut(range).unwrap()
     }
@@ -639,14 +639,14 @@ impl<T> CudaSlice<T> {
 
     /// Splits the [CudaSlice] into two at the given index, returning two [CudaViewMut] for the two halves.
     ///
-    /// Panics if `mid > self.len`
+    /// Panics if `mid > self.len`.
     pub fn split_at_mut<'a>(&'a mut self, mid: usize) -> (CudaViewMut<'a, T>, CudaViewMut<'a, T>) {
         self.try_split_at_mut(mid).unwrap()
     }
 
     /// Fallible version of [CudaSlice::split_at_mut].
     ///
-    /// Returns `None` if `mid > self.len`
+    /// Returns `None` if `mid > self.len`.
     pub fn try_split_at_mut<'a>(
         &'a mut self,
         mid: usize,
@@ -672,7 +672,7 @@ impl<T> CudaSlice<T> {
 impl<'a, T> CudaViewMut<'a, T> {
     /// Creates a [CudaView] at the specified offset from the start of `self`.
     ///
-    /// Returns `None` if `range.start >= self.len`
+    /// Panics if `range` and `0...self.len()` are not overlapping.
     pub fn slice<'b: 'a>(&'b self, range: impl RangeBounds<usize>) -> CudaView<'a, T> {
         self.try_slice(range).unwrap()
     }
@@ -688,7 +688,7 @@ impl<'a, T> CudaViewMut<'a, T> {
 
     /// Creates a [CudaViewMut] at the specified offset from the start of `self`.
     ///
-    /// Returns `None` if `offset >= self.len`
+    /// Panics if `range` and `0...self.len()` are not overlapping.
     pub fn slice_mut<'b: 'a>(&'b mut self, range: impl RangeBounds<usize>) -> CudaViewMut<'a, T> {
         self.try_slice_mut(range).unwrap()
     }

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -730,17 +730,17 @@ impl<T> CudaSlice<T> {
     /// let (mut view1, mut view2) = slice.split_at_mut(50);
     /// do_something(view1, view2);
     /// ```
-    pub fn split_at_mut<'a>(&'a mut self, mid: usize) -> (CudaViewMut<'a, T>, CudaViewMut<'a, T>) {
+    pub fn split_at_mut(&mut self, mid: usize) -> (CudaViewMut<'_, T>, CudaViewMut<'_, T>) {
         self.try_split_at_mut(mid).unwrap()
     }
 
     /// Fallible version of [CudaSlice::split_at_mut].
     ///
     /// Returns `None` if `mid > self.len`.
-    pub fn try_split_at_mut<'a>(
-        &'a mut self,
+    pub fn try_split_at_mut(
+        &mut self,
         mid: usize,
-    ) -> Option<(CudaViewMut<'a, T>, CudaViewMut<'a, T>)> {
+    ) -> Option<(CudaViewMut<'_, T>, CudaViewMut<'_, T>)> {
         if mid > self.len() {
             return None;
         }

--- a/src/nccl/result.rs
+++ b/src/nccl/result.rs
@@ -311,6 +311,8 @@ pub fn group_start() -> Result<NcclStatus, NcclError> {
 mod tests {
     use super::*;
     use crate::driver::CudaDevice;
+    #[cfg(feature = "no-std")]
+    use no_std_compat::{vec, vec::Vec};
     use std::ffi::c_void;
 
     #[test]

--- a/src/nccl/result.rs
+++ b/src/nccl/result.rs
@@ -367,7 +367,6 @@ mod tests {
         let comm_id = get_uniqueid().unwrap();
         let threads: Vec<_> = (0..n_devices)
             .map(|i| {
-                let n_devices = n_devices.clone();
                 std::thread::spawn(move || {
                     let dev = CudaDevice::new(i).unwrap();
                     let sendslice = dev.htod_copy(vec![(i + 1) as f32 * 1.0; n]).unwrap();

--- a/src/nccl/safe.rs
+++ b/src/nccl/safe.rs
@@ -355,6 +355,8 @@ macro_rules! group {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "no-std")]
+    use no_std_compat::println;
 
     #[test]
     fn test_all_reduce() {


### PR DESCRIPTION
This is an attempt to address #233.

Since this is code that touches some aspects of the lifetimes of `CudaView` and `CudaViewMut`, this could use some extra scrutiny to check if the safety invariants of the involved types are still ok. 

I removed the `root` field of both `CudaView` and `CudaViewMut`, since it's only purpose was AFAIK, to keep track of the lifetimes of the respective structs. I have moved this into a `PhantomData` which should serve the same purpose.

Furthermore, I have now added the `split_at_mut` methods to `CudaSlice` and `CudaViewMut`, which mimic the behavior of `split_at_mut` of the standard library.

The old method of storing a `&mut` to the cuda device pointer does not work for splitting, since it would mean that there exist two mutable references to the same value (the u64 device ptr value) at the same time, which AFAIK is always unsound. Therefore the removal and moving the lifetimes into PhantomData as discussed above.