### PR TITLE
Adds `SyncOnDrop` & DevicePtr/Mut now return `(CUdeviceptr, SyncOnDrop)`

### DIFF
--- a/src/cublas/safe.rs
+++ b/src/cublas/safe.rs
@@ -127,24 +127,23 @@ impl Gemv<f32> for CudaBlas {
         x: &X,
         y: &mut Y,
     ) -> Result<(), CublasError> {
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (x, _record_x) = x.device_ptr(&self.stream);
+        let (y, _record_y) = y.device_ptr_mut(&self.stream);
         result::sgemv(
             self.handle,
             cfg.trans,
             cfg.m,
             cfg.n,
             (&cfg.alpha) as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             cfg.lda,
-            x.device_ptr(&self.stream) as *const _,
+            x as *const _,
             cfg.incx,
             (&cfg.beta) as *const _,
-            y.device_ptr_mut(&self.stream) as *mut _,
+            y as *mut _,
             cfg.incy,
-        )?;
-        a.record_read(&self.stream);
-        x.record_read(&self.stream);
-        y.record_write(&self.stream);
-        Ok(())
+        )
     }
 }
 
@@ -156,24 +155,23 @@ impl Gemv<f64> for CudaBlas {
         x: &X,
         y: &mut Y,
     ) -> Result<(), CublasError> {
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (x, _record_x) = x.device_ptr(&self.stream);
+        let (y, _record_y) = y.device_ptr_mut(&self.stream);
         result::dgemv(
             self.handle,
             cfg.trans,
             cfg.m,
             cfg.n,
             (&cfg.alpha) as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             cfg.lda,
-            x.device_ptr(&self.stream) as *const _,
+            x as *const _,
             cfg.incx,
             (&cfg.beta) as *const _,
-            y.device_ptr_mut(&self.stream) as *mut _,
+            y as *mut _,
             cfg.incy,
-        )?;
-        a.record_read(&self.stream);
-        x.record_read(&self.stream);
-        y.record_write(&self.stream);
-        Ok(())
+        )
     }
 }
 
@@ -244,6 +242,9 @@ impl Gemm<half::f16> for CudaBlas {
     ) -> Result<(), CublasError> {
         let alpha: f32 = cfg.alpha.to_f32();
         let beta: f32 = cfg.beta.to_f32();
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (b, _record_b) = b.device_ptr(&self.stream);
+        let (c, _record_c) = c.device_ptr_mut(&self.stream);
         result::gemm_ex(
             self.handle,
             cfg.transa,
@@ -252,23 +253,19 @@ impl Gemm<half::f16> for CudaBlas {
             cfg.n,
             cfg.k,
             (&alpha) as *const f32 as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             sys::cudaDataType_t::CUDA_R_16F,
             cfg.lda,
-            b.device_ptr(&self.stream) as *const _,
+            b as *const _,
             sys::cudaDataType_t::CUDA_R_16F,
             cfg.ldb,
             (&beta) as *const f32 as *const _,
-            c.device_ptr_mut(&self.stream) as *mut _,
+            c as *mut _,
             sys::cudaDataType_t::CUDA_R_16F,
             cfg.ldc,
             sys::cublasComputeType_t::CUBLAS_COMPUTE_32F,
             sys::cublasGemmAlgo_t::CUBLAS_GEMM_DEFAULT,
-        )?;
-        a.record_read(&self.stream);
-        b.record_read(&self.stream);
-        c.record_write(&self.stream);
-        Ok(())
+        )
     }
     unsafe fn gemm_strided_batched<
         A: DevicePtr<half::f16>,
@@ -283,6 +280,9 @@ impl Gemm<half::f16> for CudaBlas {
     ) -> Result<(), CublasError> {
         let alpha: f32 = cfg.gemm.alpha.to_f32();
         let beta: f32 = cfg.gemm.beta.to_f32();
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (b, _record_b) = b.device_ptr(&self.stream);
+        let (c, _record_c) = c.device_ptr_mut(&self.stream);
         result::gemm_strided_batched_ex(
             self.handle,
             cfg.gemm.transa,
@@ -291,27 +291,23 @@ impl Gemm<half::f16> for CudaBlas {
             cfg.gemm.n,
             cfg.gemm.k,
             (&alpha) as *const f32 as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             sys::cudaDataType_t::CUDA_R_16F,
             cfg.gemm.lda,
             cfg.stride_a,
-            b.device_ptr(&self.stream) as *const _,
+            b as *const _,
             sys::cudaDataType_t::CUDA_R_16F,
             cfg.gemm.ldb,
             cfg.stride_b,
             (&beta) as *const f32 as *const _,
-            c.device_ptr_mut(&self.stream) as *mut _,
+            c as *mut _,
             sys::cudaDataType_t::CUDA_R_16F,
             cfg.gemm.ldc,
             cfg.stride_c,
             cfg.batch_size,
             sys::cublasComputeType_t::CUBLAS_COMPUTE_32F,
             sys::cublasGemmAlgo_t::CUBLAS_GEMM_DEFAULT,
-        )?;
-        a.record_read(&self.stream);
-        b.record_read(&self.stream);
-        c.record_write(&self.stream);
-        Ok(())
+        )
     }
 }
 
