### PR TITLE
driver/safe test: fix 20% relative tolerance instead of absolute

### DIFF
--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -668,7 +668,7 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
         };
 
         assert!(
-            (double_launch_ms - 2.0 * par_launch_ms).abs() < 20.0 / 100.0,
+            (double_launch_ms - 2.0 * par_launch_ms).abs() < 0.2 * double_launch_ms,
             "par={:?} dbl={:?}",
             par_launch_ms,
             double_launch_ms


### PR DESCRIPTION
The LHS has units of ms, but the RHS looks like it may have been intended to be 20% rather than an absolute tolerance of 0.2 ms. Without this change, I get test failures like this:
```
thread 'driver::safe::launch::tests::test_par_launch' panicked at src/driver/safe/launch.rs:670:9:
par=147.41606 dbl=295.22842
```