### PR TITLE
Check `ctx::get_current()` before calling `ctx::set_current()`

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -113,9 +113,10 @@ impl CudaContext {
 
     /// Binds this context to the calling thread. Calling this is key for thread safety.
     pub fn bind_to_thread(&self) -> Result<(), DriverError> {
-        // NOTE: it isn't possible for the current ctx to be None if we have `self`.
-        let curr_ctx = result::ctx::get_current()?.unwrap();
-        if curr_ctx != self.cu_ctx {
+        if match result::ctx::get_current()? {
+            Some(curr_ctx) => curr_ctx != self.cu_ctx,
+            None => true,
+        } {
             unsafe { result::ctx::set_current(self.cu_ctx) }?;
         }
         Ok(())

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -113,7 +113,12 @@ impl CudaContext {
 
     /// Binds this context to the calling thread. Calling this is key for thread safety.
     pub fn bind_to_thread(&self) -> Result<(), DriverError> {
-        unsafe { result::ctx::set_current(self.cu_ctx) }
+        // NOTE: it isn't possible for the current ctx to be None if we have `self`.
+        let curr_ctx = result::ctx::get_current()?.unwrap();
+        if curr_ctx != self.cu_ctx {
+            unsafe { result::ctx::set_current(self.cu_ctx) }?;
+        }
+        Ok(())
     }
 
     /// Get the value of the specified attribute of the device in [CudaContext].


### PR DESCRIPTION
There may be slightly less overhead with this call, and it's called very frequently. I remember when we first added bind_to_thread, it didn't noticeably affect throughput, but this version should be the same or faster.