### PR TITLE
PushKernelArg for scalar now takes reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ let sin_kernel = module.load_function("sin_kernel")?;
 let mut builder = stream.launch_builder(&sin_kernel);
 builder.arg(&mut out);
 builder.arg(&inp);
-builder.arg(100usize);
+builder.arg(&100usize);
 unsafe { builder.launch(LaunchConfig::for_num_elems(100)) }?;
 ```
 

--- a/examples/03-launch-kernel.rs
+++ b/examples/03-launch-kernel.rs
@@ -19,12 +19,12 @@ fn main() -> Result<(), DriverError> {
     let mut b_dev = a_dev.clone();
 
     // we use a buidler pattern to launch kernels.
-    let n = 3;
-    let cfg = LaunchConfig::for_num_elems(n);
+    let n = 3i32;
+    let cfg = LaunchConfig::for_num_elems(n as u32);
     let mut launch_args = stream.launch_builder(&f);
     launch_args.arg(&mut b_dev);
     launch_args.arg(&a_dev);
-    launch_args.arg(n as i32);
+    launch_args.arg(&n);
     unsafe { launch_args.launch(cfg) }?;
 
     let a_host_2 = stream.memcpy_dtov(&a_dev)?;

--- a/examples/04-streams.rs
+++ b/examples/04-streams.rs
@@ -10,10 +10,10 @@ fn main() -> Result<(), DriverError> {
     let module = ctx.load_module(Ptx::from_file("./examples/sin.ptx"))?;
     let f = module.load_function("sin_kernel")?;
 
-    let n = 3;
+    let n = 3i32;
     let a_host = [1.0, 2.0, 3.0];
     let a_dev = stream.memcpy_stod(&a_host)?;
-    let mut b_dev = stream.alloc_zeros::<f32>(n)?;
+    let mut b_dev = stream.alloc_zeros::<f32>(n as usize)?;
 
     // we can safely create a second stream using [CudaStream::fork()].
     // This synchronizes with the source stream, so
@@ -25,7 +25,7 @@ fn main() -> Result<(), DriverError> {
     let mut builder = stream2.launch_builder(&f);
     builder.arg(&mut b_dev); // NOTE: tells cudarc that we are mutating this.
     builder.arg(&a_dev); // NOTE: tells cudarc that we are reading from this slice
-    builder.arg(n as i32);
+    builder.arg(&n);
     unsafe { builder.launch(LaunchConfig::for_num_elems(n as u32)) }?;
 
     // cudarc automatically manages multi stream synchronization,

--- a/examples/05-device-repr.rs
+++ b/examples/05-device-repr.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), DriverError> {
 
     let mut builder = stream.launch_builder(&f);
     // since MyCoolRustStruct implements DeviceRepr, we can pass it to launch.
-    builder.arg(thing);
+    builder.arg(&thing);
     unsafe { builder.launch(LaunchConfig::for_num_elems(1)) }?;
 
     Ok(())

--- a/examples/06-threading.rs
+++ b/examples/06-threading.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), DriverError> {
                     unsafe {
                         stream
                             .launch_builder(&f)
-                            .arg(i)
+                            .arg(&i)
                             .launch(LaunchConfig::for_num_elems(1))
                     }
                 });
@@ -49,7 +49,7 @@ fn main() -> Result<(), DriverError> {
                     unsafe {
                         stream
                             .launch_builder(&f)
-                            .arg(i)
+                            .arg(&i)
                             .launch(LaunchConfig::for_num_elems(1))
                     }
                 });

--- a/examples/matmul-kernel.rs
+++ b/examples/matmul-kernel.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), DriverError> {
     builder.arg(&a_dev);
     builder.arg(&b_dev);
     builder.arg(&mut c_dev);
-    builder.arg(2i32);
+    builder.arg(&2i32);
     let cfg = LaunchConfig {
         block_dim: (2, 2, 1),
         grid_dim: (1, 1, 1),

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -718,7 +718,7 @@ pub trait DevicePtr<T>: DeviceSlice<T> {
     /// the [sys::CUdeviceptr] is scheduled.
     ///
     /// In most cases you can use like:
-    /// ```no_run
+    /// ```ignore
     /// let (src, _record_src) = src.device_ptr(&stream);
     /// ```
     /// Which will drop the [SyncOnDrop] at the end of the scope.
@@ -761,7 +761,7 @@ pub trait DevicePtrMut<T>: DeviceSlice<T> {
     /// the [sys::CUdeviceptr] is scheduled.
     ///
     /// In most cases you can use like:
-    /// ```no_run
+    /// ```ignore
     /// let (src, _record_src) = src.device_ptr_mut(&stream);
     /// ```
     /// Which will drop the [SyncOnDrop] at the end of the scope.


### PR DESCRIPTION
Resolves #361 

So this issue was caused by lifetime issues when using `--release`. The old implementation of `PushKernelArg` accepted owned values (`--release` was not tested during development), and relied on `#[inline(always)]` to attempt to ensure the lifetime of the reference was valid. I suspect this used worked in the old tuple implementation for kernel args because the lifetime implementation for tuples is different from raw scalars.

This PR changes the implementation to explicitly annotate the reference it now takes outlines the `LaunchBuilder` struct.

