### PR TITLE
fp8 and fp4 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ cufile = ["driver"]
 std = []
 no-std = ["no-std-compat/std"]
 f16 = ["dep:half"]
+f8 = ["dep:float8"]
 
 [dependencies]
 no-std-compat = { version = "0.4.1", optional = true, features = ["alloc"] }
@@ -66,4 +67,5 @@ half = { version = "2", optional = true, default-features = false, features = [
     "num-traits",
     "rand_distr",
 ] }
+float8 = { version = "0.3.0", optional = true }
 libloading = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,39 @@ repository = "https://github.com/coreylowman/cudarc"
 readme = "README.md"
 
 keywords = ["cuda", "nvidia", "gpu", "cudnn", "cublas"]
-categories = ["api-bindings", "hardware-support", "memory-management", "no-std", "science"]
+categories = [
+    "api-bindings",
+    "hardware-support",
+    "memory-management",
+    "no-std",
+    "science",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [package.metadata.docs.rs]
-features = ["cuda-12090", "f16", "cudnn", "nccl", "cusparse", "cusolver", "cusolvermg", "cufile"]
+features = [
+    "cuda-12090",
+    "f16",
+    "cudnn",
+    "nccl",
+    "cusparse",
+    "cusolver",
+    "cusolvermg",
+    "cufile",
+]
 
 [features]
-default = ["std", "cublas", "cublaslt", "curand", "driver", "runtime", "nvrtc", "dynamic-loading"]
+default = [
+    "std",
+    "cublas",
+    "cublaslt",
+    "curand",
+    "driver",
+    "runtime",
+    "nvrtc",
+    "dynamic-loading",
+]
 
 cuda-version-from-build-system = []
 cuda-11040 = []
@@ -60,6 +84,7 @@ std = []
 no-std = ["no-std-compat/std"]
 f16 = ["dep:half"]
 f8 = ["dep:float8"]
+f4 = ["dep:float4"]
 
 [dependencies]
 no-std-compat = { version = "0.4.1", optional = true, features = ["alloc"] }
@@ -68,4 +93,5 @@ half = { version = "2", optional = true, default-features = false, features = [
     "rand_distr",
 ] }
 float8 = { version = "0.3.0", optional = true }
+float4 = { version = "0.1.0", optional = true }
 libloading = "0.8"

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -747,6 +747,18 @@ unsafe impl DeviceRepr for half::f16 {}
 #[cfg(feature = "f16")]
 unsafe impl DeviceRepr for half::bf16 {}
 
+#[cfg(feature = "f8")]
+unsafe impl DeviceRepr for float8::F8E4M3 {}
+
+#[cfg(feature = "f8")]
+unsafe impl ValidAsZeroBits for float8::F8E4M3 {}
+
+#[cfg(feature = "f8")]
+unsafe impl DeviceRepr for float8::F8E5M2 {}
+
+#[cfg(feature = "f8")]
+unsafe impl ValidAsZeroBits for float8::F8E5M2 {}
+
 /// Base trait for abstracting over [CudaSlice]/[CudaView]/[CudaViewMut].
 ///
 /// Don't use this directly - use [DevicePtr]/[DevicePtrMut].

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -749,15 +749,23 @@ unsafe impl DeviceRepr for half::bf16 {}
 
 #[cfg(feature = "f8")]
 unsafe impl DeviceRepr for float8::F8E4M3 {}
-
 #[cfg(feature = "f8")]
 unsafe impl ValidAsZeroBits for float8::F8E4M3 {}
 
 #[cfg(feature = "f8")]
 unsafe impl DeviceRepr for float8::F8E5M2 {}
-
 #[cfg(feature = "f8")]
 unsafe impl ValidAsZeroBits for float8::F8E5M2 {}
+
+#[cfg(feature = "f4")]
+unsafe impl DeviceRepr for float4::F4E2M1 {}
+#[cfg(feature = "f4")]
+unsafe impl ValidAsZeroBits for float4::F4E2M1 {}
+
+#[cfg(feature = "f4")]
+unsafe impl DeviceRepr for float4::E8M0 {}
+#[cfg(feature = "f4")]
+unsafe impl ValidAsZeroBits for float4::E8M0 {}
 
 /// Base trait for abstracting over [CudaSlice]/[CudaView]/[CudaViewMut].
 ///


### PR DESCRIPTION
Add dependency and `DeviceRepr` impls for fp8. 

@EricLBuehler currently has these behind a feature in the float8 repo but to avoid circular dependencies this should mirror how half is used in cudarc. 
