### PR TITLE
[WIP] Refactoring CudaStream & add CudaStream::launch/launch_cooperative

### DIFF
--- a/src/driver/safe/device_ptr.rs
+++ b/src/driver/safe/device_ptr.rs
@@ -1,8 +1,9 @@
 use crate::driver::sys;
 
-use super::core::{CudaSlice, CudaView, CudaViewMut};
+use super::core::{CudaSlice, CudaStream, CudaView, CudaViewMut};
 
 pub trait DeviceSlice<T> {
+    fn stream(&self) -> &CudaStream;
     fn len(&self) -> usize;
     fn num_bytes(&self) -> usize {
         self.len() * std::mem::size_of::<T>()
@@ -13,18 +14,29 @@ pub trait DeviceSlice<T> {
 }
 
 impl<T> DeviceSlice<T> for CudaSlice<T> {
+    fn stream(&self) -> &CudaStream {
+        &self.stream
+    }
     fn len(&self) -> usize {
         self.len
     }
 }
 
 impl<T> DeviceSlice<T> for CudaView<'_, T> {
+    fn stream(&self) -> &CudaStream {
+        self.stream
+    }
+
     fn len(&self) -> usize {
         self.len
     }
 }
 
 impl<T> DeviceSlice<T> for CudaViewMut<'_, T> {
+    fn stream(&self) -> &CudaStream {
+        self.stream
+    }
+
     fn len(&self) -> usize {
         self.len
     }

--- a/src/nccl/result.rs
+++ b/src/nccl/result.rs
@@ -370,7 +370,7 @@ mod tests {
                     sys::ncclDataType_t::ncclFloat32,
                     sys::ncclRedOp_t::ncclSum,
                     comms[i],
-                    dev.stream as sys::cudaStream_t,
+                    std::ptr::null_mut(),
                 )
                 .unwrap();
             }
@@ -410,7 +410,7 @@ mod tests {
                             sys::ncclDataType_t::ncclFloat32,
                             sys::ncclRedOp_t::ncclSum,
                             comm,
-                            dev.stream as sys::cudaStream_t,
+                            std::ptr::null_mut(),
                         )
                         .unwrap();
                     }


### PR DESCRIPTION
# TODOS

- [ ] Decide on what methods are deprecated and what should be removed. Should this PR be breaking?
- [ ] Update documentation
- [ ] Update examples
- [ ] Updating tests
- [ ] How to soundly manage CudaSlices moving between streams
    - Previously since it was not possible to change the stream of a CudaDevice, all CudaSlices created would be on the same stream. Now it is possible to create a CudaSlice on one stream, and then use another stream to read/modify it. This can be very unsound if you don't do stream synchronization between the streams it belongs too.
    - The first iteration of this update changes `CudaSlice` to track its creation stream
    - It is easy to check if the reading/modifying stream is the same stream that the `CudaSlice` was created on.
    - It is NOT clear how to update which stream a `CudaSlice` belongs to
    - It is NOT clear if cudarc should even try to automatically manage this, or just expose things to make it easier to do for the developer.
    - A motivating example would be: allocate a CudaSlice on a stream, Split the CudaSlice into 2 CudaViewMuts, do a memset_zeros on 2 additional streams.
    - Another example is that the `impl Drop for CudaSlice` currently schedules the free_async on the stream that the CudaSlice was created on

# Background

Currently there's no way to have an existing CudaDevice use a separate CudaStream for things like allocation/memcpy/memset operations. There's CudaDevice::new_with_stream, but that won't share any loaded kernels that had been previously loaded.

Additionally, the current LaunchAsync trait is a bit too complicated and only supports a small number of compile time arguments.

# API Changes

## Allocation & copy apis

- Add `CudaDevice::default_stream() -> CudaStream`
- Add `CudaStream::null()`, `CudaStream::alloc()`, `CudaStream::alloc_zeros()`, `CudaStream::memset_zeros()`, `CudaStream::dtod_copy()`, `CudaStream::htod_copy()`, `CudaStream::htod_copy_into()`, `CudaStream::htod_sync_copy()`, `CudaStream::htod_sync_copy_into()`, `CudaStream::dtoh_sync_copy()`, `CudaStream::dtoh_sync_copy_into()`, `CudaStream::sync_reclaim()`, `CudaStream::synchronize()`

The intention after these changes is that the main way you submit jobs to cuda devices is through a `CudaStream` instead of a `CudaDevice`. Since `CudaStream` contains an `Arc<CudaDevice>`, in most cases you can just replace `CudaDevice` with `CudaStream` in downstream library code.

After this PR, **all `CudaDevice` calls just call `self.default_stream().<method>()`**

## Kernel launching API

- Add `CudaStream::launch()` and `CudaStream::launch_cooperative()`.

These methods have a much simpler API for passing kernel params:

```rust
pub unsafe fn launch<const NUM_ARGS: usize>(
    &self,
    func: CudaFunction,
    cfg: LaunchConfig,
    args: [&dyn DeviceRepr; NUM_ARGS],
) -> Result<(), result::DriverError>;
```

Here we've replaced tuples with a compile time sized array with trait objects that implement `DeviceRepr`. This is essentially what LaunchAsync did under the hood, with the following benefits:
1. It supports ANY number of arguments, without complicated trait implementations (we recently bumped the number of tuple args to 32)
2. It becomes much clearer how to launch things on separate streams (just use a separate stream object!)

## Stream creation apis

- `CudaDevice::new_stream()` creates a new stream without any synchronization with the device's current stream.
- `CudaStream::fork()` replaces the existing `CudaDevice::fork_default_stream()` and makes it more generally applicable. When you fork a stream, it will create an event at creation & at drop to synchronize with the stream it was forked from.

## Stream synchronization apis

- `CudaStream::wait_for()` enables synchronization between two streams. Replaces `CudaDevice::wait_for()` and `CudaStream::wait_for_default()`
