### PR TITLE
[Breaking] nccl::Comm now constructed with CudaStream

### DIFF
--- a/examples/02-copy.rs
+++ b/examples/02-copy.rs
@@ -1,4 +1,4 @@
-use cudarc::driver::{CudaContext, CudaSlice, DriverError};
+use cudarc::driver::{CudaContext, CudaSlice, DeviceSlice, DriverError};
 
 fn main() -> Result<(), DriverError> {
     let ctx = CudaContext::new(0)?;
@@ -11,7 +11,7 @@ fn main() -> Result<(), DriverError> {
     stream.memcpy_dtod(&a, &mut b)?;
 
     // but also host to device copys with already allocated buffers
-    stream.memcpy_htod(&vec![2.0; 10], &mut b)?;
+    stream.memcpy_htod(&vec![2.0; b.len()], &mut b)?;
     // you can use any type of slice
     stream.memcpy_htod(&[3.0; 10], &mut b)?;
 


### PR DESCRIPTION
Follow up to #341 

This is for two main reasons:
1. To align all the libraries to utilize the same API (all of them are moving to construction with streams)
2. To make it clear what stream the Comm object operates on
3. To enable Comm to operate on a separate stream
4. To increase the soundness of multi stream operations with slices/views.

This PR adds ptr.block_for_read/write and ptr.record_read/write calls in all the NCCL apis.