### PR TITLE
CudaContext::disable_event_tracking now properly stops all stream sync after call

### DIFF
--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -100,7 +100,7 @@ unsafe impl<'a, 'b: 'a, T: DeviceRepr> PushKernelArg<&'b T> for LaunchArgs<'a> {
 unsafe impl<'a, 'b: 'a, T> PushKernelArg<&'b CudaSlice<T>> for LaunchArgs<'a> {
     #[inline(always)]
     fn arg(&mut self, arg: &'b CudaSlice<T>) -> &mut Self {
-        if self.stream.context().is_in_multi_stream_mode() {
+        if self.stream.context().is_managing_stream_synchronization() {
             if let Some(write) = arg.write.as_ref() {
                 self.waits.push(write);
             }
@@ -117,7 +117,7 @@ unsafe impl<'a, 'b: 'a, T> PushKernelArg<&'b CudaSlice<T>> for LaunchArgs<'a> {
 unsafe impl<'a, 'b: 'a, T> PushKernelArg<&'b mut CudaSlice<T>> for LaunchArgs<'a> {
     #[inline(always)]
     fn arg(&mut self, arg: &'b mut CudaSlice<T>) -> &mut Self {
-        if self.stream.context().is_in_multi_stream_mode() {
+        if self.stream.context().is_managing_stream_synchronization() {
             if let Some(read) = arg.read.as_ref() {
                 self.waits.push(read);
             }
@@ -135,7 +135,7 @@ unsafe impl<'a, 'b: 'a, T> PushKernelArg<&'b mut CudaSlice<T>> for LaunchArgs<'a
 unsafe impl<'a, 'b: 'a, 'c: 'b, T> PushKernelArg<&'b CudaView<'c, T>> for LaunchArgs<'a> {
     #[inline(always)]
     fn arg(&mut self, arg: &'b CudaView<'c, T>) -> &mut Self {
-        if self.stream.context().is_in_multi_stream_mode() {
+        if self.stream.context().is_managing_stream_synchronization() {
             if let Some(write) = arg.write.as_ref() {
                 self.waits.push(write);
             }
@@ -151,7 +151,7 @@ unsafe impl<'a, 'b: 'a, 'c: 'b, T> PushKernelArg<&'b CudaView<'c, T>> for Launch
 unsafe impl<'a, 'b: 'a, 'c: 'b, T> PushKernelArg<&'b mut CudaViewMut<'c, T>> for LaunchArgs<'a> {
     #[inline(always)]
     fn arg(&mut self, arg: &'b mut CudaViewMut<'c, T>) -> &mut Self {
-        if self.stream.context().is_in_multi_stream_mode() {
+        if self.stream.context().is_managing_stream_synchronization() {
             if let Some(read) = arg.read.as_ref() {
                 self.waits.push(read);
             }


### PR DESCRIPTION
Resolves #435 