### PR TITLE
Add `CudaDevice::name()` and `result::device::get_name()`

### DIFF
--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -95,8 +95,10 @@ pub mod device {
         sys::{self, lib},
         DriverError,
     };
-    use core::ffi::{c_int, CStr};
-    use std::{ffi::CString, mem::MaybeUninit};
+    use std::{
+        ffi::{c_int, CStr},
+        mem::MaybeUninit,
+    };
 
     /// Get a device for a specific ordinal.
     /// See [cuDeviceGet() docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__DEVICE.html#group__CUDA__DEVICE_1g8bdd1cc7201304b01357b8034f6587cb).

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -98,6 +98,7 @@ pub mod device {
     use std::{
         ffi::{c_int, CStr},
         mem::MaybeUninit,
+        string::String,
     };
 
     /// Get a device for a specific ordinal.
@@ -163,7 +164,7 @@ pub mod device {
                 .result()?;
         }
         let name = CStr::from_bytes_until_nul(&buf).expect("No null byte was present");
-        Ok(String::from_utf8_lossy(name.to_bytes()).to_string())
+        Ok(String::from_utf8_lossy(name.to_bytes()).into())
     }
 }
 

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -129,6 +129,11 @@ impl CudaDevice {
         self.ordinal
     }
 
+    /// Get the name of this device.
+    pub fn name(&self) -> Result<String, result::DriverError> {
+        result::device::get_name(self.cu_device)
+    }
+
     /// Get the underlying [sys::CUdevice] of this [CudaDevice].
     ///
     /// # Safety


### PR DESCRIPTION
Resolves #248 