### PR TITLE
[Breaking] Add CudaContext, CudaEvent. Refactor CudaStream & launching

### DIFF
--- a/examples/01-allocate.rs
+++ b/examples/01-allocate.rs
@@ -1,19 +1,18 @@
-use cudarc::driver::{CudaDevice, CudaSlice, DriverError};
+use cudarc::driver::{CudaContext, CudaSlice, DriverError};
 
 fn main() -> Result<(), DriverError> {
-    let dev = CudaDevice::new(0)?;
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.default_stream();
 
     // unsafe initialization of unset memory
-    let _: CudaSlice<f32> = unsafe { dev.alloc::<f32>(10) }?;
+    let _: CudaSlice<f32> = unsafe { stream.alloc::<f32>(10) }?;
 
     // this will have memory initialized as 0
-    let _: CudaSlice<f64> = dev.alloc_zeros::<f64>(10)?;
+    let _: CudaSlice<f64> = stream.alloc_zeros::<f64>(10)?;
 
-    // initialize with a rust vec
-    let _: CudaSlice<usize> = dev.htod_copy(vec![0; 10])?;
-
-    // or finially, initialize with a slice. this is synchronous though.
-    let _: CudaSlice<u32> = dev.htod_sync_copy(&[1, 2, 3])?;
+    // initialize with slices!
+    let _: CudaSlice<usize> = stream.memcpy_stod(&vec![0; 10])?;
+    let _: CudaSlice<u32> = stream.memcpy_stod(&[1, 2, 3])?;
 
     Ok(())
 }

--- a/examples/02-copy.rs
+++ b/examples/02-copy.rs
@@ -1,30 +1,29 @@
-use cudarc::driver::{CudaDevice, CudaSlice, DriverError};
+use cudarc::driver::{CudaContext, CudaSlice, DriverError};
 
 fn main() -> Result<(), DriverError> {
-    let dev = CudaDevice::new(0)?;
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.default_stream();
 
-    let a: CudaSlice<f64> = dev.alloc_zeros::<f64>(10)?;
-    let mut b = dev.alloc_zeros::<f64>(10)?;
+    let a: CudaSlice<f64> = stream.alloc_zeros::<f64>(10)?;
+    let mut b = stream.alloc_zeros::<f64>(10)?;
 
     // you can do device to device copies of course
-    dev.dtod_copy(&a, &mut b)?;
+    stream.memcpy_dtod(&a, &mut b)?;
 
     // but also host to device copys with already allocated buffers
-    dev.htod_copy_into(vec![2.0; 10], &mut b)?;
+    stream.memcpy_htod(&vec![2.0; 10], &mut b)?;
+    // you can use any type of slice
+    stream.memcpy_htod(&[3.0; 10], &mut b)?;
 
-    // if you want to use slices, you can do synchronous copy
-    dev.htod_sync_copy_into(&[3.0; 10], &mut b)?;
-
-    // you can transfer back using reclaim:
-    let mut a_host: Vec<f64> = dev.sync_reclaim(a)?;
+    // you can transfer back using memcpy_dtov
+    let mut a_host: Vec<f64> = stream.memcpy_dtov(&a)?;
     assert_eq!(a_host, [0.0; 10]);
 
-    // or copy back without losing ownership:
-    let b_host = dev.dtoh_sync_copy(&b)?;
+    let b_host = stream.memcpy_dtov(&b)?;
     assert_eq!(b_host, [3.0; 10]);
 
-    // or use a slice
-    dev.dtoh_sync_copy_into(&b, &mut a_host)?;
+    // or transfer into a pre allocated slice
+    stream.memcpy_dtoh(&b, &mut a_host)?;
     assert_eq!(a_host, b_host);
 
     Ok(())

--- a/examples/03-launch-kernel.rs
+++ b/examples/03-launch-kernel.rs
@@ -1,28 +1,34 @@
 use cudarc::{
-    driver::{CudaDevice, DriverError, LaunchAsync, LaunchConfig},
+    driver::{CudaContext, DriverError, LaunchConfig, PushKernelArg},
     nvrtc::Ptx,
 };
 
 fn main() -> Result<(), DriverError> {
-    let dev = CudaDevice::new(0)?;
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.default_stream();
 
     // You can load a function from a pre-compiled PTX like so:
-    dev.load_ptx(Ptx::from_file("./examples/sin.ptx"), "sin", &["sin_kernel"])?;
+    let module = ctx.load_ptx(Ptx::from_file("./examples/sin.ptx"), &["sin_kernel"])?;
 
     // and then retrieve the function with `get_func`
-    let f = dev.get_func("sin", "sin_kernel").unwrap();
+    let f = module.get_func("sin_kernel").unwrap();
 
     let a_host = [1.0, 2.0, 3.0];
 
-    let a_dev = dev.htod_copy(a_host.into())?;
+    let a_dev = stream.memcpy_stod(&a_host)?;
     let mut b_dev = a_dev.clone();
 
+    // we use a buidler pattern to launch kernels.
     let n = 3;
     let cfg = LaunchConfig::for_num_elems(n);
-    unsafe { f.launch(cfg, (&mut b_dev, &a_dev, n as i32)) }?;
+    let mut launch_args = stream.launch_builder(&f);
+    launch_args.arg(&mut b_dev);
+    launch_args.arg(&a_dev);
+    launch_args.arg(n as i32);
+    unsafe { launch_args.launch(cfg) }?;
 
-    let a_host_2 = dev.sync_reclaim(a_dev)?;
-    let b_host = dev.sync_reclaim(b_dev)?;
+    let a_host_2 = stream.memcpy_dtov(&a_dev)?;
+    let b_host = stream.memcpy_dtov(&b_dev)?;
 
     println!("Found {:?}", b_host);
     println!("Expected {:?}", a_host.map(f32::sin));

--- a/examples/06-threading.rs
+++ b/examples/06-threading.rs
@@ -10,55 +10,52 @@ extern \"C\" __global__ void hello_world(int i) {
 ";
 
 fn main() -> Result<(), DriverError> {
-    let cfg = LaunchConfig {
-        grid_dim: (1, 1, 1),
-        block_dim: (1, 1, 1),
-        shared_mem_bytes: 0,
-    };
-
     {
-        // Option 1: use the same device on each thread.
-        // This requires calling the CudaDevice::bind_to_thread() method.
-        // Note that all kernels are submitted to the same stream/context,
-        // so the kernels will still execute in sequentially in the order
-        // they are submitted to the gpu.
-        let dev = CudaDevice::new(0)?;
-        let ptx = compile_ptx(KERNEL_SRC).unwrap();
-        dev.load_ptx(ptx, "kernel", &["hello_world"])?;
-
-        // explicit borrow so we don't have to re-clone the device for each thread
-        let dev = &dev;
-
-        thread::scope(move |s| {
+        // Option 1: sharing ctx & module between threads
+        thread::scope(|s| {
+            let ptx = compile_ptx(KERNEL_SRC).unwrap();
+            let ctx = CudaContext::new(0)?;
+            let module = ctx.load_ptx(ptx, &["hello_world"])?;
             for i in 0..10i32 {
+                let thread_ctx = ctx.clone();
+                let thread_module = module.clone();
                 s.spawn(move || {
-                    // NOTE: this is the important call to have
-                    // without this, you'll get a CUDA_ERROR_INVALID_CONTEXT
-                    dev.bind_to_thread()?;
-                    let f = dev.get_func("kernel", "hello_world").unwrap();
-                    unsafe { f.launch(cfg, (i,)) }
+                    let stream = thread_ctx.default_stream();
+                    let f = thread_module.get_func("hello_world").unwrap();
+                    unsafe {
+                        stream
+                            .launch_builder(&f)
+                            .arg(i)
+                            .launch(LaunchConfig::for_num_elems(1))
+                    }
                 });
             }
-        });
+            Ok(())
+        })?;
     }
 
     {
-        // Option 2: create a new device in each thread
-        // This requires loading the PTX for each device, since they won't
-        // share a loaded modules on the Rust side of things.
-        let ptx = compile_ptx(KERNEL_SRC).unwrap();
-
-        thread::scope(|s| {
+        // Option 2: initializing different context in each
+        // Note that this will still schedule to the same stream since we are using the
+        // default stream here on the same device.
+        thread::scope(move |s| {
             for i in 0..10i32 {
-                let ptx = ptx.clone();
                 s.spawn(move || {
-                    let dev = CudaDevice::new(0)?;
-                    dev.load_ptx(ptx, "kernel", &["hello_world"])?;
-                    let f = dev.get_func("kernel", "hello_world").unwrap();
-                    unsafe { f.launch(cfg, (i + 100,)) }
+                    let ptx = compile_ptx(KERNEL_SRC).unwrap();
+                    let ctx = CudaContext::new(0)?;
+                    let module = ctx.load_ptx(ptx, &["hello_world"])?;
+                    let stream = ctx.default_stream();
+                    let f = module.get_func("hello_world").unwrap();
+                    unsafe {
+                        stream
+                            .launch_builder(&f)
+                            .arg(i)
+                            .launch(LaunchConfig::for_num_elems(1))
+                    }
                 });
             }
-        });
+            Ok(())
+        })?;
     }
 
     Ok(())

--- a/src/cublas/safe.rs
+++ b/src/cublas/safe.rs
@@ -29,7 +29,7 @@ impl CudaBlas {
         device.bind_to_thread().unwrap();
         let handle = result::create_handle()?;
         let blas = Self { handle, device };
-        unsafe { result::set_stream(handle, blas.device.stream as *mut _) }?;
+        unsafe { result::set_stream(handle, blas.device.stream.cu_stream as *mut _) }?;
         Ok(blas)
     }
 
@@ -46,8 +46,8 @@ impl CudaBlas {
     /// write to the same memory address.
     pub unsafe fn set_stream(&self, opt_stream: Option<&CudaStream>) -> Result<(), CublasError> {
         match opt_stream {
-            Some(s) => result::set_stream(self.handle, s.stream as *mut _),
-            None => result::set_stream(self.handle, self.device.stream as *mut _),
+            Some(s) => result::set_stream(self.handle, s.cu_stream as *mut _),
+            None => result::set_stream(self.handle, self.device.stream.cu_stream as *mut _),
         }
     }
 

--- a/src/cublaslt/safe.rs
+++ b/src/cublaslt/safe.rs
@@ -415,7 +415,7 @@ impl MatmulShared for CudaBlasLT {
     }
 
     fn stream(&self) -> &CUstream {
-        &self.device.stream
+        &self.device.stream.cu_stream
     }
 }
 

--- a/src/cudnn/safe/core.rs
+++ b/src/cudnn/safe/core.rs
@@ -20,7 +20,7 @@ impl Cudnn {
     pub fn new(device: Arc<CudaDevice>) -> Result<Arc<Self>, CudnnError> {
         device.bind_to_thread().unwrap();
         let handle = result::create_handle()?;
-        unsafe { result::set_stream(handle, device.stream as *mut _) }?;
+        unsafe { result::set_stream(handle, device.stream.cu_stream as *mut _) }?;
         Ok(Arc::new(Self { handle, device }))
     }
 
@@ -32,8 +32,8 @@ impl Cudnn {
     /// write to the same memory address.
     pub unsafe fn set_stream(&self, opt_stream: Option<&CudaStream>) -> Result<(), CudnnError> {
         match opt_stream {
-            Some(s) => result::set_stream(self.handle, s.stream as *mut _),
-            None => result::set_stream(self.handle, self.device.stream as *mut _),
+            Some(s) => result::set_stream(self.handle, s.cu_stream as *mut _),
+            None => result::set_stream(self.handle, self.device.stream.cu_stream as *mut _),
         }
     }
 }

--- a/src/curand/safe.rs
+++ b/src/curand/safe.rs
@@ -37,7 +37,7 @@ impl CudaRng {
         let gen = result::create_generator()?;
         let mut rng = Self { gen, device };
         rng.set_seed(seed)?;
-        unsafe { result::set_stream(rng.gen, rng.device.stream as *mut _) }?;
+        unsafe { result::set_stream(rng.gen, rng.device.stream.cu_stream as *mut _) }?;
         Ok(rng)
     }
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -168,4 +168,6 @@ pub mod safe;
 #[allow(warnings)]
 pub mod sys;
 
+pub mod safe_v2;
+
 pub use safe::*;

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -168,6 +168,4 @@ pub mod safe;
 #[allow(warnings)]
 pub mod sys;
 
-pub mod safe_v2;
-
 pub use safe::*;

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -457,6 +457,12 @@ pub mod ctx {
         }
     }
 
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g66655c37602c8628eae3e40c82619f1e)
+    pub fn set_flags(flags: sys::CUctx_flags) -> Result<(), DriverError> {
+        unsafe { lib().cuCtxSetFlags(flags as u32).result() }
+    }
+
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g7a54725f28d34b8c6299f0c6ca579616)
     pub fn synchronize() -> Result<(), DriverError> {
         unsafe { lib().cuCtxSynchronize() }.result()
     }

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -575,6 +575,18 @@ pub mod stream {
             .cuStreamAttachMemAsync(stream, dptr, num_bytes, flags as u32)
             .result()
     }
+
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXEC.html#group__CUDA__EXEC_1gab95a78143bae7f21eebb978f91e7f3f)
+    ///
+    /// # Safety
+    /// See docs, it's really unsafe ya'll.
+    pub unsafe fn launch_host_function(
+        stream: sys::CUstream,
+        func: unsafe extern "C" fn(*mut ::core::ffi::c_void),
+        arg: *mut std::ffi::c_void,
+    ) -> Result<(), DriverError> {
+        lib().cuLaunchHostFunc(stream, Some(func), arg).result()
+    }
 }
 
 /// Allocates memory with stream ordered semantics.

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -456,6 +456,10 @@ pub mod ctx {
             }
         }
     }