@@ -330,6 +326,9 @@ impl Gemm<half::bf16> for CudaBlas {
     ) -> Result<(), CublasError> {
         let alpha: f32 = cfg.alpha.to_f32();
         let beta: f32 = cfg.beta.to_f32();
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (b, _record_b) = b.device_ptr(&self.stream);
+        let (c, _record_c) = c.device_ptr_mut(&self.stream);
         result::gemm_ex(
             self.handle,
             cfg.transa,
@@ -338,23 +337,19 @@ impl Gemm<half::bf16> for CudaBlas {
             cfg.n,
             cfg.k,
             (&alpha) as *const f32 as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             sys::cudaDataType_t::CUDA_R_16BF,
             cfg.lda,
-            b.device_ptr(&self.stream) as *const _,
+            b as *const _,
             sys::cudaDataType_t::CUDA_R_16BF,
             cfg.ldb,
             (&beta) as *const f32 as *const _,
-            c.device_ptr_mut(&self.stream) as *mut _,
+            c as *mut _,
             sys::cudaDataType_t::CUDA_R_16BF,
             cfg.ldc,
             sys::cublasComputeType_t::CUBLAS_COMPUTE_32F,
             sys::cublasGemmAlgo_t::CUBLAS_GEMM_DEFAULT,
-        )?;
-        a.record_read(&self.stream);
-        b.record_read(&self.stream);
-        c.record_write(&self.stream);
-        Ok(())
+        )
     }
     unsafe fn gemm_strided_batched<
         A: DevicePtr<half::bf16>,
@@ -369,6 +364,9 @@ impl Gemm<half::bf16> for CudaBlas {
     ) -> Result<(), CublasError> {
         let alpha: f32 = cfg.gemm.alpha.to_f32();
         let beta: f32 = cfg.gemm.beta.to_f32();
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (b, _record_b) = b.device_ptr(&self.stream);
+        let (c, _record_c) = c.device_ptr_mut(&self.stream);
         result::gemm_strided_batched_ex(
             self.handle,
             cfg.gemm.transa,
@@ -377,27 +375,23 @@ impl Gemm<half::bf16> for CudaBlas {
             cfg.gemm.n,
             cfg.gemm.k,
             (&alpha) as *const f32 as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             sys::cudaDataType_t::CUDA_R_16BF,
             cfg.gemm.lda,
             cfg.stride_a,
-            b.device_ptr(&self.stream) as *const _,
+            b as *const _,
             sys::cudaDataType_t::CUDA_R_16BF,
             cfg.gemm.ldb,
             cfg.stride_b,
             (&beta) as *const f32 as *const _,
-            c.device_ptr_mut(&self.stream) as *mut _,
+            c as *mut _,
             sys::cudaDataType_t::CUDA_R_16BF,
             cfg.gemm.ldc,
             cfg.stride_c,
             cfg.batch_size,
             sys::cublasComputeType_t::CUBLAS_COMPUTE_32F,
             sys::cublasGemmAlgo_t::CUBLAS_GEMM_DEFAULT,
-        )?;
-        a.record_read(&self.stream);
-        b.record_read(&self.stream);
-        c.record_write(&self.stream);
-        Ok(())
+        )
     }
 }
 
