### PR TITLE
Fix `nvrtc` lib for CUDA 12.6

### DIFF
--- a/src/nvrtc/sys/mod.rs
+++ b/src/nvrtc/sys/mod.rs
@@ -725,35 +725,20 @@ mod loaded {
                     feature = "cuda-12090"
                 ))]
                 nvrtcGetOptiXIRSize,
-                #[cfg(any(
-                    feature = "cuda-12080",
-                    feature = "cuda-12090"
-                ))]
+                #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
                 nvrtcGetPCHCreateStatus,
-                #[cfg(any(
-                    feature = "cuda-12080",
-                    feature = "cuda-12090"
-                ))]
+                #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
                 nvrtcGetPCHHeapSize,
-                #[cfg(any(
-                    feature = "cuda-12080",
-                    feature = "cuda-12090"
-                ))]
+                #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
                 nvrtcGetPCHHeapSizeRequired,
                 nvrtcGetPTX,
                 nvrtcGetPTXSize,
                 nvrtcGetProgramLog,
                 nvrtcGetProgramLogSize,
                 nvrtcGetSupportedArchs,
-                #[cfg(any(
-                    feature = "cuda-12080",
-                    feature = "cuda-12090"
-                ))]
+                #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
                 nvrtcSetFlowCallback,
-                #[cfg(any(
-                    feature = "cuda-12080",
-                    feature = "cuda-12090"
-                ))]
+                #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
                 nvrtcSetPCHHeapSize,
                 nvrtcVersion,
             })

