### PR TITLE
Remove compile error for unsupported CUDA 13.0 in cudnn module

### DIFF
--- a/src/cudnn/mod.rs
+++ b/src/cudnn/mod.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "cuda-13000")]
-compile_error!("cudnn doesn't support cuda 13.0 yet, please open a PR once support has been added by cudnn team");
-
 pub mod result;
 pub mod safe;
 #[allow(warnings)]


### PR DESCRIPTION
Bring back cuDNN support for cuda13 since according to [cuDNN docs](https://docs.nvidia.com/deeplearning/cudnn/backend/latest/reference/support-matrix.html) it is supported now