@@ -409,6 +403,9 @@ impl Gemm<f32> for CudaBlas {
         b: &B,
         c: &mut C,
     ) -> Result<(), CublasError> {
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (b, _record_b) = b.device_ptr(&self.stream);
+        let (c, _record_c) = c.device_ptr_mut(&self.stream);
         result::sgemm(
             self.handle,
             cfg.transa,
@@ -417,18 +414,14 @@ impl Gemm<f32> for CudaBlas {
             cfg.n,
             cfg.k,
             (&cfg.alpha) as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             cfg.lda,
-            b.device_ptr(&self.stream) as *const _,
+            b as *const _,
             cfg.ldb,
             (&cfg.beta) as *const _,
-            c.device_ptr_mut(&self.stream) as *mut _,
+            c as *mut _,
             cfg.ldc,
-        )?;
-        a.record_read(&self.stream);
-        b.record_read(&self.stream);
-        c.record_write(&self.stream);
-        Ok(())
+        )
     }
 
     unsafe fn gemm_strided_batched<A: DevicePtr<f32>, B: DevicePtr<f32>, C: DevicePtrMut<f32>>(
@@ -438,6 +431,9 @@ impl Gemm<f32> for CudaBlas {
         b: &B,
         c: &mut C,
     ) -> Result<(), CublasError> {
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (b, _record_b) = b.device_ptr(&self.stream);
+        let (c, _record_c) = c.device_ptr_mut(&self.stream);
         result::sgemm_strided_batched(
             self.handle,
             cfg.gemm.transa,
@@ -446,22 +442,18 @@ impl Gemm<f32> for CudaBlas {
             cfg.gemm.n,
             cfg.gemm.k,
             (&cfg.gemm.alpha) as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             cfg.gemm.lda,
             cfg.stride_a,
-            b.device_ptr(&self.stream) as *const _,
+            b as *const _,
             cfg.gemm.ldb,
             cfg.stride_b,
             (&cfg.gemm.beta) as *const _,
-            c.device_ptr_mut(&self.stream) as *mut _,
+            c as *mut _,
             cfg.gemm.ldc,
             cfg.stride_c,
             cfg.batch_size,
-        )?;
-        a.record_read(&self.stream);
-        b.record_read(&self.stream);
-        c.record_write(&self.stream);
-        Ok(())
+        )
     }
 }
 
@@ -473,6 +465,9 @@ impl Gemm<f64> for CudaBlas {
         b: &B,
         c: &mut C,
     ) -> Result<(), CublasError> {
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (b, _record_b) = b.device_ptr(&self.stream);
+        let (c, _record_c) = c.device_ptr_mut(&self.stream);
         result::dgemm(
             self.handle,
             cfg.transa,
@@ -481,18 +476,14 @@ impl Gemm<f64> for CudaBlas {
             cfg.n,
             cfg.k,
             (&cfg.alpha) as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             cfg.lda,
-            b.device_ptr(&self.stream) as *const _,
+            b as *const _,
             cfg.ldb,
             (&cfg.beta) as *const _,
-            c.device_ptr_mut(&self.stream) as *mut _,
+            c as *mut _,
             cfg.ldc,
-        )?;
-        a.record_read(&self.stream);
-        b.record_read(&self.stream);
-        c.record_write(&self.stream);
-        Ok(())
+        )
     }
 
     unsafe fn gemm_strided_batched<A: DevicePtr<f64>, B: DevicePtr<f64>, C: DevicePtrMut<f64>>(
@@ -502,6 +493,9 @@ impl Gemm<f64> for CudaBlas {
         b: &B,
         c: &mut C,
     ) -> Result<(), CublasError> {
+        let (a, _record_a) = a.device_ptr(&self.stream);
+        let (b, _record_b) = b.device_ptr(&self.stream);
+        let (c, _record_c) = c.device_ptr_mut(&self.stream);
         result::dgemm_strided_batched(
             self.handle,
             cfg.gemm.transa,
@@ -510,22 +504,18 @@ impl Gemm<f64> for CudaBlas {
             cfg.gemm.n,
             cfg.gemm.k,
             (&cfg.gemm.alpha) as *const _,
-            a.device_ptr(&self.stream) as *const _,
+            a as *const _,
             cfg.gemm.lda,
             cfg.stride_a,
-            b.device_ptr(&self.stream) as *const _,
+            b as *const _,
             cfg.gemm.ldb,
             cfg.stride_b,
             (&cfg.gemm.beta) as *const _,
-            c.device_ptr_mut(&self.stream) as *mut _,
+            c as *mut _,
             cfg.gemm.ldc,
             cfg.stride_c,
             cfg.batch_size,
-        )?;
-        a.record_read(&self.stream);
-        b.record_read(&self.stream);
-        c.record_write(&self.stream);
-        Ok(())
+        )
     }
 }
 
