### PR TITLE
 Save errors in Drop impls instead of .unwrap()

### DIFF
--- a/src/cublas/safe.rs
+++ b/src/cublas/safe.rs
@@ -26,7 +26,8 @@ unsafe impl Sync for CudaBlas {}
 impl CudaBlas {
     /// Creates a new cublas handle and sets the stream to the `device`'s stream.
     pub fn new(stream: Arc<CudaStream>) -> Result<Self, CublasError> {
-        stream.context().bind_to_thread().unwrap();
+        let ctx = stream.context();
+        ctx.record_err(ctx.bind_to_thread());
         let handle = result::create_handle()?;
         unsafe { result::set_stream(handle, stream.cu_stream() as _) }?;
         let blas = Self { handle, stream };

--- a/src/curand/safe.rs
+++ b/src/curand/safe.rs
@@ -35,7 +35,8 @@ pub struct CudaRng {
 impl CudaRng {
     /// Constructs the RNG with the given `seed`. All calls run on `stream`.
     pub fn new(seed: u64, stream: Arc<CudaStream>) -> Result<Self, result::CurandError> {
-        stream.context().bind_to_thread().unwrap();
+        let ctx = &stream.ctx;
+        ctx.record_err(ctx.bind_to_thread());
         let gen = result::create_generator()?;
         unsafe { result::set_stream(gen, stream.cu_stream as _) }?;
         let mut rng = Self { gen, stream };

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -237,16 +237,15 @@ impl CudaContext {
             Ok(())
         } else {
             Err(result::DriverError(unsafe {
-                std::mem::transmute(error_state)
+                std::mem::transmute::<u32, sys::cudaError_enum>(error_state)
             }))
         }
     }
 
     /// Records a result for later inspection when a Result can be returned.
     pub fn record_err<T>(&self, result: Result<T, DriverError>) {
-        match result {
-            Err(err) => self.error_state.store(err.0 as u32, Ordering::Relaxed),
-            _ => (),
+        if let Err(err) = result {
+            self.error_state.store(err.0 as u32, Ordering::Relaxed)
         }
     }
 }

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -39,10 +39,10 @@ unsafe impl Sync for CudaContext {}
 
 impl Drop for CudaContext {
     fn drop(&mut self) {
-        self.bind_to_thread().unwrap();
+        self.record_err(self.bind_to_thread());
         let ctx = std::mem::replace(&mut self.cu_ctx, std::ptr::null_mut());
         if !ctx.is_null() {
-            unsafe { result::primary_ctx::release(self.cu_device) }.unwrap();
+            self.record_err(unsafe { result::primary_ctx::release(self.cu_device) });
         }
     }
 }

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -8,7 +8,7 @@ use std::{
     marker::PhantomData,
     ops::{Bound, RangeBounds},
     string::String,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
     sync::Arc,
     vec::Vec,
 };
@@ -31,6 +31,7 @@ pub struct CudaContext {
     pub(crate) has_async_alloc: bool,
     pub(crate) num_streams: AtomicUsize,
     pub(crate) event_tracking: AtomicBool,
+    pub(crate) error_state: AtomicU32,
 }
 
 unsafe impl Send for CudaContext {}
@@ -75,6 +76,7 @@ impl CudaContext {
             has_async_alloc,
             num_streams: AtomicUsize::new(0),
             event_tracking: AtomicBool::new(true),
+            error_state: AtomicU32::new(0),
         });
         ctx.bind_to_thread()?;
         Ok(ctx)
@@ -93,11 +95,13 @@ impl CudaContext {
 
     /// Get the name of this device.
     pub fn name(&self) -> Result<String, result::DriverError> {
+        self.check_error()?;
         result::device::get_name(self.cu_device)
     }
 
     /// Get the UUID of this device.
     pub fn uuid(&self) -> Result<sys::CUuuid, result::DriverError> {
+        self.check_error()?;
         result::device::get_uuid(self.cu_device)
     }
 
@@ -127,6 +131,7 @@ impl CudaContext {
 
     /// Binds this context to the calling thread. Calling this is key for thread safety.
     pub fn bind_to_thread(&self) -> Result<(), DriverError> {
+        self.check_error()?;
         if match result::ctx::get_current()? {
             Some(curr_ctx) => curr_ctx != self.cu_ctx,
             None => true,
@@ -138,6 +143,7 @@ impl CudaContext {
 
     /// Get the value of the specified attribute of the device in [CudaContext].
     pub fn attribute(&self, attrib: sys::CUdevice_attribute) -> Result<i32, result::DriverError> {
+        self.check_error()?;
         unsafe { result::device::get_attribute(self.cu_device, attrib) }
     }
 
@@ -219,6 +225,24 @@ impl CudaContext {
     pub unsafe fn disable_event_tracking(&self) {
         self.event_tracking.store(false, Ordering::Relaxed);
     }
+
+    pub fn check_error(&self) -> Result<(), DriverError> {
+        let error_state = self.error_state.swap(0, Ordering::Relaxed);
+        if error_state == 0 {
+            Ok(())
+        } else {
+            Err(result::DriverError(unsafe {
+                std::mem::transmute(error_state)
+            }))
+        }
+    }
+
+    pub fn record_err<T>(&self, result: Result<T, DriverError>) {
+        match result {
+            Err(err) => self.error_state.store(err.0 as u32, Ordering::Relaxed),
+            _ => (),
+        }
+    }
 }
 
 /// A lightweight synchronization primitive used to synchronize between [CudaStream]s.
@@ -242,8 +266,9 @@ unsafe impl Sync for CudaEvent {}
 
 impl Drop for CudaEvent {
     fn drop(&mut self) {
-        self.ctx.bind_to_thread().unwrap();
-        unsafe { result::event::destroy(self.cu_event) }.unwrap()
+        self.ctx.record_err(self.ctx.bind_to_thread());
+        self.ctx
+            .record_err(unsafe { result::event::destroy(self.cu_event) });
     }
 }
 
@@ -340,10 +365,11 @@ unsafe impl Sync for CudaStream {}
 
 impl Drop for CudaStream {
     fn drop(&mut self) {
-        self.ctx.bind_to_thread().unwrap();
+        self.ctx.record_err(self.ctx.bind_to_thread());
         if !self.cu_stream.is_null() {
             self.ctx.num_streams.fetch_sub(1, Ordering::Relaxed);
-            unsafe { result::stream::destroy(self.cu_stream).unwrap() };
+            self.ctx
+                .record_err(unsafe { result::stream::destroy(self.cu_stream) });
         }
     }
 }
@@ -466,13 +492,14 @@ unsafe impl<T> Sync for CudaSlice<T> {}
 
 impl<T> Drop for CudaSlice<T> {
     fn drop(&mut self) {
+        let ctx = &self.stream.ctx;
         if let Some(read) = self.read.as_ref() {
-            self.stream.wait(read).unwrap();
+            ctx.record_err(self.stream.wait(read));
         }
         if let Some(write) = self.write.as_ref() {
-            self.stream.wait(write).unwrap();
+            ctx.record_err(self.stream.wait(write));
         }
-        unsafe { result::free_async(self.cu_device_ptr, self.stream.cu_stream) }.unwrap();
+        ctx.record_err(unsafe { result::free_async(self.cu_device_ptr, self.stream.cu_stream) });
     }
 }
 
@@ -775,12 +802,12 @@ impl Drop for SyncOnDrop<'_> {
         match self {
             SyncOnDrop::Record(target) => {
                 if let Some((event, stream)) = std::mem::take(target) {
-                    event.record(stream).unwrap();
+                    stream.ctx.record_err(event.record(stream));
                 }
             }
             SyncOnDrop::Sync(target) => {
                 if let Some(stream) = std::mem::take(target) {
-                    stream.synchronize().unwrap();
+                    stream.ctx.record_err(stream.synchronize());
                 }
             }
         }
@@ -810,7 +837,7 @@ impl<T> DevicePtr<T> for CudaSlice<T> {
     fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
         if self.stream.context().is_in_multi_stream_mode() {
             if let Some(write) = self.write.as_ref() {
-                stream.wait(write).unwrap();
+                stream.ctx.record_err(stream.wait(write));
             }
         }
         (
@@ -824,7 +851,7 @@ impl<T> DevicePtr<T> for CudaView<'_, T> {
     fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
         if self.stream.context().is_in_multi_stream_mode() {
             if let Some(write) = self.write.as_ref() {
-                stream.wait(write).unwrap();
+                stream.ctx.record_err(stream.wait(write));
             }
         }
         (self.ptr, SyncOnDrop::record_event(self.read, stream))
@@ -835,7 +862,7 @@ impl<T> DevicePtr<T> for CudaViewMut<'_, T> {
     fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
         if self.stream.context().is_in_multi_stream_mode() {
             if let Some(write) = self.write.as_ref() {
-                stream.wait(write).unwrap();
+                stream.ctx.record_err(stream.wait(write));
             }
         }
         (self.ptr, SyncOnDrop::record_event(self.read, stream))
@@ -871,10 +898,10 @@ impl<T> DevicePtrMut<T> for CudaSlice<T> {
     ) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
         if self.stream.context().is_in_multi_stream_mode() {
             if let Some(read) = self.read.as_ref() {
-                stream.wait(read).unwrap();
+                stream.ctx.record_err(stream.wait(read));
             }
             if let Some(write) = self.write.as_ref() {
-                stream.wait(write).unwrap();
+                stream.ctx.record_err(stream.wait(write));
             }
         }
         (
@@ -891,10 +918,10 @@ impl<T> DevicePtrMut<T> for CudaViewMut<'_, T> {
     ) -> (sys::CUdeviceptr, SyncOnDrop<'a>) {
         if self.stream.context().is_in_multi_stream_mode() {
             if let Some(read) = self.read.as_ref() {
-                stream.wait(read).unwrap();
+                stream.ctx.record_err(stream.wait(read));
             }
             if let Some(write) = self.write.as_ref() {
-                stream.wait(write).unwrap();
+                stream.ctx.record_err(stream.wait(write));
             }
         }
         (self.ptr, SyncOnDrop::record_event(self.write, stream))
@@ -997,8 +1024,9 @@ unsafe impl<T> Sync for PinnedHostSlice<T> {}
 
 impl<T> Drop for PinnedHostSlice<T> {
     fn drop(&mut self) {
-        self.event.synchronize().unwrap();
-        unsafe { result::free_host(self.ptr as _) }.unwrap();
+        let ctx = &self.event.ctx;
+        ctx.record_err(self.event.synchronize());
+        ctx.record_err(unsafe { result::free_host(self.ptr as _) });
     }
 }
 
@@ -1087,7 +1115,7 @@ impl<T> HostSlice<T> for PinnedHostSlice<T> {
         &'a self,
         stream: &'a CudaStream,
     ) -> (&'a [T], SyncOnDrop<'a>) {
-        stream.wait(&self.event).unwrap();
+        stream.ctx.record_err(stream.wait(&self.event));
         (
             std::slice::from_raw_parts(self.ptr, self.len),
             SyncOnDrop::Record(Some((&self.event, stream))),
@@ -1097,7 +1125,7 @@ impl<T> HostSlice<T> for PinnedHostSlice<T> {
         &'a mut self,
         stream: &'a CudaStream,
     ) -> (&'a mut [T], SyncOnDrop<'a>) {
-        stream.wait(&self.event).unwrap();
+        stream.ctx.record_err(stream.wait(&self.event));
         (
             std::slice::from_raw_parts_mut(self.ptr, self.len),
             SyncOnDrop::Record(Some((&self.event, stream))),
@@ -1630,8 +1658,9 @@ unsafe impl Sync for CudaModule {}
 
 impl Drop for CudaModule {
     fn drop(&mut self) {
-        self.ctx.bind_to_thread().unwrap();
-        unsafe { result::module::unload(self.cu_module) }.unwrap();
+        self.ctx.record_err(self.ctx.bind_to_thread());
+        self.ctx
+            .record_err(unsafe { result::module::unload(self.cu_module) });
     }
 }
 
@@ -1850,17 +1879,18 @@ impl<T> CudaSlice<T> {
     ///
     /// Drops the underlying host_buf if there is one.
     pub fn leak(self) -> sys::CUdeviceptr {
+        let ctx = &self.stream.ctx;
         // drop self.read
         if let Some(read) = self.read.as_ref() {
-            self.stream.wait(read).unwrap();
-            unsafe { result::event::destroy(read.cu_event) }.unwrap();
+            ctx.record_err(self.stream.wait(read));
+            ctx.record_err(unsafe { result::event::destroy(read.cu_event) });
             unsafe { Arc::decrement_strong_count(Arc::as_ptr(&read.ctx)) };
         }
 
         // drop self.write
         if let Some(write) = self.write.as_ref() {
-            self.stream.wait(write).unwrap();
-            unsafe { result::event::destroy(write.cu_event) }.unwrap();
+            ctx.record_err(self.stream.wait(write));
+            ctx.record_err(unsafe { result::event::destroy(write.cu_event) });
             unsafe { Arc::decrement_strong_count(Arc::as_ptr(&write.ctx)) };
         }
 

--- a/src/driver/safe/graph.rs
+++ b/src/driver/safe/graph.rs
@@ -27,14 +27,16 @@ pub struct CudaGraph {
 
 impl Drop for CudaGraph {
     fn drop(&mut self) {
+        let ctx = &self.stream.ctx;
+
         let cu_graph_exec = std::mem::replace(&mut self.cu_graph_exec, std::ptr::null_mut());
         if !cu_graph_exec.is_null() {
-            unsafe { result::graph::exec_destroy(cu_graph_exec) }.unwrap();
+            ctx.record_err(unsafe { result::graph::exec_destroy(cu_graph_exec) });
         }
 
         let cu_graph = std::mem::replace(&mut self.cu_graph, std::ptr::null_mut());
         if !cu_graph.is_null() {
-            unsafe { result::graph::destroy(cu_graph) }.unwrap();
+            ctx.record_err(unsafe { result::graph::destroy(cu_graph) });
         }
     }
 }
@@ -42,6 +44,7 @@ impl Drop for CudaGraph {
 impl CudaStream {
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__STREAM.html#group__CUDA__STREAM_1g767167da0bbf07157dc20b6c258a2143)
     pub fn begin_capture(&self, mode: sys::CUstreamCaptureMode) -> Result<(), DriverError> {
+        self.ctx.bind_to_thread()?;
         unsafe { result::stream::begin_capture(self.cu_stream, mode) }
     }
 
@@ -52,6 +55,7 @@ impl CudaStream {
         self: &Arc<Self>,
         flags: sys::CUgraphInstantiate_flags,
     ) -> Result<Option<CudaGraph>, DriverError> {
+        self.ctx.bind_to_thread()?;
         let cu_graph = unsafe { result::stream::end_capture(self.cu_stream) }?;
         if cu_graph.is_null() {
             return Ok(None);
@@ -66,6 +70,7 @@ impl CudaStream {
 
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__STREAM.html#group__CUDA__STREAM_1g37823c49206e3704ae23c7ad78560bca)
     pub fn capture_status(&self) -> Result<sys::CUstreamCaptureStatus, DriverError> {
+        self.ctx.bind_to_thread()?;
         unsafe { result::stream::is_capturing(self.cu_stream) }
     }
 }
@@ -73,6 +78,7 @@ impl CudaStream {
 impl CudaGraph {
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1g6b2dceb3901e71a390d2bd8b0491e471)
     pub fn launch(&self) -> Result<(), DriverError> {
+        self.stream.ctx.bind_to_thread()?;
         unsafe { result::graph::launch(self.cu_graph_exec, self.stream.cu_stream) }
     }
 }

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -781,16 +781,17 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
     }
 
     #[test]
+    #[ignore = "must be executed by itself"]
     fn test_device_side_assert() -> Result<(), DriverError> {
         let ctx = CudaContext::new(0)?;
-        let stream = ctx.default_stream();
+        let stream = ctx.new_stream()?;
         let inp = stream.memcpy_stod(&[1.0f32; 100])?;
         let mut out = stream.alloc_zeros::<f32>(100)?;
         let ptx = crate::nvrtc::compile_ptx(
             "
-extern \"C\" __global__ void foo(float *out, const float *inp, const size_t numel) {
-    assert(0);
-}",
+    extern \"C\" __global__ void foo(float *out, const float *inp, const size_t numel) {
+        assert(0);
+    }",
         )
         .unwrap();
         let module = ctx.load_module(ptx)?;


### PR DESCRIPTION
Resolves #277 
Resolves #396

Adds `AtomicU32` into `CudaContext` which can track errors that occur in functions that cannot return a Result, like `Drop::drop()`.

These errors can be recorded with new method `CudaContext::record_err()`.

The driver code now also calls `CudaContext::check_err()` at the beginning of functions which return `Result`, which will reset error state to empty and return the error if there is one.
