### PR TITLE
[Breaking][Waiting to Merge] Making `cudnn` and `nccl` non-default features in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ keywords = [
 features = ["cuda-12050", "f16", "cudnn"]
 
 [features]
-default = ["std", "cublas", "cublaslt", "cudnn", "curand", "driver", "nccl", "nvrtc"]
+default = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc"]
 
 cuda-version-from-build-system = []
 cuda-11040 = []


### PR DESCRIPTION
Since they generally require a separate install on GPU machines.