@@ -690,8 +680,9 @@ mod tests {
     #[cfg(feature = "f16")]
     #[test]
     fn test_hgemm() {
-        let dev = CudaDevice::new(0).unwrap();
-        let blas = CudaBlas::new(dev.clone()).unwrap();
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let blas = CudaBlas::new(stream.clone()).unwrap();
         const M: usize = 3;
         const K: usize = 4;
         const N: usize = 5;
@@ -718,19 +709,19 @@ mod tests {
         );
 
         #[rustfmt::skip]
-        let a_dev = dev.htod_sync_copy::<half::f16>(&[
+        let a_dev = stream.memcpy_stod(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ].map(half::f16::from_f32)).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.htod_sync_copy::<half::f16>(&[
+        let b_dev = stream.memcpy_stod(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
             3.4746711, -1.0930681, 0.16502666, -0.59988785, 0.41375792,
         ].map(half::f16::from_f32)).unwrap();
-        let mut c_dev = dev.alloc_zeros::<half::f16>(M * N).unwrap();
+        let mut c_dev = stream.alloc_zeros::<half::f16>(M * N).unwrap();
         unsafe {
             blas.gemm(
                 GemmConfig {
@@ -752,7 +743,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = dev.sync_reclaim(c_dev).unwrap();
+        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];
@@ -765,19 +756,19 @@ mod tests {
         }
 
         #[rustfmt::skip]
-        let a_dev = dev.htod_sync_copy::<half::bf16>(&[
+        let a_dev = stream.memcpy_stod(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ].map(half::bf16::from_f32)).unwrap();
         #[rustfmt::skip]
-        let b_dev = dev.htod_sync_copy::<half::bf16>(&[
+        let b_dev = stream.memcpy_stod(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
             3.4746711, -1.0930681, 0.16502666, -0.59988785, 0.41375792,
         ].map(half::bf16::from_f32)).unwrap();
-        let mut c_dev = dev.alloc_zeros::<half::bf16>(M * N).unwrap();
+        let mut c_dev = stream.alloc_zeros::<half::bf16>(M * N).unwrap();
         unsafe {
             blas.gemm(
                 GemmConfig {
@@ -798,7 +789,7 @@ mod tests {
             )
         }
         .unwrap();
-        let c_host = dev.sync_reclaim(c_dev).unwrap();
+        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];

--- a/src/cudnn/safe/activation.rs
+++ b/src/cudnn/safe/activation.rs
@@ -66,18 +66,17 @@ where
         let stream = &self.act.handle.stream;
         let alpha = alpha.into_scaling_parameter();
         let beta = beta.into_scaling_parameter();
+        let (x, _record_x) = x.device_ptr(stream);
+        let (y, _record_y) = y.device_ptr_mut(stream);
         result::activation_forward(
             self.act.handle.handle,
             self.act.desc,
             (&alpha) as *const Y::Scalar as *const std::ffi::c_void,
             self.x.desc,
-            x.device_ptr(stream) as *const X as *const std::ffi::c_void,
+            x as *const X as *const std::ffi::c_void,
             (&beta) as *const Y::Scalar as *const std::ffi::c_void,
             self.y.desc,
-            y.device_ptr_mut(stream) as *mut Y as *mut std::ffi::c_void,
-        )?;
-        x.record_read(stream);
-        y.record_write(stream);
-        Ok(())
+            y as *mut Y as *mut std::ffi::c_void,
+        )
     }
 }

--- a/src/cudnn/safe/pooling.rs
+++ b/src/cudnn/safe/pooling.rs
@@ -82,18 +82,17 @@ where
         let stream = &self.x.handle.stream;
         let alpha = alpha.into_scaling_parameter();
         let beta = beta.into_scaling_parameter();
+        let (src, _record_src) = src.device_ptr(stream);
+        let (y, _record_y) = y.device_ptr_mut(stream);
         result::pooling_forward(
             self.pooling.handle.handle,
             self.pooling.desc,
             (&alpha) as *const Y::Scalar as *const std::ffi::c_void,
             self.x.desc,
-            src.device_ptr(stream) as *const X as *const std::ffi::c_void,
+            src as *const X as *const std::ffi::c_void,
             (&beta) as *const Y::Scalar as *const std::ffi::c_void,
             self.y.desc,
-            y.device_ptr_mut(stream) as *mut Y as *mut std::ffi::c_void,
-        )?;
-        src.record_read(stream);
-        y.record_write(stream);
-        Ok(())
+            y as *mut Y as *mut std::ffi::c_void,
+        )
     }
 }

--- a/src/curand/safe.rs
+++ b/src/curand/safe.rs
@@ -70,15 +70,9 @@ impl CudaRng {
     where
         sys::curandGenerator_t: result::UniformFill<T>,
     {
-        unsafe {
-            result::UniformFill::fill(
-                self.gen,
-                dst.device_ptr_mut(&self.stream) as *mut T,
-                dst.len(),
-            )
-        }?;
-        dst.record_write(&self.stream);
-        Ok(())
+        let num = dst.len();
+        let (dst, _record_dst) = dst.device_ptr_mut(&self.stream);
+        unsafe { result::UniformFill::fill(self.gen, dst as *mut T, num) }
     }
 
     /// Fill the [crate::driver::CudaSlice]/[crate::driver::CudaViewMut] with data from a `Normal(mean, std)` distribution.
@@ -91,17 +85,9 @@ impl CudaRng {
     where
         sys::curandGenerator_t: result::NormalFill<T>,
     {
-        unsafe {
-            result::NormalFill::fill(
-                self.gen,
-                dst.device_ptr_mut(&self.stream) as *mut T,
-                dst.len(),
-                mean,
-                std,
-            )
-        }?;
-        dst.record_write(&self.stream);
-        Ok(())
+        let num = dst.len();
+        let (dst, _record_dst) = dst.device_ptr_mut(&self.stream);
+        unsafe { result::NormalFill::fill(self.gen, dst as *mut T, num, mean, std) }
     }
 
     /// Fill the [crate::driver::CudaSlice]/[crate::driver::CudaViewMut] with data from a `LogNormal(mean, std)` distribution.
@@ -114,17 +100,9 @@ impl CudaRng {
     where
         sys::curandGenerator_t: result::LogNormalFill<T>,
     {
-        unsafe {
-            result::LogNormalFill::fill(
-                self.gen,
-                dst.device_ptr_mut(&self.stream) as *mut T,
-                dst.len(),
-                mean,
-                std,
-            )
-        }?;
-        dst.record_write(&self.stream);
-        Ok(())
+        let num = dst.len();
+        let (dst, _record_dst) = dst.device_ptr_mut(&self.stream);
+        unsafe { result::LogNormalFill::fill(self.gen, dst as *mut T, num, mean, std) }
     }
 }
 

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -667,6 +667,39 @@ impl<T> DeviceSlice<T> for CudaViewMut<'_, T> {
     }
 }
 
+#[derive(Debug)]
+#[must_use]
+pub enum SyncOnDrop<'a> {
+    Record(Option<(&'a CudaEvent, &'a CudaStream)>),
+    Sync(Option<&'a CudaStream>),
+}
+
+impl<'a> SyncOnDrop<'a> {
+    pub fn record_event(event: &'a CudaEvent, stream: &'a CudaStream) -> Self {
+        SyncOnDrop::Record(Some((event, stream)))
+    }
+    pub fn sync_stream(stream: &'a CudaStream) -> Self {
+        SyncOnDrop::Sync(Some(stream))
+    }
+}
+
+impl Drop for SyncOnDrop<'_> {
+    fn drop(&mut self) {
+        match self {
+            SyncOnDrop::Record(target) => {
+                if let Some((event, stream)) = std::mem::take(target) {
+                    event.record(stream).unwrap();
+                }
+            }
+            SyncOnDrop::Sync(target) => {
+                if let Some(stream) = std::mem::take(target) {
+                    stream.synchronize().unwrap();
+                }
+            }
+        }
+    }
+}
+
 /// Abstraction over [CudaSlice]/[CudaView]
 pub trait DevicePtr<T>: DeviceSlice<T> {
     /// Retrieve the device pointer with the intent to read the device memory
@@ -677,40 +710,30 @@ pub trait DevicePtr<T>: DeviceSlice<T> {
     ///
     /// Callees of this method should ensure that the corresponding [DevicePtr::record_read()]
     /// is called after this method is called.
-    fn device_ptr(&self, stream: &CudaStream) -> sys::CUdeviceptr;
-    fn read_event(&self) -> &CudaEvent;
-    fn record_read(&self, stream: &CudaStream) {
-        self.read_event().record(stream).unwrap();
-    }
+    fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>);
 }
 
 impl<T> DevicePtr<T> for CudaSlice<T> {
-    fn device_ptr(&self, stream: &CudaStream) -> sys::CUdeviceptr {
+    fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
         stream.wait(&self.write).unwrap();
-        self.cu_device_ptr
-    }
-    fn read_event(&self) -> &CudaEvent {
-        &self.read
+        (
+            self.cu_device_ptr,
+            SyncOnDrop::record_event(&self.read, stream),
+        )
     }
 }
 
 impl<T> DevicePtr<T> for CudaView<'_, T> {
-    fn device_ptr(&self, stream: &CudaStream) -> sys::CUdeviceptr {
+    fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
         stream.wait(&self.write).unwrap();
-        self.ptr
-    }
-    fn read_event(&self) -> &CudaEvent {
-        self.read
+        (self.ptr, SyncOnDrop::record_event(&self.read, stream))
     }
 }
 
 impl<T> DevicePtr<T> for CudaViewMut<'_, T> {
-    fn device_ptr(&self, stream: &CudaStream) -> sys::CUdeviceptr {
+    fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
         stream.wait(&self.write).unwrap();
-        self.ptr
-    }
-    fn read_event(&self) -> &CudaEvent {
-        self.read
+        (self.ptr, SyncOnDrop::record_event(&self.read, stream))
     }
 }
 
