### PR TITLE
Add support for Cuda 13.0

### DIFF
--- a/.github/workflows/cargo-check.yaml
+++ b/.github/workflows/cargo-check.yaml
@@ -23,6 +23,7 @@ jobs:
           - cuda-12060
           - cuda-12080
           - cuda-12090
+          - cuda-13000
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cargo-clippy.yaml
+++ b/.github/workflows/cargo-clippy.yaml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-default-features --features cuda-12090,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl,dynamic-loading,cufile --all-targets -- -D warnings
+          args: --no-default-features --features cuda-13000,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl,dynamic-loading,cufile --all-targets -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["api-bindings", "hardware-support", "memory-management", "no-std",
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [package.metadata.docs.rs]
-features = ["cuda-12090", "f16", "cudnn"]
+features = ["cuda-13000", "f16", "cudnn"]
 
 [features]
 default = ["std", "cublas", "cublaslt", "curand", "driver", "runtime", "nvrtc", "dynamic-loading"]
@@ -36,6 +36,7 @@ cuda-12050 = []
 cuda-12060 = []
 cuda-12080 = []
 cuda-12090 = []
+cuda-13000 = []
 
 dynamic-loading = []
 dynamic-linking = []

--- a/build.rs
+++ b/build.rs
@@ -22,6 +22,7 @@ fn main() {
 
     let (major, minor): (usize, usize) = if let Ok(version) = std::env::var("CUDARC_CUDA_VERSION") {
         let (major, minor) = match version.as_str() {
+            "13000" => (13, 0),
             "12090" => (12, 9),
             "12080" => (12, 8),
             "12060" => (12, 6),
@@ -40,6 +41,8 @@ fn main() {
         };
         println!("cargo:rustc-cfg=feature=\"cuda-{major}0{minor}0\"");
         (major, minor)
+    } else if cfg!(feature = "cuda-13000") {
+        (13, 0)
     } else if cfg!(feature = "cuda-12090") {
         (12, 9)
     } else if cfg!(feature = "cuda-12080") {
@@ -70,7 +73,7 @@ fn main() {
         (11, 4)
     } else {
         #[cfg(not(feature = "cuda-version-from-build-system"))]
-        panic!("Must specify one of the following features: [cuda-version-from-build-system, cuda-12090, cuda-12080, cuda-12060, cuda-12050, cuda-12040, cuda-12030, cuda-12020, cuda-12010, cuda-12000, cuda-11080, cuda-11070, cuda-11060, cuda-11050, cuda-11040]");
+        panic!("Must specify one of the following features: [cuda-version-from-build-system, cuda-13000, cuda-12090, cuda-12080, cuda-12060, cuda-12050, cuda-12040, cuda-12030, cuda-12020, cuda-12010, cuda-12000, cuda-11080, cuda-11070, cuda-11060, cuda-11050, cuda-11040]");
 
         #[cfg(feature = "cuda-version-from-build-system")]
         {
@@ -111,6 +114,7 @@ fn cuda_version_from_build_system() -> (usize, usize) {
     let version_number = release_section.split(' ').nth(1).unwrap();
 
     match version_number {
+        "13.0" => (13, 0),
         "12.9" => (12, 9),
         "12.8" => (12, 8),
         "12.6" => (12, 6),


### PR DESCRIPTION
Currently bindings generator fails because of a couple reasons:
- [ ] Cudnn doesn't have support for cuda 13.0 yet. need to decide what to do, probably just skip for cudnn for now?
- [ ] the header file for cudart seems to have some missing types (see below)

```
Error: Failed to generate cusolver for cuda-13000

Caused by:
    0: Failed to generate bindings for ../src/cusolver/sys/wrapper.h
    1: clang diagnosed error: downloads/primary/cuda_cudart-linux-x86_64-13.0.48-archive/include/cuda_runtime_api.h:9365:58: error: unknown type name 'cudaLogLevel'
       downloads/primary/cuda_cudart-linux-x86_64-13.0.48-archive/include/cuda_runtime_api.h:9378:113: error: unknown type name 'cudaLogsCallbackHandle'
       downloads/primary/cuda_cudart-linux-x86_64-13.0.48-archive/include/cuda_runtime_api.h:9389:66: error: unknown type name 'cudaLogsCallbackHandle'
       downloads/primary/cuda_cudart-linux-x86_64-13.0.48-archive/include/cuda_runtime_api.h:9401:55: error: unknown type name 'cudaLogIterator'
       downloads/primary/cuda_cudart-linux-x86_64-13.0.48-archive/include/cuda_runtime_api.h:9425:58: error: unknown type name 'cudaLogIterator'
       downloads/primary/cuda_cudart-linux-x86_64-13.0.48-archive/include/cuda_runtime_api.h:9461:60: error: unknown type name 'cudaLogIterator'
```