--- a/src/nvrtc/sys/mod.rs
+++ b/src/nvrtc/sys/mod.rs
@@ -161,18 +161,18 @@ extern "C" {
         feature = "cuda-12090"
     ))]
     pub fn nvrtcGetOptiXIRSize(prog: nvrtcProgram, optixirSizeRet: *mut usize) -> nvrtcResult;
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub fn nvrtcGetPCHCreateStatus(prog: nvrtcProgram) -> nvrtcResult;
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub fn nvrtcGetPCHHeapSize(ret: *mut usize) -> nvrtcResult;
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub fn nvrtcGetPCHHeapSizeRequired(prog: nvrtcProgram, size: *mut usize) -> nvrtcResult;
     pub fn nvrtcGetPTX(prog: nvrtcProgram, ptx: *mut ::core::ffi::c_char) -> nvrtcResult;
     pub fn nvrtcGetPTXSize(prog: nvrtcProgram, ptxSizeRet: *mut usize) -> nvrtcResult;
     pub fn nvrtcGetProgramLog(prog: nvrtcProgram, log: *mut ::core::ffi::c_char) -> nvrtcResult;
     pub fn nvrtcGetProgramLogSize(prog: nvrtcProgram, logSizeRet: *mut usize) -> nvrtcResult;
     pub fn nvrtcGetSupportedArchs(supportedArchs: *mut ::core::ffi::c_int) -> nvrtcResult;
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub fn nvrtcSetFlowCallback(
         prog: nvrtcProgram,
         callback: ::core::option::Option<
@@ -183,7 +183,7 @@ extern "C" {
         >,
         payload: *mut ::core::ffi::c_void,
     ) -> nvrtcResult;
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub fn nvrtcSetPCHHeapSize(size: usize) -> nvrtcResult;
     pub fn nvrtcVersion(
         major: *mut ::core::ffi::c_int,
@@ -312,15 +312,15 @@ mod loaded {
     ) -> nvrtcResult {
         (culib().nvrtcGetOptiXIRSize)(prog, optixirSizeRet)
     }
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub unsafe fn nvrtcGetPCHCreateStatus(prog: nvrtcProgram) -> nvrtcResult {
         (culib().nvrtcGetPCHCreateStatus)(prog)
     }
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub unsafe fn nvrtcGetPCHHeapSize(ret: *mut usize) -> nvrtcResult {
         (culib().nvrtcGetPCHHeapSize)(ret)
     }
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub unsafe fn nvrtcGetPCHHeapSizeRequired(prog: nvrtcProgram, size: *mut usize) -> nvrtcResult {
         (culib().nvrtcGetPCHHeapSizeRequired)(prog, size)
     }
@@ -345,7 +345,7 @@ mod loaded {
     pub unsafe fn nvrtcGetSupportedArchs(supportedArchs: *mut ::core::ffi::c_int) -> nvrtcResult {
         (culib().nvrtcGetSupportedArchs)(supportedArchs)
     }
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub unsafe fn nvrtcSetFlowCallback(
         prog: nvrtcProgram,
         callback: ::core::option::Option<
@@ -358,7 +358,7 @@ mod loaded {
     ) -> nvrtcResult {
         (culib().nvrtcSetFlowCallback)(prog, callback, payload)
     }
-    #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+    #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
     pub unsafe fn nvrtcSetPCHHeapSize(size: usize) -> nvrtcResult {
         (culib().nvrtcSetPCHHeapSize)(size)
     }
@@ -463,11 +463,11 @@ mod loaded {
         ))]
         pub nvrtcGetOptiXIRSize:
             unsafe extern "C" fn(prog: nvrtcProgram, optixirSizeRet: *mut usize) -> nvrtcResult,
-        #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+        #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
         pub nvrtcGetPCHCreateStatus: unsafe extern "C" fn(prog: nvrtcProgram) -> nvrtcResult,
-        #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+        #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
         pub nvrtcGetPCHHeapSize: unsafe extern "C" fn(ret: *mut usize) -> nvrtcResult,
-        #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+        #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
         pub nvrtcGetPCHHeapSizeRequired:
             unsafe extern "C" fn(prog: nvrtcProgram, size: *mut usize) -> nvrtcResult,
         pub nvrtcGetPTX:
@@ -480,7 +480,7 @@ mod loaded {
             unsafe extern "C" fn(prog: nvrtcProgram, logSizeRet: *mut usize) -> nvrtcResult,
         pub nvrtcGetSupportedArchs:
             unsafe extern "C" fn(supportedArchs: *mut ::core::ffi::c_int) -> nvrtcResult,
-        #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+        #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
         pub nvrtcSetFlowCallback: unsafe extern "C" fn(
             prog: nvrtcProgram,
             callback: ::core::option::Option<
@@ -491,7 +491,7 @@ mod loaded {
             >,
             payload: *mut ::core::ffi::c_void,
         ) -> nvrtcResult,
-        #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+        #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
         pub nvrtcSetPCHHeapSize: unsafe extern "C" fn(size: usize) -> nvrtcResult,
         pub nvrtcVersion: unsafe extern "C" fn(
             major: *mut ::core::ffi::c_int,
@@ -615,17 +615,17 @@ mod loaded {
                 .get(b"nvrtcGetOptiXIRSize\0")
                 .map(|sym| *sym)
                 .expect("Expected symbol in library");
-            #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+            #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
             let nvrtcGetPCHCreateStatus = __library
                 .get(b"nvrtcGetPCHCreateStatus\0")
                 .map(|sym| *sym)
                 .expect("Expected symbol in library");
-            #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+            #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
             let nvrtcGetPCHHeapSize = __library
                 .get(b"nvrtcGetPCHHeapSize\0")
                 .map(|sym| *sym)
                 .expect("Expected symbol in library");
-            #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+            #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
             let nvrtcGetPCHHeapSizeRequired = __library
                 .get(b"nvrtcGetPCHHeapSizeRequired\0")
                 .map(|sym| *sym)
@@ -650,12 +650,12 @@ mod loaded {
                 .get(b"nvrtcGetSupportedArchs\0")
                 .map(|sym| *sym)
                 .expect("Expected symbol in library");
-            #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+            #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
             let nvrtcSetFlowCallback = __library
                 .get(b"nvrtcSetFlowCallback\0")
                 .map(|sym| *sym)
                 .expect("Expected symbol in library");
-            #[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
+            #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
             let nvrtcSetPCHHeapSize = __library
                 .get(b"nvrtcSetPCHHeapSize\0")
                 .map(|sym| *sym)
@@ -726,19 +726,16 @@ mod loaded {
                 ))]
                 nvrtcGetOptiXIRSize,
                 #[cfg(any(
-                    feature = "cuda-12060",
                     feature = "cuda-12080",
                     feature = "cuda-12090"
                 ))]
                 nvrtcGetPCHCreateStatus,
                 #[cfg(any(
-                    feature = "cuda-12060",
                     feature = "cuda-12080",
                     feature = "cuda-12090"
                 ))]
                 nvrtcGetPCHHeapSize,
                 #[cfg(any(
-                    feature = "cuda-12060",
                     feature = "cuda-12080",
                     feature = "cuda-12090"
                 ))]
@@ -749,13 +746,11 @@ mod loaded {
                 nvrtcGetProgramLogSize,
                 nvrtcGetSupportedArchs,
                 #[cfg(any(
-                    feature = "cuda-12060",
                     feature = "cuda-12080",
                     feature = "cuda-12090"
                 ))]
                 nvrtcSetFlowCallback,
                 #[cfg(any(
-                    feature = "cuda-12060",
                     feature = "cuda-12080",
                     feature = "cuda-12090"
                 ))]


### PR DESCRIPTION
In [this](https://github.com/coreylowman/cudarc/commit/a6d4c9a020f76bb32bc8a4683504314be2a18676) commit, the following NVRTC API functions were erroneously added for compiling with CUDA 12.6:
- nvrtcGetPCHCreateStatus
- nvrtcGetPCHHeapSize
- nvrtcGetPCHHeapSizeRequired
- nvrtcSetFlowCallback
- nvrtcSetPCHHeapSize

If you review the [archived API documentation](https://docs.nvidia.com/cuda/archive/12.6.0/nvrtc/index.html) you can see these are not present.
Maybe something strange happened in the bindings generator? I reran it for CUDA 12.6 only and it did not generate the erroneous bindings.