@@ -724,32 +747,34 @@ pub trait DevicePtrMut<T>: DeviceSlice<T> {
     ///
     /// Callees of this method should ensure that the corresponding [DevicePtrMut::record_write()]
     /// is called after this method is called.
-    fn device_ptr_mut(&mut self, stream: &CudaStream) -> sys::CUdeviceptr;
-    fn write_event(&self) -> &CudaEvent;
-    fn record_write(&mut self, stream: &CudaStream) {
-        self.write_event().record(stream).unwrap();
-    }
+    fn device_ptr_mut<'a>(
+        &'a mut self,
+        stream: &'a CudaStream,
+    ) -> (sys::CUdeviceptr, SyncOnDrop<'a>);
 }
 
 impl<T> DevicePtrMut<T> for CudaSlice<T> {
-    fn device_ptr_mut(&mut self, stream: &CudaStream) -> sys::CUdeviceptr {
-        stream.wait(&self.read);
-        stream.wait(&self.write);
-        self.cu_device_ptr
-    }
-    fn write_event(&self) -> &CudaEvent {
-        &self.write
+    fn device_ptr_mut<'a>(
+        &'a mut self,
+        stream: &'a CudaStream,
+    ) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
+        stream.wait(&self.read).unwrap();
+        stream.wait(&self.write).unwrap();
+        (
+            self.cu_device_ptr,
+            SyncOnDrop::record_event(&self.write, stream),
+        )
     }
 }
 
 impl<T> DevicePtrMut<T> for CudaViewMut<'_, T> {