+
+    pub fn synchronize() -> Result<(), DriverError> {
+        unsafe { lib().cuCtxSynchronize() }.result()
+    }
 }
 
 pub mod stream {

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -458,6 +458,14 @@ pub mod ctx {
     }
 
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g66655c37602c8628eae3e40c82619f1e)
+    #[cfg(not(any(
+        feature = "cuda-11040",
+        feature = "cuda-11050",
+        feature = "cuda-11060",
+        feature = "cuda-11070",
+        feature = "cuda-11080",
+        feature = "cuda-12000"
+    )))]
     pub fn set_flags(flags: sys::CUctx_flags) -> Result<(), DriverError> {
         unsafe { lib().cuCtxSetFlags(flags as u32).result() }
     }

--- a/src/driver/safe/alloc.rs
+++ b/src/driver/safe/alloc.rs
@@ -1,414 +1,17 @@
-use crate::driver::{result, sys};
+use crate::driver::{
+    result::{self, DriverError},
+    sys,
+};
 
-use super::core::{CudaDevice, CudaSlice, CudaView, CudaViewMut, PinnedHostSlice};
-use super::device_ptr::{DevicePtr, DevicePtrMut, DeviceSlice};
+use super::device_ptr::{DevicePtr, DevicePtrMut};
+use super::host_slice::PinnedHostSlice;
+use super::{
+    core::{CudaDevice, CudaSlice, CudaStream},
+    HostSlice,
+};
 
-use std::{marker::Unpin, pin::Pin, sync::Arc, vec::Vec};
-
-/// Something that can be copied to device memory and
-/// turned into a parameter for [result::launch_kernel].
-///
-/// # Safety
-///
-/// This is unsafe because a struct should likely
-/// be `#[repr(C)]` to be represented in cuda memory,
-/// and not all types are valid.
-pub unsafe trait DeviceRepr {
-    #[inline(always)]
-    fn as_kernel_param(&self) -> *mut std::ffi::c_void {
-        self as *const Self as *mut _
-    }
-}
-
-unsafe impl DeviceRepr for bool {}
-unsafe impl DeviceRepr for i8 {}
-unsafe impl DeviceRepr for i16 {}
-unsafe impl DeviceRepr for i32 {}
-unsafe impl DeviceRepr for i64 {}
-unsafe impl DeviceRepr for i128 {}
-unsafe impl DeviceRepr for isize {}
-unsafe impl DeviceRepr for u8 {}
-unsafe impl DeviceRepr for u16 {}
-unsafe impl DeviceRepr for u32 {}
-unsafe impl DeviceRepr for u64 {}
-unsafe impl DeviceRepr for u128 {}
-unsafe impl DeviceRepr for usize {}
-unsafe impl DeviceRepr for f32 {}
-unsafe impl DeviceRepr for f64 {}
-#[cfg(feature = "f16")]
-unsafe impl DeviceRepr for half::f16 {}
-#[cfg(feature = "f16")]
-unsafe impl DeviceRepr for half::bf16 {}
-
-unsafe impl<T: DeviceRepr> DeviceRepr for &mut CudaSlice<T> {
-    #[inline(always)]
-    fn as_kernel_param(&self) -> *mut std::ffi::c_void {
-        (&self.cu_device_ptr) as *const sys::CUdeviceptr as *mut std::ffi::c_void
-    }
-}
-
-unsafe impl<T: DeviceRepr> DeviceRepr for &CudaSlice<T> {
-    #[inline(always)]
-    fn as_kernel_param(&self) -> *mut std::ffi::c_void {
-        (&self.cu_device_ptr) as *const sys::CUdeviceptr as *mut std::ffi::c_void
-    }
-}
-
-unsafe impl<T: DeviceRepr> DeviceRepr for &CudaView<'_, T> {
-    #[inline(always)]
-    fn as_kernel_param(&self) -> *mut std::ffi::c_void {
-        (&self.ptr) as *const sys::CUdeviceptr as *mut std::ffi::c_void
-    }
-}
-
-unsafe impl<T: DeviceRepr> DeviceRepr for &mut CudaViewMut<'_, T> {
-    #[inline(always)]
-    fn as_kernel_param(&self) -> *mut std::ffi::c_void {
-        (&self.ptr) as *const sys::CUdeviceptr as *mut std::ffi::c_void
-    }
-}
-
-impl<T> CudaSlice<T> {
-    /// Takes ownership of the underlying [sys::CUdeviceptr]. **It is up
-    /// to the owner to free this value**.
-    ///
-    /// Drops the underlying host_buf if there is one.
-    pub fn leak(mut self) -> sys::CUdeviceptr {
-        if let Some(host_buf) = std::mem::take(&mut self.host_buf) {
-            drop(host_buf);
-        }
-        let ptr = self.cu_device_ptr;
-        std::mem::forget(self);
-        ptr
-    }
-}
-
-impl CudaDevice {
-    /// Creates a [CudaSlice] from a [sys::CUdeviceptr]. Useful in conjunction with
-    /// [`CudaSlice::leak()`].
-    ///
-    /// # Safety
-    /// - `cu_device_ptr` must be a valid allocation
-    /// - `cu_device_ptr` must space for `len * std::mem::size_of<T>()` bytes
-    /// - The memory may not be valid for type `T`, so some sort of memset operation
-    ///   should be called on the memory.
-    pub unsafe fn upgrade_device_ptr<T>(
-        self: &Arc<Self>,
-        cu_device_ptr: sys::CUdeviceptr,
-        len: usize,
-    ) -> CudaSlice<T> {
-        CudaSlice {
-            cu_device_ptr,
-            len,
-            device: self.clone(),
-            host_buf: None,
-        }
-    }
-}
-
-impl CudaDevice {
-    /// Allocates an empty [CudaSlice] with 0 length.
-    pub fn null<T>(self: &Arc<Self>) -> Result<CudaSlice<T>, result::DriverError> {
-        self.bind_to_thread()?;
-        let cu_device_ptr = unsafe {
-            if self.is_async {
-                result::malloc_async(self.stream, 0)?
-            } else {
-                result::malloc_sync(0)?
-            }
-        };
-        Ok(CudaSlice {
-            cu_device_ptr,
-            len: 0,
-            device: self.clone(),
-            host_buf: None,
-        })
-    }
-
-    /// Allocates device memory and increments the reference counter of [CudaDevice].
-    ///
-    /// # Safety
-    /// This is unsafe because the device memory is unset after this call.
-    pub unsafe fn alloc<T: DeviceRepr>(
-        self: &Arc<Self>,
-        len: usize,
-    ) -> Result<CudaSlice<T>, result::DriverError> {
-        self.bind_to_thread()?;
-        let cu_device_ptr = if self.is_async {
-            result::malloc_async(self.stream, len * std::mem::size_of::<T>())?
-        } else {
-            result::malloc_sync(len * std::mem::size_of::<T>())?
-        };
-        Ok(CudaSlice {
-            cu_device_ptr,
-            len,
-            device: self.clone(),
-            host_buf: None,
-        })
-    }
-
-    /// Allocates page locked host memory with `sys::CU_MEMHOSTALLOC_WRITECOMBINED` flags.
-    ///
-    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g572ca4011bfcb25034888a14d4e035b9)
-    ///
-    /// # Safety
-    /// 1. This is unsafe because the memory is unset after this call.
-    pub unsafe fn alloc_pinned<T: DeviceRepr>(
-        self: &Arc<Self>,
-        len: usize,
-    ) -> Result<PinnedHostSlice<T>, result::DriverError> {
-        result::malloc_host(
-            len * std::mem::size_of::<T>(),
-            sys::CU_MEMHOSTALLOC_WRITECOMBINED,
-        )
-        .map(|ptr| PinnedHostSlice::new(ptr as _, len, self.clone()))
-    }
-
-    /// Allocates device memory with no associated host memory, and memsets
-    /// the device memory to all 0s.
-    ///
-    /// # Safety
-    /// 1. `T` is marked as [ValidAsZeroBits], so the device memory is valid to use
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn alloc_zeros<T: ValidAsZeroBits + DeviceRepr>(
-        self: &Arc<Self>,
-        len: usize,
-    ) -> Result<CudaSlice<T>, result::DriverError> {
-        let mut dst = unsafe { self.alloc(len) }?;
-        self.memset_zeros(&mut dst)?;
-        Ok(dst)
-    }
-
-    /// Sets all memory to 0 asynchronously.
-    ///
-    /// # Safety
-    /// 1. `T` is marked as [ValidAsZeroBits], so the device memory is valid to use
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn memset_zeros<T: ValidAsZeroBits + DeviceRepr, Dst: DevicePtrMut<T>>(
-        self: &Arc<Self>,
-        dst: &mut Dst,
-    ) -> Result<(), result::DriverError> {
-        self.bind_to_thread()?;
-        if self.is_async {
-            unsafe {
-                result::memset_d8_async(*dst.device_ptr_mut(), 0, dst.num_bytes(), self.stream)
-            }
-        } else {
-            unsafe { result::memset_d8_sync(*dst.device_ptr_mut(), 0, dst.num_bytes()) }
-        }
-    }
-
-    /// Device to device copy (safe version of [result::memcpy_dtod_async]).
-    ///
-    /// # Panics
-    ///
-    /// If the length of the two values are different
-    ///
-    /// # Safety
-    /// 1. We are guarunteed that `src` and `dst` are pointers to the same underlying
-    ///     type `T`
-    /// 2. Since they are both references, they can't have been freed
-    /// 3. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn dtod_copy<T: DeviceRepr, Src: DevicePtr<T>, Dst: DevicePtrMut<T>>(
-        self: &Arc<Self>,
-        src: &Src,
-        dst: &mut Dst,
-    ) -> Result<(), result::DriverError> {
-        assert_eq!(src.len(), dst.len());
-        self.bind_to_thread()?;
-        if self.is_async {
-            unsafe {
-                result::memcpy_dtod_async(
-                    *dst.device_ptr_mut(),
-                    *src.device_ptr(),
-                    src.len() * std::mem::size_of::<T>(),
-                    self.stream,
-                )
-            }
-        } else {
-            unsafe {
-                result::memcpy_dtod_sync(
-                    *dst.device_ptr_mut(),
-                    *src.device_ptr(),
-                    src.len() * std::mem::size_of::<T>(),
-                )
-            }
-        }
-    }
-
-    /// Takes ownership of the host data and copies it to device data asynchronously.
-    ///
-    /// # Safety
-    ///
-    /// 1. Since `src` is owned by this funcion, it is safe to copy data. Any actions executed
-    ///    after this will take place after the data has been successfully copied.
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn htod_copy<T: Unpin + DeviceRepr>(
-        self: &Arc<Self>,
-        src: Vec<T>,
-    ) -> Result<CudaSlice<T>, result::DriverError> {
-        let mut dst = unsafe { self.alloc(src.len()) }?;
-        self.htod_copy_into(src, &mut dst)?;
-        Ok(dst)
-    }
-
-    /// Asynchronously copies pinned host data (allocated with [CudaDevice::alloc_pinned()] to the device.
-    ///
-    /// This is generally at least 2x as fast as synchronous copies.
-    ///
-    /// # Safety
-    /// 1. We don't have to synchronize at all here because the cuda driver allocated the [PinnedHostSlice].
-    pub fn htod_copy_pinned<T: DeviceRepr + ValidAsZeroBits>(
-        self: &Arc<Self>,
-        src: &PinnedHostSlice<T>,
-    ) -> Result<CudaSlice<T>, result::DriverError> {
-        let mut dst = unsafe { self.alloc(src.len()) }?;
-        assert_eq!(src.len(), dst.len());
-        unsafe { result::memcpy_htod_async(*dst.device_ptr_mut(), src.as_slice(), self.stream) }?;
-        Ok(dst)
-    }
-
-    /// Takes ownership of the host data and copies it to device data asynchronously.
-    ///
-    /// # Safety
-    ///
-    /// 1. Since `src` is owned by this funcion, it is safe to copy data. Any actions executed
-    ///    after this will take place after the data has been successfully copied.
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn htod_copy_into<T: DeviceRepr + Unpin>(
-        self: &Arc<Self>,
-        src: Vec<T>,
-        dst: &mut CudaSlice<T>,
-    ) -> Result<(), result::DriverError> {
-        assert_eq!(src.len(), dst.len());
-        dst.host_buf = Some(Pin::new(src));
-        self.bind_to_thread()?;
-        if self.is_async {
-            unsafe {
-                result::memcpy_htod_async(
-                    dst.cu_device_ptr,
-                    dst.host_buf.as_ref().unwrap(),
-                    self.stream,
-                )
-            }?
-        } else {
-            unsafe { result::memcpy_htod_sync(dst.cu_device_ptr, dst.host_buf.as_ref().unwrap()) }?
-        }
-        Ok(())
-    }
-
-    /// Allocates new device memory and synchronously copies data from `src` into the new allocation.
-    ///
-    /// If you want an asynchronous copy, see [CudaDevice::htod_copy()].
-    ///
-    /// # Safety
-    ///
-    /// 1. Since this function doesn't own `src` it is executed synchronously.
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn htod_sync_copy<T: DeviceRepr>(
-        self: &Arc<Self>,
-        src: &[T],
-    ) -> Result<CudaSlice<T>, result::DriverError> {
-        let mut dst = unsafe { self.alloc(src.len()) }?;
-        self.htod_sync_copy_into(src, &mut dst)?;
-        Ok(dst)
-    }
-
-    /// Synchronously copies data from `src` into the new allocation.
-    ///
-    /// If you want an asynchronous copy, see [CudaDevice::htod_copy()].
-    ///
-    /// # Panics
-    ///
-    /// If the lengths of slices are not equal, this method panics.
-    ///
-    /// # Safety
-    /// 1. Since this function doesn't own `src` it is executed synchronously.
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn htod_sync_copy_into<T: DeviceRepr, Dst: DevicePtrMut<T>>(
-        self: &Arc<Self>,
-        src: &[T],
-        dst: &mut Dst,
-    ) -> Result<(), result::DriverError> {
-        assert_eq!(src.len(), dst.len());
-        self.bind_to_thread()?;
-        if self.is_async {
-            unsafe { result::memcpy_htod_async(*dst.device_ptr_mut(), src, self.stream) }?;
-        } else {
-            unsafe { result::memcpy_htod_sync(*dst.device_ptr_mut(), src) }?;
-        }
-        self.synchronize()
-    }
-
-    /// Synchronously copies device memory into host memory.
-    /// Unlike [`CudaDevice::dtoh_sync_copy_into`] this returns a [`Vec<T>`].
-    ///
-    /// # Safety
-    /// 1. Since this function doesn't own `dst` (after returning) it is executed synchronously.
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    #[allow(clippy::uninit_vec)]
-    pub fn dtoh_sync_copy<T: DeviceRepr, Src: DevicePtr<T>>(
-        self: &Arc<Self>,
-        src: &Src,
-    ) -> Result<Vec<T>, result::DriverError> {
-        let mut dst = Vec::with_capacity(src.len());
-        unsafe { dst.set_len(src.len()) };
-        self.dtoh_sync_copy_into(src, &mut dst)?;
-        Ok(dst)
-    }
-
-    /// Synchronously copies device memory into host memory
-    ///
-    /// Use [`CudaDevice::dtoh_sync_copy`] if you need [`Vec<T>`] and can't provide
-    /// a correctly sized slice.
-    ///
-    /// # Panics
-    ///
-    /// If the lengths of slices are not equal, this method panics.
-    ///
-    /// # Safety
-    /// 1. Since this function doesn't own `dst` it is executed synchronously.
-    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn dtoh_sync_copy_into<T: DeviceRepr, Src: DevicePtr<T>>(
-        self: &Arc<Self>,
-        src: &Src,
-        dst: &mut [T],
-    ) -> Result<(), result::DriverError> {
-        assert_eq!(src.len(), dst.len());
-        self.bind_to_thread()?;
-        if self.is_async {
-            unsafe { result::memcpy_dtoh_async(dst, *src.device_ptr(), self.stream) }?;
-        } else {
-            unsafe { result::memcpy_dtoh_sync(dst, *src.device_ptr()) }?;
-        }
-        self.synchronize()
-    }
-
-    /// Synchronously de-allocates `src` and converts it into it's host value.
-    /// You can just [drop] the slice if you don't need the host data.
-    ///
-    /// # Safety
-    /// 1. Self is [`Arc<Self>`], and this method increments the rc for self
-    pub fn sync_reclaim<T: Clone + Default + DeviceRepr + Unpin>(
-        self: &Arc<Self>,
-        mut src: CudaSlice<T>,
-    ) -> Result<Vec<T>, result::DriverError> {
-        let buf = src.host_buf.take();
-        let mut buf = buf.unwrap_or_else(|| {
-            let mut b = Vec::with_capacity(src.len);
-            b.resize(src.len, Default::default());
-            Pin::new(b)
-        });
-        self.dtoh_sync_copy_into(&src, &mut buf)?;
-        Ok(Pin::into_inner(buf))
-    }
-
-    /// Synchronizes the stream.
-    pub fn synchronize(self: &Arc<Self>) -> Result<(), result::DriverError> {
-        self.bind_to_thread()?;
-        unsafe { result::stream::synchronize(self.stream) }
-    }
-}
+use core::marker::PhantomData;
+use std::{marker::Unpin, sync::Arc, vec::Vec};
 
 /// Marker trait to indicate that the type is valid
 /// when all of its bits are set to 0.
