### PR TITLE
[Breaking] `&Option<T>` -> `Option<&T>` in nccl broadcast. Add Option argument to nccl reduce.

### DIFF
--- a/src/nccl/safe.rs
+++ b/src/nccl/safe.rs
@@ -1,6 +1,5 @@
 use super::{result, sys};
 use crate::driver::{CudaDevice, DevicePtr, DevicePtrMut};
-use std::io::BufRead;
 use std::mem::MaybeUninit;
 use std::ptr;
 use std::{sync::Arc, vec, vec::Vec};


### PR DESCRIPTION
Resolves #290 