-    fn device_ptr_mut(&mut self, stream: &CudaStream) -> sys::CUdeviceptr {
-        stream.wait(self.read);
-        stream.wait(self.write);
-        self.ptr
-    }
-    fn write_event(&self) -> &CudaEvent {
-        self.write
+    fn device_ptr_mut<'a>(
+        &'a mut self,
+        stream: &'a CudaStream,
+    ) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
+        stream.wait(self.read).unwrap();
+        stream.wait(self.write).unwrap();
+        (self.ptr, SyncOnDrop::record_event(&self.write, stream))
     }
 }
 
@@ -763,34 +788,35 @@ pub trait HostSlice<T> {
     /// # Safety
     /// This is **only** safe if the resulting slice is used with `stream`. Otherwise
     /// You may run into device synchronization errors
-    unsafe fn stream_synced_slice(&self, stream: &CudaStream) -> Result<&[T], DriverError>;
+    unsafe fn stream_synced_slice<'a>(
+        &'a self,
+        stream: &'a CudaStream,
+    ) -> (&'a [T], SyncOnDrop<'a>);
 
     /// # Safety
     /// This is **only** safe if the resulting slice is used with `stream`. Otherwise
     /// You may run into device synchronization errors
-    unsafe fn stream_synced_mut_slice(
-        &mut self,
-        stream: &CudaStream,
-    ) -> Result<&mut [T], DriverError>;
-
-    fn record_use(&self, stream: &CudaStream);
+    unsafe fn stream_synced_mut_slice<'a>(
+        &'a mut self,
+        stream: &'a CudaStream,
+    ) -> (&'a mut [T], SyncOnDrop<'a>);
 }
 
 impl<T, const N: usize> HostSlice<T> for [T; N] {
     fn len(&self) -> usize {
         N
     }
-    unsafe fn stream_synced_slice(&self, _stream: &CudaStream) -> Result<&[T], DriverError> {
-        Ok(self)
+    unsafe fn stream_synced_slice<'a>(
+        &'a self,
+        stream: &'a CudaStream,
+    ) -> (&'a [T], SyncOnDrop<'a>) {
+        (self, SyncOnDrop::sync_stream(stream))
     }
-    unsafe fn stream_synced_mut_slice(
-        &mut self,
-        _stream: &CudaStream,
-    ) -> Result<&mut [T], DriverError> {
-        Ok(self)
-    }
-    fn record_use(&self, stream: &CudaStream) {
-        stream.synchronize().unwrap();
+    unsafe fn stream_synced_mut_slice<'a>(
+        &'a mut self,
+        stream: &'a CudaStream,
+    ) -> (&'a mut [T], SyncOnDrop<'a>) {
+        (self, SyncOnDrop::sync_stream(stream))
     }
 }
 
