### PR TITLE
Handling self.error_string() failing in Debug for DriverError

### DIFF
--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -64,7 +64,7 @@ impl std::fmt::Debug for DriverError {
             Ok(err_str) => f
                 .debug_tuple("DriverError")
                 .field(&self.0)
-                .field(err_str)
+                .field(&err_str)
                 .finish(),
             Err(_) => f
                 .debug_tuple("DriverError")

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -60,11 +60,18 @@ impl DriverError {
 
 impl std::fmt::Debug for DriverError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let err_str = self.error_string().unwrap();
-        f.debug_tuple("DriverError")
-            .field(&self.0)
-            .field(&err_str)
-            .finish()
+        match self.error_string() {
+            Ok(err_str) => f
+                .debug_tuple("DriverError")
+                .field(&self.0)
+                .field(err_str)
+                .finish(),
+            Err(_) => f
+                .debug_tuple("DriverError")
+                .field(&self.0)
+                .field(&"<Failure when calling cuGetErrorString()>")
+                .finish(),
+        }
     }
 }
 


### PR DESCRIPTION
Mentioned in #265 

Also linking to https://github.com/EricLBuehler/mistral.rs/issues/395#issuecomment-2189994656