@@ -456,9 +59,450 @@ macro_rules! impl_tuples {
 }
 impl_tuples!(A, B, C, D, E, F, G, H, I, J, K, L);
 
+/// Something that can be copied to device memory and
+/// turned into a parameter for [result::launch_kernel].
+///
+/// # Safety
+///
+/// This is unsafe because a struct should likely
+/// be `#[repr(C)]` to be represented in cuda memory,
+/// and not all types are valid.
+pub unsafe trait DeviceRepr {
+    #[inline(always)]
+    fn as_kernel_param(&self) -> *mut std::ffi::c_void {
+        self as *const Self as *mut _
+    }
+}
+
+unsafe impl DeviceRepr for bool {}
+unsafe impl DeviceRepr for i8 {}
+unsafe impl DeviceRepr for i16 {}
+unsafe impl DeviceRepr for i32 {}
+unsafe impl DeviceRepr for i64 {}
+unsafe impl DeviceRepr for i128 {}
+unsafe impl DeviceRepr for isize {}
+unsafe impl DeviceRepr for u8 {}
+unsafe impl DeviceRepr for u16 {}
+unsafe impl DeviceRepr for u32 {}
+unsafe impl DeviceRepr for u64 {}
+unsafe impl DeviceRepr for u128 {}
+unsafe impl DeviceRepr for usize {}
+unsafe impl DeviceRepr for f32 {}
+unsafe impl DeviceRepr for f64 {}
+#[cfg(feature = "f16")]
+unsafe impl DeviceRepr for half::f16 {}
+#[cfg(feature = "f16")]
+unsafe impl DeviceRepr for half::bf16 {}
+
+impl<T> CudaSlice<T> {
+    /// Takes ownership of the underlying [sys::CUdeviceptr]. **It is up
+    /// to the owner to free this value**.
+    ///
+    /// Drops the underlying host_buf if there is one.
+    pub fn leak(self) -> sys::CUdeviceptr {
+        let ptr = self.cu_device_ptr;
+        std::mem::forget(self);
+        ptr
+    }
+}
+
+impl CudaDevice {
+    /// Creates a [CudaSlice] from a [sys::CUdeviceptr]. Useful in conjunction with
+    /// [`CudaSlice::leak()`].
+    ///
+    /// # Safety
+    /// - `cu_device_ptr` must be a valid allocation
+    /// - `cu_device_ptr` must space for `len * std::mem::size_of<T>()` bytes
+    /// - The memory may not be valid for type `T`, so some sort of memset operation
+    ///   should be called on the memory.
+    pub unsafe fn upgrade_device_ptr<T>(
+        self: &Arc<Self>,
+        cu_device_ptr: sys::CUdeviceptr,
+        len: usize,
+    ) -> CudaSlice<T> {
+        self.stream.upgrade_device_ptr(cu_device_ptr, len)
+    }
+}
+
+impl CudaStream {
+    /// Creates a [CudaSlice] from a [sys::CUdeviceptr]. Useful in conjunction with
+    /// [`CudaSlice::leak()`].
+    ///
+    /// # Safety
+    /// - `cu_device_ptr` must be a valid allocation
+    /// - `cu_device_ptr` must space for `len * std::mem::size_of<T>()` bytes
+    /// - The memory may not be valid for type `T`, so some sort of memset operation
+    ///   should be called on the memory.
+    pub unsafe fn upgrade_device_ptr<T>(
+        self: &Arc<Self>,
+        cu_device_ptr: sys::CUdeviceptr,
+        len: usize,
+    ) -> CudaSlice<T> {
+        let event = self.ctx.empty_event(None).unwrap();
+        CudaSlice {
+            cu_device_ptr,
+            len,
+            event,
+            stream: self.clone(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl CudaDevice {
+    /// Allocates an empty [CudaSlice] with 0 length.
+    pub fn null<T>(self: &Arc<Self>) -> Result<CudaSlice<T>, result::DriverError> {
+        self.stream.null()
+    }
+
+    /// Allocates device memory and increments the reference counter of [CudaDevice].
+    ///
+    /// # Safety
+    /// This is unsafe because the device memory is unset after this call.
+    pub unsafe fn alloc<T: DeviceRepr>(
+        self: &Arc<Self>,
+        len: usize,
+    ) -> Result<CudaSlice<T>, result::DriverError> {
+        self.stream.alloc(len)
+    }
+
+    /// Allocates page locked host memory with `sys::CU_MEMHOSTALLOC_WRITECOMBINED` flags.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g572ca4011bfcb25034888a14d4e035b9)
+    ///
+    /// # Safety
+    /// 1. This is unsafe because the memory is unset after this call.
+    pub unsafe fn alloc_pinned<T: DeviceRepr>(
+        self: &Arc<Self>,
+        len: usize,
+    ) -> Result<PinnedHostSlice<T>, result::DriverError> {
+        self.stream.ctx.alloc_pinned(len)
+    }
+
+    /// Allocates device memory with no associated host memory, and memsets
+    /// the device memory to all 0s.
+    ///
+    /// # Safety
+    /// 1. `T` is marked as [ValidAsZeroBits], so the device memory is valid to use
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn alloc_zeros<T: ValidAsZeroBits + DeviceRepr>(
+        self: &Arc<Self>,
+        len: usize,
+    ) -> Result<CudaSlice<T>, result::DriverError> {
+        self.stream.alloc_zeros(len)
+    }
+
+    /// Sets all memory to 0 asynchronously.
+    ///
+    /// # Safety
+    /// 1. `T` is marked as [ValidAsZeroBits], so the device memory is valid to use
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn memset_zeros<T: ValidAsZeroBits + DeviceRepr, Dst: DevicePtrMut<T>>(
+        self: &Arc<Self>,
+        dst: &mut Dst,
+    ) -> Result<(), result::DriverError> {
+        self.stream.memset_zeros(dst)
+    }
+
+    /// Device to device copy (safe version of [result::memcpy_dtod_async]).
+    ///
+    /// # Panics
+    ///
+    /// If the length of the two values are different
+    ///
+    /// # Safety
+    /// 1. We are guarunteed that `src` and `dst` are pointers to the same underlying
+    ///     type `T`
+    /// 2. Since they are both references, they can't have been freed
+    /// 3. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn dtod_copy<T: DeviceRepr, Src: DevicePtr<T>, Dst: DevicePtrMut<T>>(
+        self: &Arc<Self>,
+        src: &Src,
+        dst: &mut Dst,
+    ) -> Result<(), result::DriverError> {
+        self.stream.memcpy_dtod(src, dst)
+    }
+
+    /// Takes ownership of the host data and copies it to device data asynchronously.
+    ///
+    /// # Safety
+    ///
+    /// 1. Since `src` is owned by this funcion, it is safe to copy data. Any actions executed
+    ///    after this will take place after the data has been successfully copied.
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn htod_copy<T: Unpin + DeviceRepr>(
+        self: &Arc<Self>,
+        src: Vec<T>,
+    ) -> Result<CudaSlice<T>, result::DriverError> {
+        self.stream.memcpy_vtod(src)
+    }
+
+    /// Asynchronously copies pinned host data (allocated with [CudaDevice::alloc_pinned()] to the device.
+    ///
+    /// This is generally at least 2x as fast as synchronous copies.
+    ///
+    /// # Safety
+    /// 1. We don't have to synchronize at all here because the cuda driver allocated the [PinnedHostSlice].
+    pub fn htod_copy_pinned<T: DeviceRepr + ValidAsZeroBits>(
+        self: &Arc<Self>,
+        src: &PinnedHostSlice<T>,
+    ) -> Result<CudaSlice<T>, result::DriverError> {
+        let mut dst = unsafe { self.stream.alloc(src.len()) }?;
+        self.stream.memcpy_htod(src, &mut dst)?;
+        Ok(dst)
+    }
+
+    /// Takes ownership of the host data and copies it to device data asynchronously.
+    ///
+    /// # Safety
+    ///
+    /// 1. Since `src` is owned by this funcion, it is safe to copy data. Any actions executed
+    ///    after this will take place after the data has been successfully copied.
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn htod_copy_into<T: DeviceRepr + Unpin>(
+        self: &Arc<Self>,
+        src: Vec<T>,
+        dst: &mut CudaSlice<T>,
+    ) -> Result<(), result::DriverError> {
+        self.stream.memcpy_htod(&src, dst)
+    }
+
+    /// Allocates new device memory and synchronously copies data from `src` into the new allocation.
+    ///
+    /// If you want an asynchronous copy, see [CudaDevice::htod_copy()].
+    ///
+    /// # Safety
+    ///
+    /// 1. Since this function doesn't own `src` it is executed synchronously.
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn htod_sync_copy<T: DeviceRepr>(
+        self: &Arc<Self>,
+        src: &[T],
+    ) -> Result<CudaSlice<T>, result::DriverError> {
+        let mut dst = unsafe { self.stream.alloc(src.len()) }?;
+        self.stream.memcpy_htod(src, &mut dst)?;
+        Ok(dst)
+    }
+
+    /// Synchronously copies data from `src` into the new allocation.
+    ///
+    /// If you want an asynchronous copy, see [CudaDevice::htod_copy()].
+    ///
+    /// # Panics
+    ///
+    /// If the lengths of slices are not equal, this method panics.
+    ///
+    /// # Safety
+    /// 1. Since this function doesn't own `src` it is executed synchronously.
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn htod_sync_copy_into<T: DeviceRepr, Dst: DevicePtrMut<T>>(
+        self: &Arc<Self>,
+        src: &[T],
+        dst: &mut Dst,
+    ) -> Result<(), result::DriverError> {
+        self.stream.memcpy_htod(src, dst)
+    }
+
+    /// Synchronously copies device memory into host memory.
+    /// Unlike [`CudaDevice::dtoh_sync_copy_into`] this returns a [`Vec<T>`].
+    ///
+    /// # Safety
+    /// 1. Since this function doesn't own `dst` (after returning) it is executed synchronously.
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    #[allow(clippy::uninit_vec)]
+    pub fn dtoh_sync_copy<T: DeviceRepr, Src: DevicePtr<T>>(
+        self: &Arc<Self>,
+        src: &Src,
+    ) -> Result<Vec<T>, result::DriverError> {
+        self.stream.memcpy_dtov(src)
+    }
+
+    /// Synchronously copies device memory into host memory
+    ///
+    /// Use [`CudaDevice::dtoh_sync_copy`] if you need [`Vec<T>`] and can't provide
+    /// a correctly sized slice.
+    ///
+    /// # Panics
+    ///
+    /// If the lengths of slices are not equal, this method panics.
+    ///
+    /// # Safety
+    /// 1. Since this function doesn't own `dst` it is executed synchronously.
+    /// 2. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn dtoh_sync_copy_into<T: DeviceRepr, Src: DevicePtr<T>>(
+        self: &Arc<Self>,
+        src: &Src,
+        dst: &mut [T],
+    ) -> Result<(), result::DriverError> {
+        self.stream.memcpy_dtoh(src, dst)
+    }
+
+    /// Synchronously de-allocates `src` and converts it into it's host value.
+    /// You can just [drop] the slice if you don't need the host data.
+    ///
+    /// # Safety
+    /// 1. Self is [`Arc<Self>`], and this method increments the rc for self
+    pub fn sync_reclaim<T: Clone + Default + DeviceRepr + Unpin>(
+        self: &Arc<Self>,
+        src: CudaSlice<T>,
+    ) -> Result<Vec<T>, result::DriverError> {
+        let mut dst = vec![Default::default(); src.len];
+        self.stream.memcpy_dtoh(&src, &mut dst)?;
+        Ok(dst)
+    }
+
+    /// Synchronizes the stream.
+    pub fn synchronize(self: &Arc<Self>) -> Result<(), result::DriverError> {
+        self.stream.synchronize()
+    }
+}
+
+impl CudaStream {
+    /// Allocates an empty [CudaSlice] with 0 length.
+    pub fn null<T>(self: &Arc<Self>) -> Result<CudaSlice<T>, result::DriverError> {
+        self.ctx.bind_to_thread()?;
+        let cu_device_ptr = if self.ctx.has_async_alloc {
+            unsafe { result::malloc_async(self.cu_stream, 0) }?
+        } else {
+            unsafe { result::malloc_sync(0) }?
+        };
+        let event = self.ctx.empty_event(None)?;
+        Ok(CudaSlice {
+            cu_device_ptr,
+            len: 0,
+            event,
+            stream: self.clone(),
+            marker: PhantomData,
+        })
+    }
+
+    pub unsafe fn alloc<T: DeviceRepr>(
+        self: &Arc<Self>,
+        len: usize,
+    ) -> Result<CudaSlice<T>, DriverError> {
+        self.ctx.bind_to_thread()?;
+        let cu_device_ptr = if self.ctx.has_async_alloc {
+            result::malloc_async(self.cu_stream, len * std::mem::size_of::<T>())?
+        } else {
+            result::malloc_sync(len * std::mem::size_of::<T>())?
+        };
+        let event = self.ctx.empty_event(None)?;
+        Ok(CudaSlice {
+            cu_device_ptr,
+            len,
+            event,
+            stream: self.clone(),
+            marker: PhantomData,
+        })
+    }
+
+    pub fn alloc_zeros<T: DeviceRepr + ValidAsZeroBits>(
+        self: &Arc<Self>,
+        len: usize,
+    ) -> Result<CudaSlice<T>, DriverError> {
+        let mut dst = unsafe { self.alloc(len) }?;
+        self.memset_zeros(&mut dst)?;
+        Ok(dst)
+    }
+
+    pub fn memset_zeros<T: DeviceRepr + ValidAsZeroBits, Dst: DevicePtrMut<T>>(
+        self: &Arc<Self>,
+        dst: &mut Dst,
+    ) -> Result<(), DriverError> {
+        self.wait(dst.event())?;
+        unsafe {
+            result::memset_d8_async(dst.cu_device_ptr(), 0, dst.num_bytes(), self.cu_stream)
+        }?;
+        dst.record_use(self)?;
+        Ok(())
+    }
+
+    pub fn memcpy_vtod<T: DeviceRepr>(
+        self: &Arc<Self>,
+        src: Vec<T>,
+    ) -> Result<CudaSlice<T>, DriverError> {
+        let mut dst = unsafe { self.alloc(src.len()) }?;
+        self.memcpy_htod(&src, &mut dst)?;
+        Ok(dst)
+    }
+
+    pub fn memcpy_htod<T: DeviceRepr, Src: HostSlice<T> + ?Sized, Dst: DevicePtrMut<T>>(
+        self: &Arc<Self>,
+        src: &Src,
+        dst: &mut Dst,
+    ) -> Result<(), DriverError> {
+        let src = unsafe { src.stream_synced_slice(self) }?;
+        self.wait(dst.event())?;
+        unsafe { result::memcpy_htod_async(dst.cu_device_ptr(), src, self.cu_stream) }?;
+        src.record_use(self)?;
+        dst.record_use(self)?;
+        Ok(())
+    }
+
+    pub fn memcpy_dtov<T: DeviceRepr, Src: DevicePtr<T>>(
+        self: &Arc<Self>,
+        src: &Src,
+    ) -> Result<Vec<T>, DriverError> {
+        let mut dst = Vec::with_capacity(src.len());
+        unsafe { dst.set_len(src.len()) };
+        self.memcpy_dtoh(src, &mut dst)?;
+        Ok(dst)
+    }
+
+    pub fn memcpy_dtoh<T: DeviceRepr, Src: DevicePtr<T>, Dst: HostSlice<T> + ?Sized>(
+        self: &Arc<Self>,
+        src: &Src,
+        dst: &mut Dst,
+    ) -> Result<(), DriverError> {
+        let dst = unsafe { dst.stream_synced_mut_slice(self) }?;
+        assert!(dst.len() >= src.len());
+        self.wait(src.event())?;
+        unsafe { result::memcpy_dtoh_async(dst, src.cu_device_ptr(), self.cu_stream) }?;
+        src.record_use(self)?;
+        dst.record_use(self)?;
+        Ok(())
+    }
+
+    pub fn memcpy_dtod<T: DeviceRepr, Src: DevicePtr<T>, Dst: DevicePtrMut<T>>(
+        self: &Arc<Self>,
+        src: &Src,
+        dst: &mut Dst,
+    ) -> Result<(), DriverError> {
+        self.wait(src.event())?;
+        self.wait(dst.event())?;
+        unsafe {
+            result::memcpy_dtod_async(
+                dst.cu_device_ptr(),
+                src.cu_device_ptr(),
+                src.num_bytes(),
+                self.cu_stream,
+            )
+        }?;
+        src.record_use(self)?;
+        dst.record_use(self)?;
+        Ok(())
+    }
+
+    pub fn clone_dtod<T: DeviceRepr, Src: DevicePtr<T>>(
+        self: &Arc<Self>,
+        src: &Src,
+    ) -> Result<CudaSlice<T>, DriverError> {
+        let mut dst = unsafe { self.alloc(src.len()) }?;
+        self.memcpy_dtod(src, &mut dst)?;
+        Ok(dst)
+    }
+
+    pub fn synchronize(&self) -> Result<(), DriverError> {
+        self.ctx.bind_to_thread()?;
+        unsafe { result::stream::synchronize(self.cu_stream) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Instant;
+
+    use crate::driver::DeviceSlice;
 
     use super::*;
     #[cfg(feature = "no-std")]
@@ -474,15 +518,14 @@ mod tests {
     fn test_post_alloc_arc_counts() {
         let device = CudaDevice::new(0).unwrap();
         let t = device.alloc_zeros::<f32>(1).unwrap();
-        assert!(t.host_buf.is_none());
         assert_eq!(Arc::strong_count(&device), 2);
+        drop(t);
     }
 
     #[test]
     fn test_post_take_arc_counts() {
         let device = CudaDevice::new(0).unwrap();
         let t = device.htod_copy([0.0f32; 5].to_vec()).unwrap();
-        assert!(t.host_buf.is_some());
         assert_eq!(Arc::strong_count(&device), 2);
         drop(t);
         assert_eq!(Arc::strong_count(&device), 1);
@@ -622,8 +665,8 @@ mod tests {
         let truth = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
         let dev = CudaDevice::new(0).unwrap();
         let mut pinned = unsafe { dev.alloc_pinned::<f32>(10) }.unwrap();
-        pinned.as_mut_slice().clone_from_slice(&truth);
-        assert_eq!(pinned.as_slice(), &truth);
+        pinned.as_mut_slice().unwrap().clone_from_slice(&truth);
+        assert_eq!(pinned.as_slice().unwrap(), &truth);
         let dst = dev.htod_copy_pinned(&pinned).unwrap();
         let host = dev.dtoh_sync_copy(&dst).unwrap();
         assert_eq!(&host, &truth);

--- a/src/driver/safe/alloc.rs
+++ b/src/driver/safe/alloc.rs
@@ -380,6 +380,8 @@ impl CudaStream {
         })
     }
 
+    /// # Safety
+    /// This is unsafe because the memory is unset.
     pub unsafe fn alloc<T: DeviceRepr>(
         self: &Arc<Self>,
         len: usize,
@@ -452,7 +454,10 @@ impl CudaStream {
         src: &Src,
     ) -> Result<Vec<T>, DriverError> {
         let mut dst = Vec::with_capacity(src.len());
-        unsafe { dst.set_len(src.len()) };
+        #[allow(clippy::uninit_vec)]
+        unsafe {
+            dst.set_len(src.len())
+        };
         self.memcpy_dtoh(src, &mut dst)?;
         Ok(dst)
     }

--- a/src/driver/safe/alloc.rs
+++ b/src/driver/safe/alloc.rs
@@ -348,7 +348,7 @@ impl CudaDevice {
         self: &Arc<Self>,
         src: CudaSlice<T>,
     ) -> Result<Vec<T>, result::DriverError> {
-        let mut dst = vec![Default::default(); src.len];
+        let mut dst = std::vec![Default::default(); src.len];
         self.stream.memcpy_dtoh(&src, &mut dst)?;
         Ok(dst)
     }

--- a/src/driver/safe/alloc.rs
+++ b/src/driver/safe/alloc.rs
@@ -499,11 +499,6 @@ impl CudaStream {
         self.memcpy_dtod(src, &mut dst)?;
         Ok(dst)
     }
-
-    pub fn synchronize(&self) -> Result<(), DriverError> {
-        self.ctx.bind_to_thread()?;
-        unsafe { result::stream::synchronize(self.cu_stream) }
-    }
 }
 
 #[cfg(test)]

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -121,10 +121,26 @@ impl CudaContext {
         result::ctx::synchronize()
     }
 
+    #[cfg(not(any(
+        feature = "cuda-11040",
+        feature = "cuda-11050",
+        feature = "cuda-11060",
+        feature = "cuda-11070",
+        feature = "cuda-11080",
+        feature = "cuda-12000"
+    )))]
     pub fn set_blocking_synchronize(&self) -> Result<(), DriverError> {
         self.set_flags(sys::CUctx_flags::CU_CTX_SCHED_BLOCKING_SYNC)
     }
 
+    #[cfg(not(any(
+        feature = "cuda-11040",
+        feature = "cuda-11050",
+        feature = "cuda-11060",
+        feature = "cuda-11070",
+        feature = "cuda-11080",
+        feature = "cuda-12000"
+    )))]
     pub fn set_flags(&self, flags: sys::CUctx_flags) -> Result<(), DriverError> {
         self.bind_to_thread()?;
         result::ctx::set_flags(flags)

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -115,7 +115,8 @@ impl CudaContext {
     }
 
     pub fn synchronize(&self) -> Result<(), DriverError> {
-        todo!()
+        self.bind_to_thread()?;
+        result::ctx::synchronize()
     }
 }
 
