### PR TITLE
Add `is_culib_present` function

### DIFF
--- a/bindings_generator/src/merge.rs
+++ b/bindings_generator/src/merge.rs
@@ -315,6 +315,20 @@ impl BindingMerger {
 
                #loading_lib
 
+               pub unsafe fn is_culib_present() -> bool {
+                   let lib_names = [#(#lib_names),*];
+                   let choices = lib_names
+                       .iter()
+                       .map(|l| crate::get_lib_name_candidates(l))
+                       .flatten();
+                   for choice in choices {
+                       if Lib::new(choice).is_ok() {
+                           return true;
+                       }
+                   }
+                   false
+               }
+
                pub unsafe fn culib() -> &'static Lib {
                    static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();
                    LIB.get_or_init(|| {

--- a/src/cublas/sys/mod.rs
+++ b/src/cublas/sys/mod.rs
@@ -35303,6 +35303,19 @@ mod loaded {
             })
         }
     }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["cublas"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
+    }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();
         LIB.get_or_init(|| {

--- a/src/cublaslt/sys/mod.rs
+++ b/src/cublaslt/sys/mod.rs
@@ -9,9 +9,6 @@ extern crate no_std_compat as std;
 pub use self::cudaDataType_t as cudaDataType;
 pub use self::libraryPropertyType_t as libraryPropertyType;
 pub type FILE = _IO_FILE;
-pub type _IO_lock_t = ::core::ffi::c_void;
-pub type __off64_t = ::core::ffi::c_long;
-pub type __off_t = ::core::ffi::c_long;
 pub type cublasLtHandle_t = *mut cublasLtContext;
 pub type cublasLtLoggerCallback_t = ::core::option::Option<
     unsafe extern "C" fn(
@@ -2493,51 +2490,8 @@ pub struct CUstream_st {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
-    pub _flags: ::core::ffi::c_int,
-    pub _IO_read_ptr: *mut ::core::ffi::c_char,
-    pub _IO_read_end: *mut ::core::ffi::c_char,
-    pub _IO_read_base: *mut ::core::ffi::c_char,
-    pub _IO_write_base: *mut ::core::ffi::c_char,
-    pub _IO_write_ptr: *mut ::core::ffi::c_char,
-    pub _IO_write_end: *mut ::core::ffi::c_char,
-    pub _IO_buf_base: *mut ::core::ffi::c_char,
-    pub _IO_buf_end: *mut ::core::ffi::c_char,
-    pub _IO_save_base: *mut ::core::ffi::c_char,
-    pub _IO_backup_base: *mut ::core::ffi::c_char,
-    pub _IO_save_end: *mut ::core::ffi::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::core::ffi::c_int,
-    pub _flags2: ::core::ffi::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::core::ffi::c_ushort,
-    pub _vtable_offset: ::core::ffi::c_schar,
-    pub _shortbuf: [::core::ffi::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::core::ffi::c_void,
-    pub __pad5: usize,
-    pub _mode: ::core::ffi::c_int,
-    pub _unused2: [::core::ffi::c_char; 20usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 #[repr(C)]
@@ -2632,15 +2586,6 @@ pub struct cublasLtMatrixTransformDescOpaque_t {
 #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
 impl cudaDataType_t {
     pub const CUDA_R_8F_UE4M3: cudaDataType_t = cudaDataType_t::CUDA_R_8F_E4M3;
-}
-impl Default for _IO_FILE {
-    fn default() -> Self {
-        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
 }
 impl Default for cublasLtMatmulHeuristicResult_t {
     fn default() -> Self {
@@ -3833,6 +3778,19 @@ mod loaded {
                 cublasLtMatrixTransformDescSetAttribute,
             })
         }
+    }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["cublasLt"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
     }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();

--- a/src/cudnn/sys/mod.rs
+++ b/src/cudnn/sys/mod.rs
@@ -9362,6 +9362,19 @@ mod loaded {
             })
         }
     }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["cudnn"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
+    }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();
         LIB.get_or_init(|| {

--- a/src/curand/sys/mod.rs
+++ b/src/curand/sys/mod.rs
@@ -722,6 +722,19 @@ mod loaded {
             })
         }
     }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["curand"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
+    }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();
         LIB.get_or_init(|| {

--- a/src/cusolver/sys/mod.rs
+++ b/src/cusolver/sys/mod.rs
@@ -22,48 +22,6 @@ pub use self::libraryPropertyType_t as libraryPropertyType;
     feature = "cuda-12090"
 ))]
 pub type FILE = _IO_FILE;
-#[cfg(any(
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-pub type _IO_lock_t = ::core::ffi::c_void;
-#[cfg(any(
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-pub type __off64_t = ::core::ffi::c_long;
-#[cfg(any(
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-pub type __off_t = ::core::ffi::c_long;
 pub type csrqrInfo_t = *mut csrqrInfo;
 pub type cuComplex = cuFloatComplex;
 pub type cuDoubleComplex = double2;
@@ -489,90 +447,8 @@ pub struct CUstream_st {
     feature = "cuda-12090"
 ))]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
-    pub _flags: ::core::ffi::c_int,
-    pub _IO_read_ptr: *mut ::core::ffi::c_char,
-    pub _IO_read_end: *mut ::core::ffi::c_char,
-    pub _IO_read_base: *mut ::core::ffi::c_char,
-    pub _IO_write_base: *mut ::core::ffi::c_char,
-    pub _IO_write_ptr: *mut ::core::ffi::c_char,
-    pub _IO_write_end: *mut ::core::ffi::c_char,
-    pub _IO_buf_base: *mut ::core::ffi::c_char,
-    pub _IO_buf_end: *mut ::core::ffi::c_char,
-    pub _IO_save_base: *mut ::core::ffi::c_char,
-    pub _IO_backup_base: *mut ::core::ffi::c_char,
-    pub _IO_save_end: *mut ::core::ffi::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::core::ffi::c_int,
-    pub _flags2: ::core::ffi::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::core::ffi::c_ushort,
-    pub _vtable_offset: ::core::ffi::c_schar,
-    pub _shortbuf: [::core::ffi::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::core::ffi::c_void,
-    pub __pad5: usize,
-    pub _mode: ::core::ffi::c_int,
-    pub _unused2: [::core::ffi::c_char; 20usize],
-}
-#[cfg(any(
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
-}
-#[cfg(any(
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
-}
-#[cfg(any(
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 #[repr(C)]
@@ -645,28 +521,6 @@ impl cublasOperation_t {
 #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
 impl cudaDataType_t {
     pub const CUDA_R_8F_UE4M3: cudaDataType_t = cudaDataType_t::CUDA_R_8F_E4M3;
-}
-#[cfg(any(
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-impl Default for _IO_FILE {
-    fn default() -> Self {
-        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
 }
 #[cfg(not(feature = "dynamic-loading"))]
 extern "C" {
@@ -23887,6 +23741,19 @@ mod loaded {
                 cusolverSpZcsrzfdHost,
             })
         }
+    }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["cusolver"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
     }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();

