### PR TITLE
make build.rs check if we are building for docs.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,6 +53,10 @@ fn main() {
 
 #[allow(unused)]
 fn cuda_version_from_build_system() -> (usize, usize) {
+    if std::env::var("DOCS_RS").is_ok() {
+        return (12, 8);
+    }
+
     let output = std::process::Command::new("nvcc")
         .arg("--version")
         .output()


### PR DESCRIPTION
The [docs.rs/about/builds](https://docs.rs/about/builds) page states that we can check if we are on docs.rs via the following lines:
```rust
if std::env::var("DOCS_RS").is_ok() {
    // ... your code here ...
}
```
This PR implements this and automatically sets the version which is also currently being used as a default cuda version for builds.