### PR TITLE
Remove dependency on `spin` for no-std builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,10 @@ curand = ["driver"]
 nccl = ["driver"]
 
 std = []
-no-std = ["no-std-compat/std", "dep:spin"]
+no-std = ["no-std-compat/std"]
 f16 = ["dep:half"]
 
 [dependencies]
-spin = { version = "0.9.8", optional = true, features = [
-    "rwlock",
-], default-features = false }
 no-std-compat = { version = "0.4.1", optional = true, features = ["alloc"] }
 half = { version = "2.4.1", optional = true, default-features = false, features = [
     "num-traits",

--- a/src/driver/safe/host_slice.rs
+++ b/src/driver/safe/host_slice.rs
@@ -6,6 +6,10 @@ use crate::driver::{result, sys};
 
 pub trait HostSlice<T> {
     fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// # Safety
     /// This is **only** safe if the resulting slice is used with `stream`. Otherwise
     /// You may run into device synchronization errors


### PR DESCRIPTION
Since we've removed `CudaDevice` (#351), and we no longer store modules in `RwLock<BTreeMap<String, CudaModule>>`, we no longer need this dependency on spin.

This was only used in no-std environment