--- a/src/cusolvermg/sys/mod.rs
+++ b/src/cusolvermg/sys/mod.rs
@@ -1128,6 +1128,19 @@ mod loaded {
             })
         }
     }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["cusolverMg"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
+    }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();
         LIB.get_or_init(|| {

--- a/src/cusparse/sys/mod.rs
+++ b/src/cusparse/sys/mod.rs
@@ -24,54 +24,6 @@ pub use self::libraryPropertyType_t as libraryPropertyType;
     feature = "cuda-12090"
 ))]
 pub type FILE = _IO_FILE;
-#[cfg(any(
-    feature = "cuda-11050",
-    feature = "cuda-11060",
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-pub type _IO_lock_t = ::core::ffi::c_void;
-#[cfg(any(
-    feature = "cuda-11050",
-    feature = "cuda-11060",
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-pub type __off64_t = ::core::ffi::c_long;
-#[cfg(any(
-    feature = "cuda-11050",
-    feature = "cuda-11060",
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-pub type __off_t = ::core::ffi::c_long;
 pub type bsric02Info_t = *mut bsric02Info;
 pub type bsrilu02Info_t = *mut bsrilu02Info;
 pub type bsrsm2Info_t = *mut bsrsm2Info;
@@ -759,96 +711,8 @@ pub struct CUstream_st {
     feature = "cuda-12090"
 ))]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
