### PR TITLE
Export PinnedHostSlice as pub use

### DIFF
--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -10,7 +10,9 @@ pub(crate) mod ptx;
 pub(crate) mod threading;
 
 pub use self::alloc::{DeviceRepr, ValidAsZeroBits};
-pub use self::core::{CudaDevice, CudaFunction, CudaSlice, CudaStream, CudaView, CudaViewMut};
+pub use self::core::{
+    CudaDevice, CudaFunction, CudaSlice, CudaStream, CudaView, CudaViewMut, PinnedHostSlice,
+};
 pub use self::device_ptr::{DevicePtr, DevicePtrMut, DeviceSlice};
 pub use self::external_memory::{ExternalMemory, MappedBuffer};
 pub use self::launch::{LaunchAsync, LaunchConfig};


### PR DESCRIPTION
`PinnedHostSlice` was missing a pub use.