@@ -798,17 +824,17 @@ impl<T> HostSlice<T> for [T] {
     fn len(&self) -> usize {
         self.len()
     }
-    unsafe fn stream_synced_slice(&self, _stream: &CudaStream) -> Result<&[T], DriverError> {
-        Ok(self)
+    unsafe fn stream_synced_slice<'a>(
+        &'a self,
+        stream: &'a CudaStream,
+    ) -> (&'a [T], SyncOnDrop<'a>) {
+        (self, SyncOnDrop::sync_stream(stream))
     }
-    unsafe fn stream_synced_mut_slice(
-        &mut self,
-        _stream: &CudaStream,
-    ) -> Result<&mut [T], DriverError> {
-        Ok(self)
-    }
-    fn record_use(&self, stream: &CudaStream) {
-        stream.synchronize().unwrap();
+    unsafe fn stream_synced_mut_slice<'a>(
+        &'a mut self,
+        stream: &'a CudaStream,
+    ) -> (&'a mut [T], SyncOnDrop<'a>) {
+        (self, SyncOnDrop::sync_stream(stream))
     }
 }
 
@@ -816,17 +842,17 @@ impl<T> HostSlice<T> for Vec<T> {
     fn len(&self) -> usize {
         self.len()
     }
-    unsafe fn stream_synced_slice(&self, _stream: &CudaStream) -> Result<&[T], DriverError> {
-        Ok(self)
+    unsafe fn stream_synced_slice<'a>(
+        &'a self,
+        stream: &'a CudaStream,
+    ) -> (&'a [T], SyncOnDrop<'a>) {
+        (self, SyncOnDrop::sync_stream(stream))
     }
-    unsafe fn stream_synced_mut_slice(
-        &mut self,
-        _stream: &CudaStream,
-    ) -> Result<&mut [T], DriverError> {
-        Ok(self)
-    }
-    fn record_use(&self, stream: &CudaStream) {
-        stream.synchronize().unwrap();
+    unsafe fn stream_synced_mut_slice<'a>(
+        &'a mut self,
+        stream: &'a CudaStream,
+    ) -> (&'a mut [T], SyncOnDrop<'a>) {
+        (self, SyncOnDrop::sync_stream(stream))
     }
 }
 
@@ -931,21 +957,25 @@ impl<T> HostSlice<T> for PinnedHostSlice<T> {
         self.len
     }
 
-    unsafe fn stream_synced_slice(&self, stream: &CudaStream) -> Result<&[T], DriverError> {
-        stream.wait(&self.event)?;
-        Ok(std::slice::from_raw_parts(self.ptr, self.len))
+    unsafe fn stream_synced_slice<'a>(
+        &'a self,
+        stream: &'a CudaStream,
+    ) -> (&'a [T], SyncOnDrop<'a>) {
+        stream.wait(&self.event).unwrap();
+        (
+            std::slice::from_raw_parts(self.ptr, self.len),
+            SyncOnDrop::record_event(&self.event, stream),
+        )
     }
-
-    unsafe fn stream_synced_mut_slice(
-        &mut self,
-        stream: &CudaStream,
-    ) -> Result<&mut [T], DriverError> {
-        stream.wait(&self.event)?;
-        Ok(std::slice::from_raw_parts_mut(self.ptr, self.len))
-    }
-
-    fn record_use(&self, stream: &CudaStream) {
-        self.event.record(stream).unwrap();
+    unsafe fn stream_synced_mut_slice<'a>(
+        &'a mut self,
+        stream: &'a CudaStream,
+    ) -> (&'a mut [T], SyncOnDrop<'a>) {
+        stream.wait(&self.event).unwrap();
+        (
+            std::slice::from_raw_parts_mut(self.ptr, self.len),
+            SyncOnDrop::record_event(&self.event, stream),
+        )
     }
 }
 
@@ -1010,10 +1040,9 @@ impl CudaStream {
         self: &Arc<Self>,
         dst: &mut Dst,
     ) -> Result<(), DriverError> {
-        unsafe {
-            result::memset_d8_async(dst.device_ptr_mut(self), 0, dst.num_bytes(), self.cu_stream)
-        }?;
-        dst.record_write(self);
+        let num_bytes = dst.num_bytes();
+        let (dptr, _record) = dst.device_ptr_mut(self);
+        unsafe { result::memset_d8_async(dptr, 0, num_bytes, self.cu_stream) }?;
         Ok(())
     }
 
@@ -1034,11 +1063,9 @@ impl CudaStream {
         dst: &mut Dst,
     ) -> Result<(), DriverError> {
         assert!(dst.len() >= src.len());
-        let src = unsafe { src.stream_synced_slice(self) }?;
-        unsafe { result::memcpy_htod_async(dst.device_ptr_mut(self), src, self.cu_stream) }?;
-        src.record_use(self);
-        dst.record_write(self);
-        Ok(())
+        let (src, _record_src) = unsafe { src.stream_synced_slice(self) };
+        let (dst, _record_dst) = dst.device_ptr_mut(self);
+        unsafe { result::memcpy_htod_async(dst, src, self.cu_stream) }
     }
 
     /// Copy a [`CudaSlice`]/[`CudaView`] to a new [`Vec<T>`].
