### PR TITLE
Feat: add softmax support

### DIFF
--- a/src/cudnn/result.rs
+++ b/src/cudnn/result.rs
@@ -880,3 +880,18 @@ pub unsafe fn activation_forward(
 ) -> Result<(), CudnnError> {
     sys::cudnnActivationForward(handle, activation_desc, alpha, x_desc, x, beta, y_desc, y).result()
 }
+
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn softmax_forward(
+    handle: cudnnHandle_t,
+    algo: cudnnSoftmaxAlgorithm_t,
+    mode: cudnnSoftmaxMode_t,
+    alpha: *const ::core::ffi::c_void,
+    x_desc: sys::cudnnTensorDescriptor_t,
+    x: *const ::core::ffi::c_void,
+    beta: *const ::core::ffi::c_void,
+    y_desc: sys::cudnnTensorDescriptor_t,
+    y: *mut ::core::ffi::c_void,
+) -> Result<(), CudnnError> {
+    sys::cudnnSoftmaxForward(handle, algo, mode, alpha, x_desc, x, beta, y_desc, y)
+}

--- a/src/cudnn/result.rs
+++ b/src/cudnn/result.rs
@@ -881,6 +881,9 @@ pub unsafe fn activation_forward(
     sys::cudnnActivationForward(handle, activation_desc, alpha, x_desc, x, beta, y_desc, y).result()
 }
 