-    pub _flags: ::core::ffi::c_int,
-    pub _IO_read_ptr: *mut ::core::ffi::c_char,
-    pub _IO_read_end: *mut ::core::ffi::c_char,
-    pub _IO_read_base: *mut ::core::ffi::c_char,
-    pub _IO_write_base: *mut ::core::ffi::c_char,
-    pub _IO_write_ptr: *mut ::core::ffi::c_char,
-    pub _IO_write_end: *mut ::core::ffi::c_char,
-    pub _IO_buf_base: *mut ::core::ffi::c_char,
-    pub _IO_buf_end: *mut ::core::ffi::c_char,
-    pub _IO_save_base: *mut ::core::ffi::c_char,
-    pub _IO_backup_base: *mut ::core::ffi::c_char,
-    pub _IO_save_end: *mut ::core::ffi::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::core::ffi::c_int,
-    pub _flags2: ::core::ffi::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::core::ffi::c_ushort,
-    pub _vtable_offset: ::core::ffi::c_schar,
-    pub _shortbuf: [::core::ffi::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::core::ffi::c_void,
-    pub __pad5: usize,
-    pub _mode: ::core::ffi::c_int,
-    pub _unused2: [::core::ffi::c_char; 20usize],
-}
-#[cfg(any(
-    feature = "cuda-11050",
-    feature = "cuda-11060",
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
-}
-#[cfg(any(
-    feature = "cuda-11050",
-    feature = "cuda-11060",
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
-}
-#[cfg(any(
-    feature = "cuda-11050",
-    feature = "cuda-11060",
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 #[repr(C)]
@@ -1121,30 +985,6 @@ impl cusparseSpMVAlg_t {
 ))]
 impl cusparseSpMVAlg_t {
     pub const CUSPARSE_SPMV_CSR_ALG2: cusparseSpMVAlg_t = cusparseSpMVAlg_t::CUSPARSE_CSRMV_ALG2;
-}
-#[cfg(any(
-    feature = "cuda-11050",
-    feature = "cuda-11060",
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
-    feature = "cuda-12020",
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090"
-))]
-impl Default for _IO_FILE {
-    fn default() -> Self {
-        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
 }
 #[cfg(not(feature = "dynamic-loading"))]
 extern "C" {
@@ -37178,6 +37018,19 @@ mod loaded {
                 cusparseZsctr,
             })
         }
+    }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["cusparse"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
     }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();

--- a/src/driver/sys/mod.rs
+++ b/src/driver/sys/mod.rs
@@ -23536,6 +23536,19 @@ mod loaded {
             })
         }
     }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["cuda", "nvcuda"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
+    }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();
         LIB.get_or_init(|| {

--- a/src/nccl/sys/mod.rs
+++ b/src/nccl/sys/mod.rs
@@ -821,6 +821,19 @@ mod loaded {
             })
         }
     }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["nccl"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
+    }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();
         LIB.get_or_init(|| {

--- a/src/nvrtc/sys/mod.rs
+++ b/src/nvrtc/sys/mod.rs
@@ -36,7 +36,8 @@ pub enum nvrtcResult {
     feature = "cuda-12020",
     feature = "cuda-12030",
     feature = "cuda-12040",
-    feature = "cuda-12050"
+    feature = "cuda-12050",
+    feature = "cuda-12060"
 ))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -55,7 +56,7 @@ pub enum nvrtcResult {
     NVRTC_ERROR_INTERNAL_ERROR = 11,
     NVRTC_ERROR_TIME_FILE_WRITE_FAILED = 12,
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum nvrtcResult {
@@ -743,6 +744,19 @@ mod loaded {
                 nvrtcVersion,
             })
         }
+    }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["nvrtc"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
     }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();

--- a/src/runtime/sys/mod.rs
+++ b/src/runtime/sys/mod.rs
@@ -17343,6 +17343,19 @@ mod loaded {
             })
         }
     }
+    pub unsafe fn is_culib_present() -> bool {
+        let lib_names = ["cudart"];
+        let choices = lib_names
+            .iter()
+            .map(|l| crate::get_lib_name_candidates(l))
+            .flatten();
+        for choice in choices {
+            if Lib::new(choice).is_ok() {
+                return true;
+            }
+        }
+        false
+    }
     pub unsafe fn culib() -> &'static Lib {
         static LIB: std::sync::OnceLock<Lib> = std::sync::OnceLock::new();
         LIB.get_or_init(|| {


### PR DESCRIPTION
A trimmed down version of `culib`, which simply returns `true` if a library was found and `false` otherwise.  It doesn't update the static `LIB` variable from `culib`, because `OnceLock` doesn't allow aborting initialization.  But I think that should be fine, since this function would realistically only be called once on startup.

In theory this function can be made safe by skipping loading the library.  I'm not sure what's the chance of stumbling on `libcuda.so` which isn't actually a dynamic CUDA library.

This is a draft with one such function in `driver`.  If there's an interest in this merging this PR, I'll update all of the modules.

Resolves #429