### PR TITLE
[Breaking] CudaBlas constructor requires CudaStream

### DIFF
--- a/examples/01-allocate.rs
+++ b/examples/01-allocate.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), DriverError> {
     let _: CudaSlice<f64> = stream.alloc_zeros::<f64>(10)?;
 
     // initialize with slices!
-    let _: CudaSlice<usize> = stream.memcpy_stod(&vec![0; 10])?;
+    let _: CudaSlice<usize> = stream.memcpy_stod(&[0; 10])?;
     let _: CudaSlice<u32> = stream.memcpy_stod(&[1, 2, 3])?;
 
     Ok(())


### PR DESCRIPTION
Follow up to https://github.com/coreylowman/cudarc/pull/341

- [Breaking] CudaBlas::new() now requires `Arc<CudaStream>` instead of `Arc<CudaDevice>`
- [Breaking] CudaBlas::set_stream() arguments changed to `set_stream(&mut self, stream: Arc<CudaStream>)`

This is for two main reasons:

- To align all the libraries to utilize the same API (all of them are moving to construction with streams)
- To make it clear what stream the CudaBlas object operates on
- To enable CudaBlas to operate on a separate stream
- To increase the soundness of multi stream operations with slices/views.

This PR adds ptr.block_for_read/write and ptr.record_read/write calls in all the cublas apis.