+/// # Safety
+/// Make sure the handle is valid, all data are associated with the handle, and no pointers are null
+/// unless explicitly accepted by the underlying apis.
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn softmax_forward(
     handle: sys::cudnnHandle_t,

--- a/src/cudnn/result.rs
+++ b/src/cudnn/result.rs
@@ -883,9 +883,9 @@ pub unsafe fn activation_forward(
 
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn softmax_forward(
-    handle: cudnnHandle_t,
-    algo: cudnnSoftmaxAlgorithm_t,
-    mode: cudnnSoftmaxMode_t,
+    handle: sys::cudnnHandle_t,
+    algo: sys::cudnnSoftmaxAlgorithm_t,
+    mode: sys::cudnnSoftmaxMode_t,
     alpha: *const ::core::ffi::c_void,
     x_desc: sys::cudnnTensorDescriptor_t,
     x: *const ::core::ffi::c_void,
@@ -893,5 +893,5 @@ pub unsafe fn softmax_forward(
     y_desc: sys::cudnnTensorDescriptor_t,
     y: *mut ::core::ffi::c_void,
 ) -> Result<(), CudnnError> {
-    sys::cudnnSoftmaxForward(handle, algo, mode, alpha, x_desc, x, beta, y_desc, y)
+    sys::cudnnSoftmaxForward(handle, algo, mode, alpha, x_desc, x, beta, y_desc, y).result()
 }

--- a/src/cudnn/safe/mod.rs
+++ b/src/cudnn/safe/mod.rs
@@ -43,6 +43,7 @@ pub use self::pooling::{PoolingDescriptor, PoolingForward};
 pub use self::reduce::{FlatIndices, NoIndices, ReduceTensor, ReductionDescriptor};
 pub use super::result::CudnnError;
 pub use activation::{ActivationDescriptor, ActivationForward};
+pub use softmax::{Softmax, SoftmaxForward};
 
 #[cfg(test)]
 mod tests {

--- a/src/cudnn/safe/mod.rs
+++ b/src/cudnn/safe/mod.rs
@@ -21,6 +21,7 @@ mod conv;
 mod core;
 mod pooling;
 mod reduce;
+mod softmax;
 
 #[allow(deprecated)]
 pub use self::conv::{

--- a/src/cudnn/safe/softmax.rs
+++ b/src/cudnn/safe/softmax.rs
@@ -1,7 +1,7 @@
 use crate::cudnn::{result, sys, Cudnn, CudnnDataType, CudnnError, TensorDescriptor};
 use crate::driver::{DevicePtr, DevicePtrMut};
-use alloc::sync::Arc;
 use core::marker::PhantomData;
+use std::sync::Arc;
 
 /// A handle for the Softmax operation. Create with [`Cudnn::create_softmax()`]
 #[derive(Debug)]

--- a/src/cudnn/safe/softmax.rs
+++ b/src/cudnn/safe/softmax.rs
@@ -1,0 +1,77 @@
+use crate::cudnn::{result, sys, Cudnn, CudnnDataType, CudnnError, TensorDescriptor};
+use crate::driver::{DevicePtr, DevicePtrMut};
+use alloc::sync::Arc;
+use core::marker::PhantomData;
+
+/// A handle for the Softmax operation. Create with [`Cudnn::create_softmax()`]
+#[derive(Debug)]
+pub struct Softmax<T> {
+    pub(crate) handle: Arc<Cudnn>,
+    pub(crate) mode: sys::cudnnSoftmaxMode_t,
+    pub(crate) marker: PhantomData<T>,
+}
+
+impl Cudnn {
+    pub fn create_softmax<T: CudnnDataType>(
+        self: &Arc<Cudnn>,
+        mode: sys::cudnnSoftmaxMode_t,
+    ) -> Result<Softmax<T>, CudnnError> {
+        Ok(Softmax {
+            handle: self.clone(),
+            mode,
+            marker: PhantomData,
+        })
+    }
+}
+
+/// The Softmax forward operation. Pass in references to descriptors
+/// directly, and then call [`SoftmaxForward::launch()`] .
+pub struct SoftmaxForward<'a, A: CudnnDataType, X: CudnnDataType, Y: CudnnDataType> {
+    pub softmax: &'a Softmax<A>,
+    pub x: &'a TensorDescriptor<X>,
+    pub y: &'a TensorDescriptor<Y>,
+}
+
+impl<A, X, Y> SoftmaxForward<'_, A, X, Y>
+where
+    A: CudnnDataType,
+    X: CudnnDataType,
+    Y: CudnnDataType,
+{
+    /// Launches the operation.
+    ///
+    /// - `x` is the input tensor
+    /// - `y` is the output
+    ///
+    /// # Safety
+    /// The arguments must match the data type/layout specified in the
+    /// descriptors in `self.
+    pub unsafe fn launch<Src, Dst>(
+        &self,
+        (alpha, beta): (Y, Y),
+        algo: sys::cudnnSoftmaxAlgorithm_t,
+        x: &Src,
+        y: &mut Dst,
+    ) -> Result<(), CudnnError>
+    where
+        Src: DevicePtr<A>,
+        Dst: DevicePtrMut<A>,
+    {
+        let stream = &self.x.handle.stream;
+        let alpha = alpha.into_scaling_parameter();
+        let beta = beta.into_scaling_parameter();
+        let (x, _record_src) = x.device_ptr(stream);
+        let (y, _record_y) = y.device_ptr_mut(stream);
+        result::softmax_forward(
+            self.softmax.handle.handle,
+            algo,
+            self.softmax.mode,
+            (&alpha) as *const Y::Scalar as *const std::ffi::c_void,
+            self.x.desc,
+            x as *const X as *const std::ffi::c_void,
+            (&beta) as *const Y::Scalar as *const std::ffi::c_void,
+            self.y.desc,
+            y as *mut Y as *mut std::ffi::c_void,
+        )
+    }
+}

--- a/src/cudnn/safe/softmax.rs
+++ b/src/cudnn/safe/softmax.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 /// A handle for the Softmax operation. Create with [`Cudnn::create_softmax()`]
 #[derive(Debug)]
 pub struct Softmax<T> {
+    #[allow(unused)]
     pub(crate) handle: Arc<Cudnn>,
+    #[allow(unused)]
     pub(crate) mode: sys::cudnnSoftmaxMode_t,
     pub(crate) marker: PhantomData<T>,
 }


### PR DESCRIPTION
This PR introduces a safe API for softmax operations (cudnnSoftmaxForward).

cuDNN does not provide a dedicated descriptor for softmax, unlike operations such as activation or convolution. To keep the API consistent, this implementation introduces a Softmax<T> type and a corresponding Cudnn::create_softmax() constructor, following the same design approach used for operations like ActivationDescriptor.