@@ -1062,11 +1089,9 @@ impl CudaStream {
         dst: &mut Dst,
     ) -> Result<(), DriverError> {
         assert!(dst.len() >= src.len());
-        let dst = unsafe { dst.stream_synced_mut_slice(self) }?;
-        unsafe { result::memcpy_dtoh_async(dst, src.device_ptr(self), self.cu_stream) }?;
-        src.record_read(self);
-        dst.record_use(self);
-        Ok(())
+        let (src, _record_src) = src.device_ptr(self);
+        let (dst, _record_dst) = unsafe { dst.stream_synced_mut_slice(self) };
+        unsafe { result::memcpy_dtoh_async(dst, src, self.cu_stream) }
     }
 
     /// Copy a [`CudaSlice`]/[`CudaView`] to a existing [`CudaSlice`]/[`CudaViewMut`].
@@ -1076,17 +1101,10 @@ impl CudaStream {
         dst: &mut Dst,
     ) -> Result<(), DriverError> {
         assert!(dst.len() >= src.len());
-        unsafe {
-            result::memcpy_dtod_async(
-                dst.device_ptr_mut(self),
-                src.device_ptr(self),
-                src.num_bytes(),
-                self.cu_stream,
-            )
-        }?;
-        src.record_read(self);
-        dst.record_write(self);
-        Ok(())
+        let num_bytes = src.num_bytes();
+        let (src, _record_src) = src.device_ptr(self);
+        let (dst, _record_dst) = dst.device_ptr_mut(self);
+        unsafe { result::memcpy_dtod_async(dst, src, num_bytes, self.cu_stream) }
     }
 
     /// Copy a [`CudaSlice`]/[`CudaView`] to a new [`CudaSlice`].

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -737,15 +737,15 @@ impl<T> DevicePtr<T> for CudaSlice<T> {
 
 impl<T> DevicePtr<T> for CudaView<'_, T> {
     fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
-        stream.wait(&self.write).unwrap();
-        (self.ptr, SyncOnDrop::record_event(&self.read, stream))
+        stream.wait(self.write).unwrap();
+        (self.ptr, SyncOnDrop::record_event(self.read, stream))
     }
 }
 
 impl<T> DevicePtr<T> for CudaViewMut<'_, T> {
     fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
-        stream.wait(&self.write).unwrap();
-        (self.ptr, SyncOnDrop::record_event(&self.read, stream))
+        stream.wait(self.write).unwrap();
+        (self.ptr, SyncOnDrop::record_event(self.read, stream))
     }
 }
 
@@ -792,7 +792,7 @@ impl<T> DevicePtrMut<T> for CudaViewMut<'_, T> {
     ) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
         stream.wait(self.read).unwrap();
         stream.wait(self.write).unwrap();
-        (self.ptr, SyncOnDrop::record_event(&self.write, stream))
+        (self.ptr, SyncOnDrop::record_event(self.write, stream))
     }
 }
 

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -578,8 +578,8 @@ extern \"C\" __global__ void halfs(__half h) {
         .unwrap();
         let ctx = CudaContext::new(0).unwrap();
         let stream = ctx.default_stream();
-        let module = ctx.load_ptx(ptx).unwrap();
-        let f = module.load_func("halfs").unwrap();
+        let module = ctx.load_module(ptx).unwrap();
+        let f = module.load_function("halfs").unwrap();
         unsafe {
             stream
                 .launch_builder(&f)

--- a/src/driver/safe/mod.rs
+++ b/src/driver/safe/mod.rs
@@ -8,7 +8,8 @@ pub(crate) mod profile;
 
 pub use self::core::{
     CudaContext, CudaEvent, CudaFunction, CudaModule, CudaSlice, CudaStream, CudaView, CudaViewMut,
-    DevicePtr, DevicePtrMut, DeviceRepr, DeviceSlice, HostSlice, PinnedHostSlice, ValidAsZeroBits,
+    DevicePtr, DevicePtrMut, DeviceRepr, DeviceSlice, HostSlice, PinnedHostSlice, SyncOnDrop,
+    ValidAsZeroBits,
 };
 pub use self::external_memory::{ExternalMemory, MappedBuffer};
 pub use self::graph::CudaGraph;


### PR DESCRIPTION
This is to *as thoroughly as possible* make it hard to not record slice read/write events on the stream. Previously as you can see by the diff, authors who used device_ptr/device_ptr_mut had to manually call record_read/record_write.

I actually forgot some of the places while updating the code.

This PR adds an additional value to the result of device_ptr/device_ptr_mut. When that value is dropped, the corresponding event calls `event.record(stream)`.

After this PR, callees of device_ptr/device_ptr_mut will not need to worry about knowing about stream synchronization, it will automatically occur.