### PR TITLE
[Breaking] Cudnn now requires CUdaStream in constructor

### DIFF
--- a/src/cudnn/safe/activation.rs
+++ b/src/cudnn/safe/activation.rs
@@ -63,6 +63,8 @@ where
         Src: DevicePtr<A>,
         Dst: DevicePtrMut<A>,
     {
+        x.block_for_read(&self.act.handle.stream).unwrap();
+        y.block_for_write(&self.act.handle.stream).unwrap();
         let alpha = alpha.into_scaling_parameter();
         let beta = beta.into_scaling_parameter();
         result::activation_forward(
@@ -74,6 +76,9 @@ where
             (&beta) as *const Y::Scalar as *const std::ffi::c_void,
             self.y.desc,
             *y.device_ptr_mut() as *mut Y as *mut std::ffi::c_void,
-        )
+        )?;
+        x.record_read(&self.act.handle.stream).unwrap();
+        y.record_write(&self.act.handle.stream).unwrap();
+        Ok(())
     }
 }

--- a/src/cudnn/safe/mod.rs
+++ b/src/cudnn/safe/mod.rs
@@ -46,13 +46,15 @@ pub use activation::{ActivationDescriptor, ActivationForward};
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{cudnn, driver::CudaDevice};
+    use crate::{cudnn, driver::CudaContext};
     #[cfg(feature = "no-std")]
     use no_std_compat::vec;
 
     #[test]
     fn test_create_descriptors() -> Result<(), CudnnError> {
-        let cudnn = Cudnn::new(CudaDevice::new(0).unwrap())?;
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let cudnn = Cudnn::new(stream)?;
         let _ = cudnn.create_4d_tensor_ex::<f32>([1, 2, 3, 4], [24, 12, 4, 1])?;
         let _ = cudnn.create_nd_tensor::<f64>(&[1, 2, 3, 4, 5, 6], &[720, 360, 120, 30, 6, 1])?;
         let _ = cudnn.create_4d_filter::<f32>(
@@ -72,7 +74,9 @@ mod tests {
 
     #[test]
     fn test_conv2d_pick_algorithms() -> Result<(), CudnnError> {
-        let cudnn = Cudnn::new(CudaDevice::new(0).unwrap())?;
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let cudnn = Cudnn::new(stream)?;
 
         let conv = cudnn.create_conv2d::<f32>(
             [0; 2],
@@ -140,8 +144,9 @@ mod tests {
 
     #[test]
     fn test_conv1d() -> Result<(), CudnnError> {
-        let dev = CudaDevice::new(0).unwrap();
-        let cudnn = Cudnn::new(dev.clone())?;
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let cudnn = Cudnn::new(stream.clone())?;
 
         let conv = cudnn.create_convnd::<f32>(
             &[0; 2],
@@ -153,17 +158,17 @@ mod tests {
         // dimensions
 
         // Create input, filter and output tensors
-        let x = dev.htod_copy(vec![1.0f32; 100 * 128 * 32]).unwrap();
+        let x = stream.memcpy_stod(&vec![1.0f32; 100 * 128 * 32]).unwrap();
         let x_desc = cudnn.create_4d_tensor::<f32>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             [100, 128, 32, 1],
         )?;
-        let filter = dev.htod_copy(vec![1.0f32; 256 * 128 * 3]).unwrap();
+        let filter = stream.memcpy_stod(&vec![1.0f32; 256 * 128 * 3]).unwrap();
         let filter_desc = cudnn.create_nd_filter::<f32>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             &[256, 128, 3, 1],
         )?;
-        let mut y = dev.alloc_zeros::<f32>(100 * 256 * 30).unwrap();
+        let mut y = stream.alloc_zeros::<f32>(100 * 256 * 30).unwrap();
         let y_desc = cudnn.create_4d_tensor::<f32>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             [100, 256, 30, 1],
@@ -184,14 +189,14 @@ mod tests {
 
             // Get workspace size
             let workspace_size = op.get_workspace_size(algo)?;
-            let mut workspace = dev.alloc_zeros::<u8>(workspace_size).unwrap();
+            let mut workspace = stream.alloc_zeros::<u8>(workspace_size).unwrap();
 
             // Launch conv operation
             unsafe {
                 op.launch(algo, Some(&mut workspace), (1.0, 0.0), &x, &filter, &mut y)?;
             }
 
-            let y_host = dev.sync_reclaim(y).unwrap();
+            let y_host = stream.memcpy_dtov(&y).unwrap();
             assert_eq!(y_host.len(), 100 * 256 * 30);
             assert_eq!(y_host[0], 128.0 * 3.0);
         }
@@ -201,8 +206,9 @@ mod tests {
 
     #[test]
     fn test_conv3d() -> Result<(), CudnnError> {
-        let dev = CudaDevice::new(0).unwrap();
-        let cudnn = Cudnn::new(dev.clone())?;
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let cudnn = Cudnn::new(stream.clone())?;
 
         let conv = cudnn.create_convnd::<f32>(
             &[0; 3],
@@ -212,17 +218,21 @@ mod tests {
         )?;
 
         // Create input, filter and output tensors
-        let x = dev.htod_copy(vec![1.0f32; 32 * 3 * 64 * 64 * 64]).unwrap();
+        let x = stream
+            .memcpy_stod(&vec![1.0f32; 32 * 3 * 64 * 64 * 64])
+            .unwrap();
         let x_desc = cudnn.create_nd_tensor::<f32>(
             &[32, 3, 64, 64, 64],
             &[3 * 64 * 64 * 64, 64 * 64 * 64, 64 * 64, 64, 1],
         )?;
-        let filter = dev.htod_copy(vec![1.0f32; 32 * 3 * 4 * 4 * 4]).unwrap();
+        let filter = stream
+            .memcpy_stod(&vec![1.0f32; 32 * 3 * 4 * 4 * 4])
+            .unwrap();
         let filter_desc = cudnn.create_nd_filter::<f32>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             &[32, 3, 4, 4, 4],
         )?;
-        let mut y = dev.alloc_zeros::<f32>(32 * 32 * 61 * 61 * 61).unwrap();
+        let mut y = stream.alloc_zeros::<f32>(32 * 32 * 61 * 61 * 61).unwrap();
         let y_desc = cudnn.create_nd_tensor::<f32>(
             &[32, 32, 61, 61, 61],
             &[32 * 61 * 61 * 61, 61 * 61 * 61, 61 * 61, 61, 1],
@@ -241,14 +251,14 @@ mod tests {
 
             // Get workspace size
             let workspace_size = op.get_workspace_size(algo)?;
-            let mut workspace = dev.alloc_zeros::<u8>(workspace_size).unwrap();
+            let mut workspace = stream.alloc_zeros::<u8>(workspace_size).unwrap();
 
             // Launch conv operation
             unsafe {
                 op.launch(algo, Some(&mut workspace), (1.0, 0.0), &x, &filter, &mut y)?;
             }
 
-            let y_host = dev.sync_reclaim(y).unwrap();
+            let y_host = stream.memcpy_dtov(&y).unwrap();
             assert_eq!(y_host.len(), 32 * 32 * 61 * 61 * 61);
             assert_eq!(y_host[0], 3.0 * 4.0 * 4.0 * 4.0);
         }
@@ -258,13 +268,14 @@ mod tests {
 
     #[test]
     fn test_reduction() {
-        let dev = CudaDevice::new(0).unwrap();
-        let a = dev
-            .htod_copy(std::vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0])
-            .unwrap();
-        let mut c = dev.alloc_zeros::<f32>(1).unwrap();
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let cudnn = Cudnn::new(stream.clone()).unwrap();
 
-        let cudnn = Cudnn::new(dev.clone()).unwrap();
+        let a = stream
+            .memcpy_stod(&std::vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+        let mut c = stream.alloc_zeros::<f32>(1).unwrap();
 
         let reduce = cudnn
             .create_reduction_no_indices::<f32>(
@@ -285,19 +296,20 @@ mod tests {
         };
 
         let workspace_size = op.get_workspace_size().unwrap();
-        let mut workspace = dev.alloc_zeros::<u8>(workspace_size).unwrap();
+        let mut workspace = stream.alloc_zeros::<u8>(workspace_size).unwrap();
 
         unsafe { op.launch(&mut workspace, (1.0, 0.0), &a, &mut c) }.unwrap();
 
-        let c_host = dev.sync_reclaim(c).unwrap();
+        let c_host = stream.memcpy_dtov(&c).unwrap();
         assert_eq!(c_host.len(), 1);
         assert_eq!(c_host[0], 21.0);
     }
 
     #[test]
     fn test_conv_bias_activation() -> Result<(), CudnnError> {
-        let dev = CudaDevice::new(0).unwrap();
-        let cudnn = Cudnn::new(dev.clone())?;
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let cudnn = Cudnn::new(stream.clone())?;
 
         let conv = cudnn.create_convnd::<f32>(
             &[0; 3],
@@ -307,29 +319,35 @@ mod tests {
         )?;
 
         // Create input, filter and output tensors
-        let x = dev.htod_copy(vec![1.0f32; 32 * 3 * 64 * 64 * 64]).unwrap();
+        let x = stream
+            .memcpy_stod(&vec![1.0f32; 32 * 3 * 64 * 64 * 64])
+            .unwrap();
         let x_desc = cudnn.create_nd_tensor::<f32>(
             &[32, 3, 64, 64, 64],
             &[3 * 64 * 64 * 64, 64 * 64 * 64, 64 * 64, 64, 1],
         )?;
-        let filter = dev.htod_copy(vec![1.0f32; 32 * 3 * 4 * 4 * 4]).unwrap();
+        let filter = stream
+            .memcpy_stod(&vec![1.0f32; 32 * 3 * 4 * 4 * 4])
+            .unwrap();
         let filter_desc = cudnn.create_nd_filter::<f32>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             &[32, 3, 4, 4, 4],
         )?;
-        let bias = dev.htod_copy(vec![1.0f32; 32]).unwrap();
+        let bias = stream.memcpy_stod(&vec![1.0f32; 32]).unwrap();
         let bias_desc = cudnn.create_nd_tensor::<f32>(&[1, 32, 1, 1, 1], &[32, 1, 1, 1, 1])?;
         let activation_desc = cudnn.create_activation::<f32>(
             cudnn::sys::cudnnActivationMode_t::CUDNN_ACTIVATION_RELU,
             cudnn::sys::cudnnNanPropagation_t::CUDNN_NOT_PROPAGATE_NAN,
             f64::MAX,
         )?;
-        let z = dev.htod_copy(vec![0.0f32; 32 * 32 * 61 * 61 * 61]).unwrap();
+        let z = stream
+            .memcpy_stod(&vec![0.0f32; 32 * 32 * 61 * 61 * 61])
+            .unwrap();
         let z_desc = cudnn.create_nd_tensor::<f32>(
             &[32, 32, 61, 61, 61],
             &[32 * 61 * 61 * 61, 61 * 61 * 61, 61 * 61, 61, 1],
         )?;
-        let mut y = dev.alloc_zeros::<f32>(32 * 32 * 61 * 61 * 61).unwrap();
+        let mut y = stream.alloc_zeros::<f32>(32 * 32 * 61 * 61 * 61).unwrap();
         let y_desc = cudnn.create_nd_tensor::<f32>(
             &[32, 32, 61, 61, 61],
             &[32 * 61 * 61 * 61, 61 * 61 * 61, 61 * 61, 61, 1],
@@ -351,7 +369,7 @@ mod tests {
 
             // Get workspace size
             let workspace_size = op.get_workspace_size(algo)?;
-            let mut workspace = dev.alloc_zeros::<u8>(workspace_size).unwrap();
+            let mut workspace = stream.alloc_zeros::<u8>(workspace_size).unwrap();
 
             // Launch conv operation
             unsafe {
@@ -367,7 +385,7 @@ mod tests {
                 )?;
             }
 
-            let y_host = dev.sync_reclaim(y).unwrap();
+            let y_host = stream.memcpy_dtov(&y).unwrap();
             assert_eq!(y_host.len(), 32 * 32 * 61 * 61 * 61);
             assert_eq!(y_host[0], 3.0 * 4.0 * 4.0 * 4.0 + 1.0);
         }
@@ -377,8 +395,9 @@ mod tests {
 
     #[test]
     fn test_pooling() -> Result<(), CudnnError> {
-        let dev = CudaDevice::new(0).unwrap();
-        let cudnn = Cudnn::new(dev.clone())?;
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let cudnn = Cudnn::new(stream.clone())?;
 
         let pooling = cudnn.create_poolingnd::<f32>(
             &[2, 2],
@@ -389,13 +408,13 @@ mod tests {
         )?;
 
         // Create input, filter and output tensors
-        let x = dev
-            .htod_copy(vec![
+        let x = stream
+            .memcpy_stod(&[
                 1.0, 1.0, 2.0, 4.0, 5.0, 6.0, 7.0, 8.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 4.0,
             ])
             .unwrap();
         let x_desc = cudnn.create_nd_tensor::<f32>(&[32, 3, 4, 4], &[32 * 3 * 4, 3 * 4, 4, 1])?;
-        let mut y = dev.alloc_zeros::<f32>(32 * 3 * 2 * 2).unwrap();
+        let mut y = stream.alloc_zeros::<f32>(32 * 3 * 2 * 2).unwrap();
         let y_desc = cudnn.create_nd_tensor::<f32>(&[32, 3, 2, 2], &[3 * 2 * 2, 2 * 2, 2, 1])?;
 
         {
@@ -410,7 +429,7 @@ mod tests {
                 op.launch((1.0, 0.0), &x, &mut y)?;
             }
 
-            let y_host = dev.sync_reclaim(y).unwrap();
+            let y_host = stream.memcpy_dtov(&y).unwrap();
             assert_eq!(y_host.len(), 32 * 3 * 2 * 2);
             assert_eq!(y_host[0], 6.0);
         }
@@ -420,8 +439,9 @@ mod tests {
 
     #[test]
     fn test_activation() -> Result<(), CudnnError> {
-        let dev = CudaDevice::new(0).unwrap();
-        let cudnn = Cudnn::new(dev.clone())?;
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let cudnn = Cudnn::new(stream.clone())?;
 
         let act = cudnn.create_activation::<f32>(
             cudnn::sys::cudnnActivationMode_t::CUDNN_ACTIVATION_RELU,
@@ -430,9 +450,9 @@ mod tests {
         )?;
 
         // Create input, filter and output tensors
-        let x = dev.htod_copy(vec![-1.0, 2.0, -3.0, 100.0]).unwrap();
+        let x = stream.memcpy_stod(&vec![-1.0, 2.0, -3.0, 100.0]).unwrap();
         let x_desc = cudnn.create_nd_tensor::<f32>(&[1, 1, 2, 2], &[2 * 2, 2 * 2, 2, 1])?;
-        let mut y = dev.alloc_zeros::<f32>(4).unwrap();
+        let mut y = stream.alloc_zeros::<f32>(4).unwrap();
         let y_desc = cudnn.create_nd_tensor::<f32>(&[1, 1, 2, 2], &[2 * 2, 2 * 2, 2, 1])?;
 
         {
@@ -447,7 +467,7 @@ mod tests {
                 op.launch((1.0, 0.0), &x, &mut y)?;
             }
 
-            let y_host = dev.sync_reclaim(y).unwrap();
+            let y_host = stream.memcpy_dtov(&y).unwrap();
             assert_eq!(y_host.len(), 2 * 2);
             assert_eq!(y_host[0], 0.0);
             assert_eq!(y_host[1], 2.0);

--- a/src/cudnn/safe/mod.rs
+++ b/src/cudnn/safe/mod.rs
@@ -333,7 +333,7 @@ mod tests {
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             &[32, 3, 4, 4, 4],
         )?;
-        let bias = stream.memcpy_stod(&vec![1.0f32; 32]).unwrap();
+        let bias = stream.memcpy_stod(&[1.0f32; 32]).unwrap();
         let bias_desc = cudnn.create_nd_tensor::<f32>(&[1, 32, 1, 1, 1], &[32, 1, 1, 1, 1])?;
         let activation_desc = cudnn.create_activation::<f32>(
             cudnn::sys::cudnnActivationMode_t::CUDNN_ACTIVATION_RELU,
@@ -450,7 +450,7 @@ mod tests {
         )?;
 
         // Create input, filter and output tensors
-        let x = stream.memcpy_stod(&vec![-1.0, 2.0, -3.0, 100.0]).unwrap();
+        let x = stream.memcpy_stod(&[-1.0, 2.0, -3.0, 100.0]).unwrap();
         let x_desc = cudnn.create_nd_tensor::<f32>(&[1, 1, 2, 2], &[2 * 2, 2 * 2, 2, 1])?;
         let mut y = stream.alloc_zeros::<f32>(4).unwrap();
         let y_desc = cudnn.create_nd_tensor::<f32>(&[1, 1, 2, 2], &[2 * 2, 2 * 2, 2, 1])?;

--- a/src/cudnn/safe/pooling.rs
+++ b/src/cudnn/safe/pooling.rs
@@ -79,6 +79,9 @@ where
         Src: DevicePtr<X>,
         Dst: DevicePtrMut<Y>,
     {
+        let stream = &self.x.handle.stream;
+        src.block_for_read(stream).unwrap();
+        y.block_for_write(stream).unwrap();
         let alpha = alpha.into_scaling_parameter();
         let beta = beta.into_scaling_parameter();
         result::pooling_forward(
@@ -90,6 +93,9 @@ where
             (&beta) as *const Y::Scalar as *const std::ffi::c_void,
             self.y.desc,
             *y.device_ptr_mut() as *mut Y as *mut std::ffi::c_void,
-        )
+        )?;
+        src.record_read(stream).unwrap();
+        y.record_write(stream).unwrap();
+        Ok(())
     }
 }

--- a/src/cudnn/safe/reduce.rs
+++ b/src/cudnn/safe/reduce.rs
@@ -155,6 +155,9 @@ impl<T: CudnnDataType> ReduceTensor<'_, T, FlatIndices> {
         A: DevicePtr<T>,
         C: DevicePtrMut<T>,
     {
+        let stream = &self.a.handle.stream;
+        a.block_for_read(stream).unwrap();
+        c.block_for_write(stream).unwrap();
         result::reduce_tensor(
             self.reduce.handle.handle,
             self.reduce.desc,
@@ -168,7 +171,10 @@ impl<T: CudnnDataType> ReduceTensor<'_, T, FlatIndices> {
             (&beta) as *const T as *const std::ffi::c_void,
             self.c.desc,
             *c.device_ptr_mut() as *mut _,
-        )
+        )?;
+        a.record_read(stream).unwrap();
+        c.record_write(stream).unwrap();
+        Ok(())
     }
 }
 
@@ -190,6 +196,9 @@ impl<T: CudnnDataType> ReduceTensor<'_, T, NoIndices> {
         A: DevicePtr<T>,
         C: DevicePtrMut<T>,
     {
+        let stream = &self.a.handle.stream;
+        a.block_for_read(stream).unwrap();
+        c.block_for_write(stream).unwrap();
         result::reduce_tensor(
             self.reduce.handle.handle,
             self.reduce.desc,
@@ -203,6 +212,9 @@ impl<T: CudnnDataType> ReduceTensor<'_, T, NoIndices> {
             (&beta) as *const T as *const std::ffi::c_void,
             self.c.desc,
             *c.device_ptr_mut() as *mut _,
-        )
+        )?;
+        a.record_read(stream).unwrap();
+        c.record_write(stream).unwrap();
+        Ok(())
     }
 }


### PR DESCRIPTION
- [Breaking] Cudnn::new() now requires `Arc<CudaStream>` instead of `Arc<CudaDevice>`
- [Breaking] Cudnn::set_stream() now looks like `set_stream(&mut self, stream: Arc<CudaStream>)`