### PR TITLE
[Breaking] Require stream synchronization to access device ptrs

### DIFF
--- a/src/cudnn/safe/activation.rs
+++ b/src/cudnn/safe/activation.rs
@@ -63,8 +63,7 @@ where
         Src: DevicePtr<A>,
         Dst: DevicePtrMut<A>,
     {
-        x.block_for_read(&self.act.handle.stream).unwrap();
-        y.block_for_write(&self.act.handle.stream).unwrap();
+        let stream = &self.act.handle.stream;
         let alpha = alpha.into_scaling_parameter();
         let beta = beta.into_scaling_parameter();
         result::activation_forward(
@@ -72,13 +71,13 @@ where
             self.act.desc,
             (&alpha) as *const Y::Scalar as *const std::ffi::c_void,
             self.x.desc,
-            *x.device_ptr() as *const X as *const std::ffi::c_void,
+            x.device_ptr(stream) as *const X as *const std::ffi::c_void,
             (&beta) as *const Y::Scalar as *const std::ffi::c_void,
             self.y.desc,
-            *y.device_ptr_mut() as *mut Y as *mut std::ffi::c_void,
+            y.device_ptr_mut(stream) as *mut Y as *mut std::ffi::c_void,
         )?;
-        x.record_read(&self.act.handle.stream).unwrap();
-        y.record_write(&self.act.handle.stream).unwrap();
+        x.record_read(stream);
+        y.record_write(stream);
         Ok(())
     }
 }

--- a/src/cudnn/safe/pooling.rs
+++ b/src/cudnn/safe/pooling.rs
@@ -80,8 +80,6 @@ where
         Dst: DevicePtrMut<Y>,
     {
         let stream = &self.x.handle.stream;
-        src.block_for_read(stream).unwrap();
-        y.block_for_write(stream).unwrap();
         let alpha = alpha.into_scaling_parameter();
         let beta = beta.into_scaling_parameter();
         result::pooling_forward(
@@ -89,13 +87,13 @@ where
             self.pooling.desc,
             (&alpha) as *const Y::Scalar as *const std::ffi::c_void,
             self.x.desc,
-            *src.device_ptr() as *const X as *const std::ffi::c_void,
+            src.device_ptr(stream) as *const X as *const std::ffi::c_void,
             (&beta) as *const Y::Scalar as *const std::ffi::c_void,
             self.y.desc,
-            *y.device_ptr_mut() as *mut Y as *mut std::ffi::c_void,
+            y.device_ptr_mut(stream) as *mut Y as *mut std::ffi::c_void,
         )?;
-        src.record_read(stream).unwrap();
-        y.record_write(stream).unwrap();
+        src.record_read(stream);
+        y.record_write(stream);
         Ok(())
     }
 }

--- a/src/curand/safe.rs
+++ b/src/curand/safe.rs
@@ -70,9 +70,14 @@ impl CudaRng {
     where
         sys::curandGenerator_t: result::UniformFill<T>,
     {
-        dst.block_for_write(&self.stream).unwrap();
-        unsafe { result::UniformFill::fill(self.gen, *dst.device_ptr_mut() as *mut T, dst.len()) }?;
-        dst.record_write(&self.stream).unwrap();
+        unsafe {
+            result::UniformFill::fill(
+                self.gen,
+                dst.device_ptr_mut(&self.stream) as *mut T,
+                dst.len(),
+            )
+        }?;
+        dst.record_write(&self.stream);
         Ok(())
     }
 
@@ -86,17 +91,16 @@ impl CudaRng {
     where
         sys::curandGenerator_t: result::NormalFill<T>,
     {
-        dst.block_for_write(&self.stream).unwrap();
         unsafe {
             result::NormalFill::fill(
                 self.gen,
-                *dst.device_ptr_mut() as *mut T,
+                dst.device_ptr_mut(&self.stream) as *mut T,
                 dst.len(),
                 mean,
                 std,
             )
         }?;
-        dst.record_write(&self.stream).unwrap();
+        dst.record_write(&self.stream);
         Ok(())
     }
 
@@ -110,17 +114,16 @@ impl CudaRng {
     where
         sys::curandGenerator_t: result::LogNormalFill<T>,
     {
-        dst.block_for_write(&self.stream).unwrap();
         unsafe {
             result::LogNormalFill::fill(
                 self.gen,
-                *dst.device_ptr_mut() as *mut T,
+                dst.device_ptr_mut(&self.stream) as *mut T,
                 dst.len(),
                 mean,
                 std,
             )
         }?;
-        dst.record_write(&self.stream).unwrap();
+        dst.record_write(&self.stream);
         Ok(())
     }
 }

--- a/src/driver/safe/external_memory.rs
+++ b/src/driver/safe/external_memory.rs
@@ -143,16 +143,13 @@ impl DeviceSlice<u8> for MappedBuffer {
 }
 
 impl DevicePtr<u8> for MappedBuffer {
-    fn device_ptr(&self) -> &sys::CUdeviceptr {
-        &self.device_ptr
-    }
-    fn read_event(&self) -> &CudaEvent {
-        &self.event
-    }
-    fn block_for_read(&self, _stream: &CudaStream) -> Result<(), DriverError> {
+    fn device_ptr(&self, _stream: &CudaStream) -> sys::CUdeviceptr {
         // Since we only implement [DevicePtr] for this, and not [DevicePtrMut],
         // this memory can never be written to, only read from. So we don't need
         // to synchronize here at all.
-        Ok(())
+        self.device_ptr
+    }
+    fn read_event(&self) -> &CudaEvent {
+        &self.event
     }
 }


### PR DESCRIPTION
- [Breaking] DevicePtr::device_ptr() now returns `sys::CUdeviceptr` instead of a reference
- [Breaking] DevicePtrMut::device_ptr_mut() now returns `sys::CUdeviceptr` instead of a reference
- [Breaking] DevicePtr::device_ptr() now requires a stream reference as input to enforce synchronization on access
- [Breaking] DevicePtrMut::device_ptr_mut() now requires a stream reference as input to enforce synchronization on access

I'm looking into how to automatically do the event record that we also require on drop, but for now we are keeping it as just call after the work completes.