### PR TITLE
Adding options for dynamic loading that include versions after .so

### DIFF
--- a/src/cublas/sys/mod.rs
+++ b/src/cublas/sys/mod.rs
@@ -59,7 +59,7 @@ pub unsafe fn lib() -> &'static Lib {
         let lib_name = "cublas";
         let choices = crate::get_lib_name_candidates(lib_name);
         for choice in choices.iter() {
-            if let Ok(lib) = Lib::new(libloading::library_filename(choice)) {
+            if let Ok(lib) = Lib::new(choice) {
                 return lib;
             }
         }

--- a/src/cublaslt/sys/mod.rs
+++ b/src/cublaslt/sys/mod.rs
@@ -59,7 +59,7 @@ pub unsafe fn lib() -> &'static Lib {
         let lib_name = "cublasLt";
         let choices = crate::get_lib_name_candidates(lib_name);
         for choice in choices.iter() {
-            if let Ok(lib) = Lib::new(libloading::library_filename(choice)) {
+            if let Ok(lib) = Lib::new(choice) {
                 return lib;
             }
         }

--- a/src/cudnn/sys/mod.rs
+++ b/src/cudnn/sys/mod.rs
@@ -59,7 +59,7 @@ pub unsafe fn lib() -> &'static Lib {
         let lib_name = "cudnn";
         let choices = crate::get_lib_name_candidates(lib_name);
         for choice in choices.iter() {
-            if let Ok(lib) = Lib::new(libloading::library_filename(choice)) {
+            if let Ok(lib) = Lib::new(choice) {
                 return lib;
             }
         }

--- a/src/curand/sys/mod.rs
+++ b/src/curand/sys/mod.rs
@@ -59,7 +59,7 @@ pub unsafe fn lib() -> &'static Lib {
         let lib_name = "curand";
         let choices = crate::get_lib_name_candidates(lib_name);
         for choice in choices.iter() {
-            if let Ok(lib) = Lib::new(libloading::library_filename(choice)) {
+            if let Ok(lib) = Lib::new(choice) {
                 return lib;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@ pub(crate) fn panic_no_lib_found<S: std::fmt::Debug>(lib_name: &str, choices: &[
 }
 
 pub(crate) fn get_lib_name_candidates(lib_name: &str) -> std::vec::Vec<std::string::String> {
+    use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
+
     let pointer_width = if cfg!(target_pointer_width = "32") {
         "32"
     } else if cfg!(target_pointer_width = "64") {
@@ -111,18 +113,22 @@ pub(crate) fn get_lib_name_candidates(lib_name: &str) -> std::vec::Vec<std::stri
     let minor = env!("CUDA_MINOR_VERSION");
 
     [
-        lib_name.into(),
-        std::format!("{lib_name}{pointer_width}"),
-        std::format!("{lib_name}{pointer_width}_{major}"),
-        std::format!("{lib_name}{pointer_width}_{major}{minor}"),
-        std::format!("{lib_name}{pointer_width}_{major}{minor}_0"),
-        std::format!("{lib_name}{pointer_width}_{major}0_{minor}"),
+        std::format!("{DLL_PREFIX}{lib_name}{DLL_SUFFIX}"),
+        std::format!("{DLL_PREFIX}{lib_name}{pointer_width}{DLL_SUFFIX}"),
+        std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_{major}{DLL_SUFFIX}"),
+        std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_{major}{minor}{DLL_SUFFIX}"),
+        std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_{major}{minor}_0{DLL_SUFFIX}"),
+        std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_{major}0_{minor}{DLL_SUFFIX}"),
         // See issue #242
-        std::format!("{lib_name}{pointer_width}_10"),
+        std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_10{DLL_SUFFIX}"),
         // See issue #246
-        std::format!("{lib_name}{pointer_width}_{major}0_0"),
+        std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_{major}0_0{DLL_SUFFIX}"),
         // See issue #260
-        std::format!("{lib_name}{pointer_width}_9"),
+        std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_9{DLL_SUFFIX}"),
+        // See issue #274
+        std::format!("{DLL_PREFIX}{lib_name}{DLL_SUFFIX}.{major}"),
+        std::format!("{DLL_PREFIX}{lib_name}{DLL_SUFFIX}.11"),
+        std::format!("{DLL_PREFIX}{lib_name}{DLL_SUFFIX}.10"),
     ]
     .into()
 }

--- a/src/nccl/sys/mod.rs
+++ b/src/nccl/sys/mod.rs
@@ -59,7 +59,7 @@ pub unsafe fn lib() -> &'static Lib {
         let lib_name = "nccl";
         let choices = crate::get_lib_name_candidates(lib_name);
         for choice in choices.iter() {
-            if let Ok(lib) = Lib::new(libloading::library_filename(choice)) {
+            if let Ok(lib) = Lib::new(choice) {
                 return lib;
             }
         }

--- a/src/nvrtc/sys/mod.rs
+++ b/src/nvrtc/sys/mod.rs
@@ -59,7 +59,7 @@ pub unsafe fn lib() -> &'static Lib {
         let lib_name = "nvrtc";
         let choices = crate::get_lib_name_candidates(lib_name);
         for choice in choices.iter() {
-            if let Ok(lib) = Lib::new(libloading::library_filename(choice)) {
+            if let Ok(lib) = Lib::new(choice) {
                 return lib;
             }
         }


### PR DESCRIPTION
Maybe address #274, though not complete 

libloading::library_filename just adds DLL_PREFIX before and DLL_POSTFIX after, so this PR just inlines those to the generated options already, removes use of libloading::library_filename, and adds a couple new options for names.