### PR TITLE
Adding static linking back in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ cuda-12060 = []
 cuda-12080 = []
 
 dynamic-linking = []
+static-linking = []
 
 nvrtc = []
 driver = ["nvrtc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["cuda", "nvidia", "gpu", "nvrtc", "cublas"]
 features = ["cuda-12080", "f16", "cudnn"]
 
 [features]
-default = ["std", "cublas", "cublaslt", "curand", "driver", "runtime", "nvrtc"]
+default = ["std", "cublas", "cublaslt", "curand", "driver", "runtime", "nvrtc", "dynamic-loading"]
 
 cuda-version-from-build-system = []
 cuda-11040 = []
@@ -35,6 +35,7 @@ cuda-12050 = []
 cuda-12060 = []
 cuda-12080 = []
 
+dynamic-loading = []
 dynamic-linking = []
 static-linking = []
 

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,11 @@ use std::path::{Path, PathBuf};
 fn main() {
     #[cfg(all(feature = "dynamic-linking", feature = "static-linking"))]
     panic!("Both `dynamic-linking` and `static-linking` features are active, this is a bug");
+    #[cfg(all(feature = "dynamic-loading", feature = "static-linking"))]
+    panic!("Both `dynamic-loading` and `static-linking` features are active, this is a bug");
+    #[cfg(all(feature = "dynamic-loading", feature = "dynamic-linking"))]
+    panic!("Both `dynamic-loading` and `dynamic-linking` features are active, this is a bug");
+
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CUDA_ROOT");
     println!("cargo:rerun-if-env-changed=CUDA_PATH");

--- a/build.rs
+++ b/build.rs
@@ -186,22 +186,36 @@ fn static_linking(major: usize, minor: usize) {
         }
     }
 
+    println!("cargo:rustc-link-lib=dylib=stdc++");
     #[cfg(feature = "driver")]
-    println!("cargo:rustc-link-lib=static=cuda");
+    println!("cargo:rustc-link-lib=dylib=cuda");
     #[cfg(feature = "nccl")]
-    println!("cargo:rustc-link-lib=static=nccl");
+    println!("cargo:rustc-link-lib=dylib=nccl");
+    #[cfg(feature = "runtime")]
+    println!("cargo:rustc-link-lib=static=cudart_static");
     #[cfg(feature = "nvrtc")]
-    println!("cargo:rustc-link-lib=static=nvrtc");
+    {
+        println!("cargo:rustc-link-lib=static=nvrtc_static");
+        println!("cargo:rustc-link-lib=static=nvptxcompiler_static");
+        println!("cargo:rustc-link-lib=static=nvrtc-builtins_static");
+    }
     #[cfg(feature = "curand")]
-    println!("cargo:rustc-link-lib=static=curand");
+    {
+        println!("cargo:rustc-link-lib=static=culibos");
+        println!("cargo:rustc-link-lib=static=curand_static");
+    }
     #[cfg(feature = "cublas")]
-    println!("cargo:rustc-link-lib=static=cublas_static");
+    {
+        println!("cargo:rustc-link-lib=static=culibos");
+        println!("cargo:rustc-link-lib=static=cublas_static");
+    }
     #[cfg(any(feature = "cublas", feature = "cublaslt"))]
-    println!("cargo:rustc-link-lib=static=cublasLt_static");
+    {
+        println!("cargo:rustc-link-lib=static=culibos");
+        println!("cargo:rustc-link-lib=static=cublasLt_static");
+    }
     #[cfg(feature = "cudnn")]
     println!("cargo:rustc-link-lib=static=cudnn");
-    #[cfg(feature = "runtime")]
-    println!("cargo:rustc-link-lib=static=cudart");
 }
 
 #[allow(unused)]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
 fn main() {
+    #[cfg(all(feature = "dynamic-linking", feature = "static-linking"))]
+    panic!("Both `dynamic-linking` and `static-linking` features are active, this is a bug");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CUDA_ROOT");
     println!("cargo:rerun-if-env-changed=CUDA_PATH");


### PR DESCRIPTION
We are using static linking in https://github.com/huggingface/text-embeddings-inference (in order to reduce binary sizes).

I'm suggesting this change to allow back static linking into cudarc.
As it was when first introduced this shrinks dependencies from a ~500MB to ~200MB for a single cublas pull, it can be more drastic in some instances.

Cheers.

Edit: More complete approach https://github.com/coreylowman/cudarc/pull/366