@@ -734,6 +735,10 @@ impl CudaStream {
                 sys::CUevent_wait_flags::CU_EVENT_WAIT_DEFAULT,
             )
         }
+    }
+
+    pub fn join(&self, other: &CudaStream) -> Result<(), DriverError> {
+        self.wait(&other.record_event(None)?)
     }
 }
 

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -273,6 +273,10 @@ impl CudaDevice {
         &self.stream.ctx.cu_ctx
     }
 
+    pub fn stream(&self) -> &CudaStream {
+        &self.stream
+    }
+
     /// Get the underlying [sys::CUstream] that this [CudaDevice] executes
     /// all of its work on.
     ///

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -964,34 +964,34 @@ impl<T> CudaSlice<T> {
     ///
     /// This method can be used to create non-overlapping mutable views into a [CudaSlice].
     /// ```rust
-    /// # use cudarc::driver::safe::{CudaDevice, CudaSlice, CudaView};
-    /// # fn do_something(view: CudaView<u8>, view2: CudaView<u8>) {}
+    /// # use cudarc::driver::safe::{CudaDevice, CudaSlice, CudaViewMut};
+    /// # fn do_something(view: CudaViewMut<u8>, view2: CudaViewMut<u8>) {}
     /// # let dev = CudaDevice::new(0).unwrap();
     /// let mut slice = dev.alloc_zeros::<u8>(100).unwrap();
     /// // split the slice into two non-overlapping, mutable views
     /// let (view1, view2) = slice.split_at(50);
     /// do_something(view1, view2);
     /// ```
-    pub fn split_at(&self, mid: usize) -> (CudaView<'_, T>, CudaView<'_, T>) {
-        self.try_split_at(mid).unwrap()
+    pub fn split_at_mut(&self, mid: usize) -> (CudaViewMut<'_, T>, CudaViewMut<'_, T>) {
+        self.try_split_at_mut(mid).unwrap()
     }
 
     /// Fallible version of [CudaSlice::split_at].
     ///
     /// Returns `None` if `mid > self.len`.
-    pub fn try_split_at(&self, mid: usize) -> Option<(CudaView<'_, T>, CudaView<'_, T>)> {
+    pub fn try_split_at_mut(&self, mid: usize) -> Option<(CudaViewMut<'_, T>, CudaViewMut<'_, T>)> {
         if mid > self.len() {
             return None;
         }
         Some((
-            CudaView {
+            CudaViewMut {
                 ptr: self.cu_device_ptr,
                 len: mid,
                 event: &self.event,
                 stream: &self.stream,
                 marker: PhantomData,
             },
-            CudaView {
+            CudaViewMut {
                 ptr: self.cu_device_ptr + (mid * std::mem::size_of::<T>()) as u64,
                 len: self.len - mid,
                 event: &self.event,

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -969,17 +969,20 @@ impl<T> CudaSlice<T> {
     /// # let dev = CudaDevice::new(0).unwrap();
     /// let mut slice = dev.alloc_zeros::<u8>(100).unwrap();
     /// // split the slice into two non-overlapping, mutable views
-    /// let (view1, view2) = slice.split_at(50);
+    /// let (mut view1, mut view2) = slice.split_at_mut(50);
     /// do_something(view1, view2);
     /// ```
-    pub fn split_at_mut(&self, mid: usize) -> (CudaViewMut<'_, T>, CudaViewMut<'_, T>) {
+    pub fn split_at_mut(&mut self, mid: usize) -> (CudaViewMut<'_, T>, CudaViewMut<'_, T>) {
         self.try_split_at_mut(mid).unwrap()
     }
 
-    /// Fallible version of [CudaSlice::split_at].
+    /// Fallible version of [CudaSlice::split_at_mut].
     ///
     /// Returns `None` if `mid > self.len`.
-    pub fn try_split_at_mut(&self, mid: usize) -> Option<(CudaViewMut<'_, T>, CudaViewMut<'_, T>)> {
+    pub fn try_split_at_mut(
+        &mut self,
+        mid: usize,
+    ) -> Option<(CudaViewMut<'_, T>, CudaViewMut<'_, T>)> {
         if mid > self.len() {
             return None;
         }

--- a/src/driver/safe/device_ptr.rs
+++ b/src/driver/safe/device_ptr.rs
@@ -1,6 +1,9 @@
 use crate::driver::{result::DriverError, sys};
 
-use super::core::{CudaEvent, CudaSlice, CudaStream, CudaView, CudaViewMut};
+use super::{
+    core::{CudaSlice, CudaStream, CudaView, CudaViewMut},
+    CudaEvent,
+};
 
 pub trait DeviceSlice<T> {
     fn len(&self) -> usize;
@@ -12,14 +15,7 @@ pub trait DeviceSlice<T> {
     }
 
     fn cu_device_ptr(&self) -> sys::CUdeviceptr;
-    fn event(&self) -> &CudaEvent;
     fn stream(&self) -> &CudaStream;
-    fn record_use(&self, stream: &CudaStream) -> Result<(), DriverError> {
-        if self.stream() != stream {
-            self.event().record(stream)?;
-        }
-        Ok(())
-    }
 }
 
 impl<T> DeviceSlice<T> for CudaSlice<T> {
@@ -28,9 +24,6 @@ impl<T> DeviceSlice<T> for CudaSlice<T> {
     }
     fn cu_device_ptr(&self) -> sys::CUdeviceptr {
         self.cu_device_ptr
-    }
-    fn event(&self) -> &CudaEvent {
-        &self.event
     }
     fn stream(&self) -> &CudaStream {
         &self.stream
@@ -44,9 +37,6 @@ impl<T> DeviceSlice<T> for CudaView<'_, T> {
     fn cu_device_ptr(&self) -> sys::CUdeviceptr {
         self.ptr
     }
-    fn event(&self) -> &CudaEvent {
-        self.event
-    }
     fn stream(&self) -> &CudaStream {
         self.stream
     }
@@ -59,9 +49,6 @@ impl<T> DeviceSlice<T> for CudaViewMut<'_, T> {
     fn cu_device_ptr(&self) -> sys::CUdeviceptr {
         self.ptr
     }
-    fn event(&self) -> &CudaEvent {
-        self.event
-    }
     fn stream(&self) -> &CudaStream {
         self.stream
     }
@@ -70,11 +57,25 @@ impl<T> DeviceSlice<T> for CudaViewMut<'_, T> {
 /// Abstraction over [CudaSlice]/[CudaView]
 pub trait DevicePtr<T>: DeviceSlice<T> {
     fn device_ptr(&self) -> &sys::CUdeviceptr;
+    fn read_event(&self) -> &CudaEvent;
+    fn block_for_read(&self, stream: &CudaStream) -> Result<(), DriverError>;
+    fn record_read(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        if self.stream() != stream {
+            self.read_event().record(stream)?;
+        }
+        Ok(())
+    }
 }
 
 impl<T> DevicePtr<T> for CudaSlice<T> {
     fn device_ptr(&self) -> &sys::CUdeviceptr {
         &self.cu_device_ptr
+    }
+    fn read_event(&self) -> &CudaEvent {
+        &self.read
+    }
+    fn block_for_read(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        stream.wait(&self.write)
     }
 }
 
@@ -82,27 +83,62 @@ impl<T> DevicePtr<T> for CudaView<'_, T> {
     fn device_ptr(&self) -> &sys::CUdeviceptr {
         &self.ptr
     }
+    fn read_event(&self) -> &CudaEvent {
+        self.read
+    }
+    fn block_for_read(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        stream.wait(self.write)
+    }
 }
 
 impl<T> DevicePtr<T> for CudaViewMut<'_, T> {
     fn device_ptr(&self) -> &sys::CUdeviceptr {
         &self.ptr
     }
+    fn read_event(&self) -> &CudaEvent {
+        self.read
+    }
+    fn block_for_read(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        stream.wait(self.write)
+    }
 }
 
 /// Abstraction over [CudaSlice]/[CudaViewMut]
-pub trait DevicePtrMut<T>: DeviceSlice<T> {
+pub trait DevicePtrMut<T>: DevicePtr<T> {
     fn device_ptr_mut(&mut self) -> &mut sys::CUdeviceptr;
+    fn write_event(&self) -> &CudaEvent;
+    fn block_for_write(&self, stream: &CudaStream) -> Result<(), DriverError>;
+    fn record_write(&mut self, stream: &CudaStream) -> Result<(), DriverError> {
+        if self.stream() != stream {
+            self.read_event().record(stream)?;
+            self.write_event().record(stream)?;
+        }
+        Ok(())
+    }
 }
 
 impl<T> DevicePtrMut<T> for CudaSlice<T> {
     fn device_ptr_mut(&mut self) -> &mut sys::CUdeviceptr {
         &mut self.cu_device_ptr
     }
+    fn write_event(&self) -> &CudaEvent {
+        &self.write
+    }
+    fn block_for_write(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        stream.wait(&self.read)?;
+        stream.wait(&self.write)
+    }
 }
 
 impl<T> DevicePtrMut<T> for CudaViewMut<'_, T> {
     fn device_ptr_mut(&mut self) -> &mut sys::CUdeviceptr {
         &mut self.ptr
+    }
+    fn write_event(&self) -> &CudaEvent {
+        self.write
+    }
+    fn block_for_write(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        stream.wait(self.read)?;
+        stream.wait(self.write)
     }
 }

--- a/src/driver/safe/device_ptr.rs
+++ b/src/driver/safe/device_ptr.rs
@@ -1,6 +1,6 @@
-use crate::driver::sys;
+use crate::driver::{result::DriverError, sys};
 
-use super::core::{CudaSlice, CudaView, CudaViewMut};
+use super::core::{CudaEvent, CudaSlice, CudaStream, CudaView, CudaViewMut};
 
 pub trait DeviceSlice<T> {
     fn len(&self) -> usize;
@@ -10,11 +10,30 @@ pub trait DeviceSlice<T> {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    fn cu_device_ptr(&self) -> sys::CUdeviceptr;
+    fn event(&self) -> &CudaEvent;
+    fn stream(&self) -> &CudaStream;
+    fn record_use(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        if self.stream() != stream {
+            self.event().record(stream)?;
+        }
+        Ok(())
+    }
 }
 
 impl<T> DeviceSlice<T> for CudaSlice<T> {
     fn len(&self) -> usize {
         self.len
+    }
+    fn cu_device_ptr(&self) -> sys::CUdeviceptr {
+        self.cu_device_ptr
+    }
+    fn event(&self) -> &CudaEvent {
+        &self.event
+    }
+    fn stream(&self) -> &CudaStream {
+        &self.stream
     }
 }
 
@@ -22,11 +41,29 @@ impl<T> DeviceSlice<T> for CudaView<'_, T> {
     fn len(&self) -> usize {
         self.len
     }
+    fn cu_device_ptr(&self) -> sys::CUdeviceptr {
+        self.ptr
+    }
+    fn event(&self) -> &CudaEvent {
+        self.event
+    }
+    fn stream(&self) -> &CudaStream {
+        self.stream
+    }
 }
 
 impl<T> DeviceSlice<T> for CudaViewMut<'_, T> {
     fn len(&self) -> usize {
         self.len
+    }
+    fn cu_device_ptr(&self) -> sys::CUdeviceptr {
+        self.ptr
+    }
+    fn event(&self) -> &CudaEvent {
+        self.event
+    }
+    fn stream(&self) -> &CudaStream {
+        self.stream
     }
 }
 

--- a/src/driver/safe/device_ptr.rs
+++ b/src/driver/safe/device_ptr.rs
@@ -13,17 +13,12 @@ pub trait DeviceSlice<T> {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
-
-    fn cu_device_ptr(&self) -> sys::CUdeviceptr;
     fn stream(&self) -> &CudaStream;
 }
 
 impl<T> DeviceSlice<T> for CudaSlice<T> {
     fn len(&self) -> usize {
         self.len
-    }
-    fn cu_device_ptr(&self) -> sys::CUdeviceptr {
-        self.cu_device_ptr
     }
     fn stream(&self) -> &CudaStream {
         &self.stream
@@ -34,9 +29,6 @@ impl<T> DeviceSlice<T> for CudaView<'_, T> {
     fn len(&self) -> usize {
         self.len
     }
-    fn cu_device_ptr(&self) -> sys::CUdeviceptr {
-        self.ptr
-    }
     fn stream(&self) -> &CudaStream {
         self.stream
     }
@@ -45,9 +37,6 @@ impl<T> DeviceSlice<T> for CudaView<'_, T> {
 impl<T> DeviceSlice<T> for CudaViewMut<'_, T> {
     fn len(&self) -> usize {
         self.len
-    }
-    fn cu_device_ptr(&self) -> sys::CUdeviceptr {
-        self.ptr
     }
     fn stream(&self) -> &CudaStream {
         self.stream

--- a/src/driver/safe/device_ptr.rs
+++ b/src/driver/safe/device_ptr.rs
@@ -49,10 +49,7 @@ pub trait DevicePtr<T>: DeviceSlice<T> {
     fn read_event(&self) -> &CudaEvent;
     fn block_for_read(&self, stream: &CudaStream) -> Result<(), DriverError>;
     fn record_read(&self, stream: &CudaStream) -> Result<(), DriverError> {
-        if self.stream() != stream {
-            self.read_event().record(stream)?;
-        }
-        Ok(())
+        self.read_event().record(stream)
     }
 }
 
@@ -98,11 +95,7 @@ pub trait DevicePtrMut<T>: DevicePtr<T> {
     fn write_event(&self) -> &CudaEvent;
     fn block_for_write(&self, stream: &CudaStream) -> Result<(), DriverError>;
     fn record_write(&mut self, stream: &CudaStream) -> Result<(), DriverError> {
-        if self.stream() != stream {
-            self.read_event().record(stream)?;
-            self.write_event().record(stream)?;
-        }
-        Ok(())
+        self.write_event().record(stream)
     }
 }
 

--- a/src/driver/safe/external_memory.rs
+++ b/src/driver/safe/external_memory.rs
@@ -155,9 +155,6 @@ impl DeviceSlice<u8> for MappedBuffer {
     fn cu_device_ptr(&self) -> sys::CUdeviceptr {
         self.device_ptr
     }
-    fn event(&self) -> &CudaEvent {
-        &self.event
-    }
     fn stream(&self) -> &CudaStream {
         &self.stream
     }
@@ -166,5 +163,11 @@ impl DeviceSlice<u8> for MappedBuffer {
 impl DevicePtr<u8> for MappedBuffer {
     fn device_ptr(&self) -> &sys::CUdeviceptr {
         &self.device_ptr
+    }
+    fn read_event(&self) -> &CudaEvent {
+        &self.event
+    }
+    fn block_for_read(&self, _stream: &CudaStream) -> Result<(), DriverError> {
+        Ok(())
     }
 }

--- a/src/driver/safe/external_memory.rs
+++ b/src/driver/safe/external_memory.rs
@@ -152,9 +152,6 @@ impl DeviceSlice<u8> for MappedBuffer {
     fn len(&self) -> usize {
         self.len
     }
-    fn cu_device_ptr(&self) -> sys::CUdeviceptr {
-        self.device_ptr
-    }
     fn stream(&self) -> &CudaStream {
         &self.stream
     }

--- a/src/driver/safe/external_memory.rs
+++ b/src/driver/safe/external_memory.rs
@@ -3,10 +3,47 @@ use std::fs::File;
 use std::ops::Range;
 use std::sync::Arc;
 
-use super::{CudaDevice, DevicePtr, DeviceSlice};
+use super::{CudaContext, CudaDevice, CudaEvent, CudaStream, DevicePtr, DeviceSlice};
 use crate::driver::{result, sys, DriverError};
 
-impl CudaDevice {
+/// An abstraction for imported external memory.
+///
+/// This struct can be created via [`CudaDevice::import_external_memory`].
+/// The imported external memory will be destroyed when this struct is dropped.
+#[derive(Debug)]
+pub struct ExternalMemory {
+    external_memory: sys::CUexternalMemory,
+    size: u64,
+    ctx: Arc<CudaContext>,
+    _file: ManuallyDrop<File>,
+}
+
+impl Drop for ExternalMemory {
+    fn drop(&mut self) {
+        self.ctx.bind_to_thread().unwrap();
+
+        unsafe { result::external_memory::destroy_external_memory(self.external_memory) }.unwrap();
+
+        // From [CUDA docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXTRES__INTEROP.html#group__CUDA__EXTRES__INTEROP_1g52aba3a7f780157d8ba12972b2481735),
+        // when successfully importing UNIX file descriptor:
+        //
+        // > Ownership of the file descriptor is transferred to the CUDA driver when the handle is imported successfully.
+        // > Performing any operations on the file descriptor after it is imported results in undefined behavior.
+        //
+        // On the other hand, on Windows:
+        //
+        // > Ownership of this handle is not transferred to CUDA after the import operation,
+        // > so the application must release the handle using the appropriate system call.
+        //
+        // Therefore, we manually drop the file when we are on Windows.
+        #[cfg(windows)]
+        unsafe {
+            ManuallyDrop::<File>::drop(&mut self._file)
+        };
+    }
+}
+
+impl CudaContext {
     /// Import external memory from a [`File`].
     ///
     /// # Safety
@@ -32,46 +69,24 @@ impl CudaDevice {
         Ok(ExternalMemory {
             external_memory,
             size,
-            device: self.clone(),
+            ctx: self.clone(),
             _file: ManuallyDrop::new(file),
         })
     }
 }
 
-/// An abstraction for imported external memory.
-///
-/// This struct can be created via [`CudaDevice::import_external_memory`].
-/// The imported external memory will be destroyed when this struct is dropped.
-#[derive(Debug)]
-pub struct ExternalMemory {
-    external_memory: sys::CUexternalMemory,
-    size: u64,
-    device: Arc<CudaDevice>,
-    _file: ManuallyDrop<File>,
-}
-
-impl Drop for ExternalMemory {
-    fn drop(&mut self) {
-        self.device.bind_to_thread().unwrap();
-
-        unsafe { result::external_memory::destroy_external_memory(self.external_memory) }.unwrap();
-
-        // From [CUDA docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXTRES__INTEROP.html#group__CUDA__EXTRES__INTEROP_1g52aba3a7f780157d8ba12972b2481735),
-        // when successfully importing UNIX file descriptor:
-        //
-        // > Ownership of the file descriptor is transferred to the CUDA driver when the handle is imported successfully.
-        // > Performing any operations on the file descriptor after it is imported results in undefined behavior.
-        //
-        // On the other hand, on Windows:
-        //
-        // > Ownership of this handle is not transferred to CUDA after the import operation,
-        // > so the application must release the handle using the appropriate system call.
-        //
-        // Therefore, we manually drop the file when we are on Windows.
-        #[cfg(windows)]
-        unsafe {
-            ManuallyDrop::<File>::drop(&mut self._file)
-        };
+impl CudaDevice {
+    /// Import external memory from a [`File`].
+    ///
+    /// # Safety
+    /// `size` must be the size of the external memory in bytes.
+    #[cfg(any(unix, windows))]
+    pub unsafe fn import_external_memory(
+        self: &Arc<Self>,
+        file: File,
+        size: u64,
+    ) -> Result<ExternalMemory, DriverError> {
+        self.stream.ctx.import_external_memory(file, size)
     }
 }
 
@@ -101,10 +116,14 @@ impl ExternalMemory {
                 range.len() as u64,
             )
         }?;
+        let event = self.ctx.empty_event(None)?;
+        let stream = self.ctx.default_stream();
         Ok(MappedBuffer {
             device_ptr,
             len: range.len(),
             external_memory: self,
+            event,
+            stream,
         })
     }
 }
@@ -118,11 +137,13 @@ pub struct MappedBuffer {
     device_ptr: sys::CUdeviceptr,
     len: usize,
     external_memory: ExternalMemory,
+    event: CudaEvent,
+    stream: Arc<CudaStream>,
 }
 
 impl Drop for MappedBuffer {
     fn drop(&mut self) {
-        self.external_memory.device.bind_to_thread().unwrap();
+        self.external_memory.ctx.bind_to_thread().unwrap();
         unsafe { result::memory_free(self.device_ptr) }.unwrap()
     }
 }
@@ -130,6 +151,15 @@ impl Drop for MappedBuffer {
 impl DeviceSlice<u8> for MappedBuffer {
     fn len(&self) -> usize {
         self.len
+    }
+    fn cu_device_ptr(&self) -> sys::CUdeviceptr {
+        self.device_ptr
+    }
+    fn event(&self) -> &CudaEvent {
+        &self.event
+    }
+    fn stream(&self) -> &CudaStream {
+        &self.stream
     }
 }
 

--- a/src/driver/safe/host_slice.rs
+++ b/src/driver/safe/host_slice.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, vec::Vec};
 
 use super::{CudaContext, CudaEvent, CudaStream, DeviceRepr, DriverError, ValidAsZeroBits};
 

--- a/src/driver/safe/host_slice.rs
+++ b/src/driver/safe/host_slice.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use super::{CudaContext, CudaEvent, CudaStream, DeviceRepr, DriverError, ValidAsZeroBits};
+
+use crate::driver::{result, sys};
+
+pub trait HostSlice<T> {
+    unsafe fn stream_synced_slice(&self, stream: &CudaStream) -> Result<&[T], DriverError>;
+    unsafe fn stream_synced_mut_slice(
+        &mut self,
+        stream: &CudaStream,
+    ) -> Result<&mut [T], DriverError>;
+    fn record_use(&self, stream: &CudaStream) -> Result<(), DriverError>;
+}
+
+impl<T> HostSlice<T> for [T] {
+    unsafe fn stream_synced_slice(&self, _stream: &CudaStream) -> Result<&[T], DriverError> {
+        Ok(self)
+    }
+    unsafe fn stream_synced_mut_slice(
+        &mut self,
+        _stream: &CudaStream,
+    ) -> Result<&mut [T], DriverError> {
+        Ok(self)
+    }
+    fn record_use(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        stream.synchronize()
+    }
+}
+
+impl<T> HostSlice<T> for Vec<T> {
+    unsafe fn stream_synced_slice(&self, _stream: &CudaStream) -> Result<&[T], DriverError> {
+        Ok(self)
+    }
+    unsafe fn stream_synced_mut_slice(
+        &mut self,
+        _stream: &CudaStream,
+    ) -> Result<&mut [T], DriverError> {
+        Ok(self)
+    }
+    fn record_use(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        stream.synchronize()
+    }
+}
+
+#[derive(Debug)]
+pub struct PinnedHostSlice<T> {
+    pub(crate) ptr: *mut T,
+    pub(crate) len: usize,
+    pub(crate) event: CudaEvent,
+}
+
+impl<T> Drop for PinnedHostSlice<T> {
+    fn drop(&mut self) {
+        self.event.synchronize().unwrap();
+        unsafe { result::free_host(self.ptr as _) }.unwrap();
+    }
+}
+
+impl CudaContext {
+    pub unsafe fn alloc_pinned<T: DeviceRepr>(
+        self: &Arc<Self>,
+        len: usize,
+    ) -> Result<PinnedHostSlice<T>, DriverError> {
+        self.bind_to_thread()?;
+        let ptr = result::malloc_host(
+            len * std::mem::size_of::<T>(),
+            sys::CU_MEMHOSTALLOC_WRITECOMBINED,
+        )?;
+        let event = self.empty_event(None)?;
+        Ok(PinnedHostSlice::new(ptr as _, len, event))
+    }
+}
+
+impl<T> PinnedHostSlice<T> {
+    /// Creates a new pinned host slice.
+    ///
+    /// # Safety
+    /// 1. `ptr` should be returned from [result::malloc_host()].
+    pub unsafe fn new(ptr: *mut T, len: usize, event: CudaEvent) -> Self {
+        assert!(!ptr.is_null());
+        assert!(len * std::mem::size_of::<T>() < isize::MAX as usize);
+        assert!(ptr.is_aligned());
+        Self { ptr, len, event }
+    }
+
+    pub fn context(&self) -> &Arc<CudaContext> {
+        &self.event.ctx
+    }
+
+    /// The size of the slice
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<T: ValidAsZeroBits> PinnedHostSlice<T> {
+    /// Waits for any scheduled work to complete and then returns a refernce
+    /// to the host side data.
+    pub fn as_ptr(&self) -> Result<*const T, DriverError> {
+        self.event.synchronize()?;
+        Ok(self.ptr)
+    }
+
+    /// Waits for any scheduled work to complete and then returns a refernce
+    /// to the host side data.
+    pub fn as_mut_ptr(&mut self) -> Result<*mut T, DriverError> {
+        self.event.synchronize()?;
+        Ok(self.ptr)
+    }
+
+    /// Waits for any scheduled work to complete and then returns a refernce
+    /// to the host side data.
+    pub fn as_slice(&self) -> Result<&[T], DriverError> {
+        self.event.synchronize()?;
+        Ok(unsafe { std::slice::from_raw_parts(self.ptr, self.len) })
+    }
+
+    /// Waits for any scheduled work to complete and then returns a refernce
+    /// to the host side data.
+    pub fn as_mut_slice(&mut self) -> Result<&mut [T], DriverError> {
+        self.event.synchronize()?;
+        Ok(unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) })
+    }
+}
+
+impl<T> HostSlice<T> for PinnedHostSlice<T> {
+    unsafe fn stream_synced_slice(&self, stream: &CudaStream) -> Result<&[T], DriverError> {
+        stream.wait(&self.event)?;
+        Ok(std::slice::from_raw_parts(self.ptr, self.len))
+    }
+
+    unsafe fn stream_synced_mut_slice(
+        &mut self,
+        stream: &CudaStream,
+    ) -> Result<&mut [T], DriverError> {
+        stream.wait(&self.event)?;
+        Ok(std::slice::from_raw_parts_mut(self.ptr, self.len))
+    }
+
+    fn record_use(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        self.event.record(stream)
+    }
+}

--- a/src/driver/safe/host_slice.rs
+++ b/src/driver/safe/host_slice.rs
@@ -13,6 +13,23 @@ pub trait HostSlice<T> {
     fn record_use(&self, stream: &CudaStream) -> Result<(), DriverError>;
 }
 
+impl<T, const N: usize> HostSlice<T> for [T; N] {
+    unsafe fn stream_synced_slice(&self, _stream: &CudaStream) -> Result<&[T], DriverError> {
+        Ok(self)
+    }
+
+    unsafe fn stream_synced_mut_slice(
+        &mut self,
+        _stream: &CudaStream,
+    ) -> Result<&mut [T], DriverError> {
+        Ok(self)
+    }
+
+    fn record_use(&self, stream: &CudaStream) -> Result<(), DriverError> {
+        stream.synchronize()
+    }
+}
+
 impl<T> HostSlice<T> for [T] {
     unsafe fn stream_synced_slice(&self, _stream: &CudaStream) -> Result<&[T], DriverError> {
         Ok(self)

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -1,3 +1,5 @@
+use std::vec::Vec;
+
 use crate::driver::{
     result::{self, DriverError},
     sys,

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -74,7 +74,7 @@ pub unsafe trait PushKernelArg<T> {
     fn arg(&mut self, arg: T) -> &mut Self;
 }
 
-unsafe impl<'a, 'b: 'a, T: DeviceRepr> PushKernelArg<T> for LaunchArgs<'a> {
+unsafe impl<T: DeviceRepr> PushKernelArg<T> for LaunchArgs<'_> {
     #[inline(always)]
     fn arg(&mut self, arg: T) -> &mut Self {
         self.args.push((&arg) as *const _ as *mut _);
@@ -218,7 +218,7 @@ impl<'a> LaunchArgs<'a> {
             self.stream.wait(event)?;
         }
         if let Some(event) = self.start_event {
-            event.record(&self.stream)?;
+            event.record(self.stream)?;
         }
         result::launch_kernel(
             self.func.cu_function,
@@ -229,7 +229,7 @@ impl<'a> LaunchArgs<'a> {
             &mut self.args,
         )?;
         if let Some(event) = self.end_event {
-            event.record(&self.stream)?;
+            event.record(self.stream)?;
         }
         for &event in self.records.iter() {
             event.record(self.stream)?;
@@ -248,7 +248,7 @@ impl<'a> LaunchArgs<'a> {
             self.stream.wait(event)?;
         }
         if let Some(event) = self.start_event {
-            event.record(&self.stream)?;
+            event.record(self.stream)?;
         }
         result::launch_cooperative_kernel(
             self.func.cu_function,
@@ -259,7 +259,7 @@ impl<'a> LaunchArgs<'a> {
             &mut self.args,
         )?;
         if let Some(event) = self.end_event {
-            event.record(&self.stream)?;
+            event.record(self.stream)?;
         }
         for &event in self.records.iter() {
             event.record(self.stream)?;

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -126,7 +126,7 @@ unsafe impl<'a, 'b: 'a, 'c: 'b, T> PushKernelArg<&'b mut CudaViewMut<'c, T>> for
     }
 }
 
-impl<'a> LaunchArgs<'a> {
+impl LaunchArgs<'_> {
     pub fn record_kernel_launch(&mut self, flags: sys::CUevent_flags) -> &mut Self {
         self.flags = Some(flags);
         self

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -17,7 +17,7 @@ pub use self::core::{
 };
 pub use self::device_ptr::{DevicePtr, DevicePtrMut, DeviceSlice};
 pub use self::external_memory::{ExternalMemory, MappedBuffer};
-pub use self::launch::{AsLaunchParam, LaunchConfig};
+pub use self::launch::{LaunchArgs, LaunchConfig, PushKernelArg};
 pub use self::profile::{profiler_start, profiler_stop, Profiler};
 pub use host_slice::{HostSlice, PinnedHostSlice};
 

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod alloc;
 pub(crate) mod core;
 pub(crate) mod device_ptr;
 pub(crate) mod external_memory;
+pub(crate) mod host_slice;
 pub(crate) mod launch;
 pub(crate) mod profile;
 pub(crate) mod ptx;
@@ -11,11 +12,13 @@ pub(crate) mod threading;
 
 pub use self::alloc::{DeviceRepr, ValidAsZeroBits};
 pub use self::core::{
-    CudaDevice, CudaFunction, CudaSlice, CudaStream, CudaView, CudaViewMut, PinnedHostSlice,
+    CudaContext, CudaDevice, CudaEvent, CudaFunction, CudaModule, CudaSlice, CudaStream, CudaView,
+    CudaViewMut,
 };
 pub use self::device_ptr::{DevicePtr, DevicePtrMut, DeviceSlice};
 pub use self::external_memory::{ExternalMemory, MappedBuffer};
-pub use self::launch::{LaunchAsync, LaunchConfig};
+pub use self::launch::{AsLaunchParam, LaunchConfig};
 pub use self::profile::{profiler_start, profiler_stop, Profiler};
+pub use host_slice::{HostSlice, PinnedHostSlice};
 
 pub use crate::driver::result::DriverError;

--- a/src/driver/safe/threading.rs
+++ b/src/driver/safe/threading.rs
@@ -1,12 +1,10 @@
 use super::{CudaDevice, DriverError};
 
-use crate::driver::result;
-
 impl CudaDevice {
     /// Binds the device to the calling thread. You must call this before
     /// using the device on a separate thread!
     pub fn bind_to_thread(&self) -> Result<(), DriverError> {
-        unsafe { result::ctx::set_current(self.cu_primary_ctx) }
+        self.stream.ctx.bind_to_thread()
     }
 }
 

--- a/src/nccl/result.rs
+++ b/src/nccl/result.rs
@@ -355,7 +355,7 @@ mod tests {
             devs.push(dev);
         }
         let mut comms = vec![std::ptr::null_mut(); n_devices];
-        let ordinals: Vec<_> = devs.iter().map(|d| d.ordinal as i32).collect();
+        let ordinals: Vec<_> = devs.iter().map(|d| d.ordinal() as i32).collect();
         unsafe {
             comm_init_all(comms.as_mut_ptr(), n_devices as i32, ordinals.as_ptr()).unwrap();
 
@@ -370,7 +370,7 @@ mod tests {
                     sys::ncclDataType_t::ncclFloat32,
                     sys::ncclRedOp_t::ncclSum,
                     comms[i],
-                    dev.stream as sys::cudaStream_t,
+                    dev.stream.cu_stream as sys::cudaStream_t,
                 )
                 .unwrap();
             }
@@ -410,7 +410,7 @@ mod tests {
                             sys::ncclDataType_t::ncclFloat32,
                             sys::ncclRedOp_t::ncclSum,
                             comm,
-                            dev.stream as sys::cudaStream_t,
+                            dev.stream.cu_stream as sys::cudaStream_t,
                         )
                         .unwrap();
                     }

--- a/src/nccl/safe.rs
+++ b/src/nccl/safe.rs
@@ -114,7 +114,7 @@ impl Comm {
     pub fn from_devices(devices: Vec<Arc<CudaDevice>>) -> Result<Vec<Self>, result::NcclError> {
         let n_devices = devices.len();
         let mut comms = vec![std::ptr::null_mut(); n_devices];
-        let ordinals: Vec<_> = devices.iter().map(|d| d.ordinal as i32).collect();
+        let ordinals: Vec<_> = devices.iter().map(|d| d.ordinal() as i32).collect();
         unsafe {
             result::comm_init_all(comms.as_mut_ptr(), n_devices as i32, ordinals.as_ptr())?;
         }
@@ -213,7 +213,7 @@ impl Comm {
                 T::as_nccl_type(),
                 peer,
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )?;
         }
         Ok(())
@@ -231,7 +231,7 @@ impl Comm {
                 T::as_nccl_type(),
                 peer,
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )
         }
     }
@@ -262,7 +262,7 @@ impl Comm {
                 T::as_nccl_type(),
                 root,
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )
         }
     }
@@ -282,7 +282,7 @@ impl Comm {
                 T::as_nccl_type(),
                 root,
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )
         }
     }
@@ -300,7 +300,7 @@ impl Comm {
                 sendbuff.len(),
                 T::as_nccl_type(),
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )
         }
     }
@@ -320,7 +320,7 @@ impl Comm {
                 T::as_nccl_type(),
                 convert_to_nccl_reduce_op(reduce_op),
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )
         }
     }
@@ -340,7 +340,7 @@ impl Comm {
                 T::as_nccl_type(),
                 convert_to_nccl_reduce_op(reduce_op),
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )
         }
     }
@@ -372,7 +372,7 @@ impl Comm {
                 convert_to_nccl_reduce_op(reduce_op),
                 root,
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )
         }
     }
@@ -394,7 +394,7 @@ impl Comm {
                 convert_to_nccl_reduce_op(reduce_op),
                 root,
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )
         }
     }
@@ -414,7 +414,7 @@ impl Comm {
                 T::as_nccl_type(),
                 convert_to_nccl_reduce_op(reduce_op),
                 self.comm,
-                self.device.stream as *mut _,
+                self.device.stream.cu_stream as *mut _,
             )
         }
     }


### PR DESCRIPTION
Follow up to #335 

Resolves #340
Resolves #314 

# Breaking API changes

- Add new methods to `trait DeviceSlice`
- Remove `trait LaunchAsync`, see sections below for new launch API.
- Remove implementations of `DeviceRepr` for `&CudaSlice`, `&mut CudaSlice`, `&CudaView`, `&mut CudaViewMut`. These have been replaced with implementations of `AsLaunchParam`.
- Remove `CudaSlice::device()`. Replaced with `CudaSlice::ordinal()` and `CudaSlice::context()`
- `CudaFunction::occupancy_max_active_clusters()` and `CudaFunction::occupancy_max_potential_cluster_size()` now require a `&CudaStream` argument
- Remove field `CudaStream.stream`. Replaced with `CudaStream.cu_stream()`

# TODOs

- [ ] Update & add new documentation
- [x] Add unit tests for multi stream use cases
    - [x] test we can read a slice concurrently from multiple streams
    - [x] test that any writes will properly block multiple streams
- [x] Update examples
- [ ] Do proper stream synchronization in other libraries (cublas/cublaslt/cudnn/curand/nccl)

# Background

Currently there's no way to have an existing CudaDevice use a separate CudaStream for things like allocation/memcpy/memset operations. There's CudaDevice::new_with_stream, but that won't share any loaded kernels that had been previously loaded.

Additionally, the current LaunchAsync trait is a bit too complicated and only supports a small number of compile time arguments.

Further, currently using multiple streams is very unsound/unsafe, because CudaSlices don't do any syncing between streams.

# API Changes

## CudaContext

This is now the lowest level struct that all other structs keep an `Arc` reference to. It has pretty much all of the methods that `CudaDevice` has, except for allocation/etc.

## CudaEvent

CudaEvent is now the main way synchronization between multiple streams is done. Create one using a CudaContext, and you can pretty much do what you expect with a CudaEvent.

- Add `CudaContext::empty_event()`
- Add `CudaStream::record_event()`
- Add `CudaEvent::record()`
- Add `CudaEvent::synchronize()`
- Add `CudaEvent::elapsed_ms()`
- Add `CudaEvent::is_complete()`

## CudaStream

- Add `CudaContext::new_stream()`
- Add `CudaStream::fork()`
- Add `CudaStream::wait()` which lets you wait on an event

### Allocations/Copies

CudaStream now has methods for alloc/memcpy/memset. Eventually we will deprecate using CudaDevice at all.

- Add `CudaStream::null()`
- Add `CudaStream::alloc()`
- Add `CudaStream::alloc_zeros()`
- Add `CudaStream::memset_zeros()`
- Add `CudaStream::memcpy_vtod()` - for copying `Vec<T>` to `CudaSlice<T>`
- Add `CudaStream::memcpy_htod()` - for copying host slices (`&[T]`, `&PinnedHostSlice<T>`, `&Vec<T>`) into existing `CudaSlice<T>`
- Add `CudaStream::memcpy_dtov()` - for copying `CudaSlice<T>` to `Vec<T>`
- Add `CudaStream::memcpy_dtoh()` - for copying `CudaSlice<T>` into host slices (`&mut [T]`, `&mut PinnedHostSlice<T>`, `&mut Vec<T>`)
- Add `CudaStream::memcpy_dtod()` - for copying between `CudaSlice<T>`

### New Kernel launching API

The new api is a builder pattern:

```rust
let f: CudaFunction = ...;
let cfg: LaunchConfig = ...;
let src: CudaSlice<T> = ...;
let mut dst = CudaSlice<T> = ...;
stream.launch_builder(&f)
    .arg(src.len())
    .arg(&src)
    .arg(&mut dst)
    .launch(cfg)
```

- Add `CudaStream::launch_builder(CudaFunction) -> LaunchArgs`
- Add `LaunchArgs::arg()` which pushes an argument (CudaSlice/CudaView/CudaViewMut/rust scalar value)
- Add `LaunchArgs::launch()`
- Add `LaunchArgs::launch_cooperative()`
- Add `trait PushKernelArg` replacing the use of `DeviceRepr` in launching.

Now we can:
1. easily pass any number of arguments without using tuples.
2. Easily specify what stream to launch on

## CudaDevice

This is what CudaDevice looks like now:

```rust
#[derive(Debug)]
pub struct CudaDevice {
    pub(crate) stream: Arc<CudaStream>,
    pub(crate) modules: RwLock<BTreeMap<String, Arc<CudaModule>>>,
}
```

So the difference is that CudaDevice is a stream and a set of loaded modules. After this PR, all `CudaDevice` calls just call `self.stream.<method>()`.

**The future intent is to remove CudaDevice and have the user just hold a `Arc<CudaStream>` instead and manage their `Arc<CudaModule>` themselves.**

## CudaSlice

This is more of an internal change, but figured I'd write about it here. CudaSlice/CudaView/CudaViewMut's now maintain three additional fields:

1. `stream: Arc<CudaStream>` - the stream that it was allocated on, and will be dropped on. Also contains the context it's in.
2. `read: CudaEvent` - an event that records any reads
3. `write: CudaEvent` - an event that records any writes

All stream apis that use CudaSlice/CudaView/CudaViewMut will now do two things:
1. Call either `DevicePtr::block_for_read()` or `DevicePtrMut::block_for_write()` to make sure the stream waits properly for other streams.
2. At the end call either `DevicePtr::record_read()` or `DevicePtrMut::record_write()`.

