### PR TITLE
Add result layer wrappers for 2D/3D pitched memory operations

### DIFF
--- a/examples/11-pitched-memory.rs
+++ b/examples/11-pitched-memory.rs
@@ -1,0 +1,208 @@
+use cudarc::driver::{result, sys, CudaContext, DriverError};
+use std::mem;
+
+fn main() -> Result<(), DriverError> {
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.default_stream();
+
+    println!("=== 2D Pitched Memory Example ===\n");
+
+    // Create a 2D "image" in host memory
+    // Let's say we have an 8x6 image of f32 values
+    const WIDTH: usize = 8;
+    const HEIGHT: usize = 6;
+    const ELEM_SIZE: usize = mem::size_of::<f32>();
+
+    let mut host_data = vec![0.0f32; WIDTH * HEIGHT];
+
+    // Fill with a pattern: value = row * 10 + col
+    for row in 0..HEIGHT {
+        for col in 0..WIDTH {
+            host_data[row * WIDTH + col] = (row * 10 + col) as f32;
+        }
+    }
+
+    println!("Host data ({}x{}):", WIDTH, HEIGHT);
+    for row in 0..HEIGHT {
+        print!("  Row {}: [", row);
+        for col in 0..WIDTH {
+            print!("{:5.1}", host_data[row * WIDTH + col]);
+            if col < WIDTH - 1 {
+                print!(", ");
+            }
+        }
+        println!("]");
+    }
+    println!();
+
+    // Allocate pitched 2D memory on device
+    let (device_ptr, pitch) =
+        unsafe { result::malloc_pitched(WIDTH * ELEM_SIZE, HEIGHT, ELEM_SIZE as u32)? };
+
+    println!("Allocated pitched memory:");
+    println!(
+        "  Requested width: {} bytes ({} elements)",
+        WIDTH * ELEM_SIZE,
+        WIDTH
+    );
+    println!(
+        "  Actual pitch:    {} bytes ({:.1} elements)",
+        pitch,
+        pitch as f64 / ELEM_SIZE as f64
+    );
+    println!("  Height:          {} rows", HEIGHT);
+    println!(
+        "  Pitch overhead:  {} bytes per row\n",
+        pitch - WIDTH * ELEM_SIZE
+    );
+
+    // Copy host data to device using 2D memcpy
+    let copy_params = sys::CUDA_MEMCPY2D {
+        srcXInBytes: 0,
+        srcY: 0,
+        srcMemoryType: sys::CUmemorytype::CU_MEMORYTYPE_HOST,
+        srcHost: host_data.as_ptr() as *const _,
+        srcDevice: 0,
+        srcArray: std::ptr::null_mut(),
+        srcPitch: WIDTH * ELEM_SIZE, // Host data is tightly packed
+
+        dstXInBytes: 0,
+        dstY: 0,
+        dstMemoryType: sys::CUmemorytype::CU_MEMORYTYPE_DEVICE,
+        dstHost: std::ptr::null_mut(),
+        dstDevice: device_ptr,
+        dstArray: std::ptr::null_mut(),
+        dstPitch: pitch, // Device uses pitched memory
+
+        WidthInBytes: WIDTH * ELEM_SIZE,
+        Height: HEIGHT,
+    };
+
+    unsafe {
+        result::memcpy_2d_async(&copy_params, stream.cu_stream())?;
+    }
+
+    stream.synchronize()?;
+    println!("Copied host data to pitched device memory\n");
+
+    // Allocate host memory to receive the data back
+    let mut host_result = vec![0.0f32; WIDTH * HEIGHT];
+
+    // Copy back from device to host
+    let copy_back_params = sys::CUDA_MEMCPY2D {
+        srcXInBytes: 0,
+        srcY: 0,
+        srcMemoryType: sys::CUmemorytype::CU_MEMORYTYPE_DEVICE,
+        srcHost: std::ptr::null(),
+        srcDevice: device_ptr,
+        srcArray: std::ptr::null_mut(),
+        srcPitch: pitch, // Device uses pitched memory
+
+        dstXInBytes: 0,
+        dstY: 0,
+        dstMemoryType: sys::CUmemorytype::CU_MEMORYTYPE_HOST,
+        dstHost: host_result.as_mut_ptr() as *mut _,
+        dstDevice: 0,
+        dstArray: std::ptr::null_mut(),
+        dstPitch: WIDTH * ELEM_SIZE, // Host data is tightly packed
+
+        WidthInBytes: WIDTH * ELEM_SIZE,
+        Height: HEIGHT,
+    };
+
+    unsafe {
+        result::memcpy_2d_async(&copy_back_params, stream.cu_stream())?;
+    }
+
+    stream.synchronize()?;
+    println!("Copied device data back to host\n");
+
+    // Verify the data
+    println!("Verification:");
+    let mut all_match = true;
+    for row in 0..HEIGHT {
+        for col in 0..WIDTH {
+            let idx = row * WIDTH + col;
+            if (host_data[idx] - host_result[idx]).abs() > 1e-6 {
+                println!(
+                    "  ✗ Mismatch at ({}, {}): expected {}, got {}",
+                    row, col, host_data[idx], host_result[idx]
+                );
+                all_match = false;
+            }
+        }
+    }
+
+    if all_match {
+        println!(" All {} elements match!", WIDTH * HEIGHT);
+    }
+
+    // Clean up
+    unsafe {
+        result::free_sync(device_ptr)?;
+    }
+
+    println!("\n=== 2D Sub-Region Copy Example ===\n");
+
+    // Now demonstrate copying a sub-region (4x3 region starting at offset (2,1))
+    let sub_width = 4;
+    let sub_height = 3;
+    let offset_x = 2;
+    let offset_y = 1;
+
+    let (device_ptr2, pitch2) =
+        unsafe { result::malloc_pitched(WIDTH * ELEM_SIZE, HEIGHT, ELEM_SIZE as u32)? };
+
+    // Copy a sub-region from host to device
+    let sub_copy_params = sys::CUDA_MEMCPY2D {
+        srcXInBytes: offset_x * ELEM_SIZE,
+        srcY: offset_y,
+        srcMemoryType: sys::CUmemorytype::CU_MEMORYTYPE_HOST,
+        srcHost: host_data.as_ptr() as *const _,
+        srcDevice: 0,
+        srcArray: std::ptr::null_mut(),
+        srcPitch: WIDTH * ELEM_SIZE,
+
+        dstXInBytes: 0,
+        dstY: 0,
+        dstMemoryType: sys::CUmemorytype::CU_MEMORYTYPE_DEVICE,
+        dstHost: std::ptr::null_mut(),
+        dstDevice: device_ptr2,
+        dstArray: std::ptr::null_mut(),
+        dstPitch: pitch2,
+
+        WidthInBytes: sub_width * ELEM_SIZE,
+        Height: sub_height,
+    };
+
+    unsafe {
+        result::memcpy_2d_async(&sub_copy_params, stream.cu_stream())?;
+    }
+
+    stream.synchronize()?;
+
+    println!(
+        "Copied {}x{} sub-region starting at ({}, {}):",
+        sub_width, sub_height, offset_x, offset_y
+    );
+
+    for row in offset_y..(offset_y + sub_height) {
+        print!("  Original row {}: [", row);
+        for col in offset_x..(offset_x + sub_width) {
+            print!("{:5.1}", host_data[row * WIDTH + col]);
+            if col < offset_x + sub_width - 1 {
+                print!(", ");
+            }
+        }
+        println!("]");
+    }
+
+    // Clean up
+    unsafe {
+        result::free_sync(device_ptr2)?;
+    }
+
+    println!("\n2D memory operations completed successfully!");
+
+    Ok(())
+}

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -657,6 +657,34 @@ pub unsafe fn malloc_managed(
     Ok(dev_ptr.assume_init())
 }
 
+/// Allocates pitched 2D memory.
+///
+/// Returns (device_ptr, pitch_in_bytes). The pitch may be larger than `width_in_bytes`
+/// for alignment purposes.
+///
+/// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g802f38ca88abfc88aaea8ca1f07b7c56)
+///
+/// # Safety
+/// 1. The memory returned by this is unset, which may be invalid for `T`.
+/// 2. Memory should be freed with [free_sync].
+pub unsafe fn malloc_pitched(
+    width_in_bytes: usize,
+    height: usize,
+    elem_size_bytes: c_uint,
+) -> Result<(sys::CUdeviceptr, usize), DriverError> {
+    let mut dev_ptr = MaybeUninit::uninit();
+    let mut pitch = MaybeUninit::uninit();
+    sys::cuMemAllocPitch_v2(
+        dev_ptr.as_mut_ptr(),
+        pitch.as_mut_ptr(),
+        width_in_bytes,
+        height,
+        elem_size_bytes,
+    )
+    .result()?;
+    Ok((dev_ptr.assume_init(), pitch.assume_init()))
+}
+
 /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g572ca4011bfcb25034888a14d4e035b9)
 /// # Safety
 /// 1. The memory return by this is unset, which may be invalid for `T`.
@@ -895,6 +923,64 @@ pub unsafe fn memcpy_dtod_sync(
     num_bytes: usize,
 ) -> Result<(), DriverError> {
     sys::cuMemcpyDtoD_v2(dst, src, num_bytes).result()
+}
+
+/// Copies 2D memory with stream ordered semantics.
+///
+/// The `copy_params` struct specifies source/destination memory types, pointers,
+/// pitches, and the region to copy.
+///
+/// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g27f885e8a6e1f5896c47c55b4e3ff0a8)
+///
+/// # Safety
+/// 1. All pointers in `copy_params` must be valid for their specified memory types
+/// 2. Source and destination regions must not overlap (unless they're the same memory)
+/// 3. Pitches must be large enough for the width being copied
+/// 4. Memory must not have been freed
+pub unsafe fn memcpy_2d_async(
+    copy_params: &sys::CUDA_MEMCPY2D,
+    stream: sys::CUstream,
+) -> Result<(), DriverError> {
+    sys::cuMemcpy2DAsync_v2(copy_params, stream).result()
+}
+
+/// Copies 2D memory synchronously.
+///
+/// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g27f885e8a6e1f5896c47c55b4e3ff0a8)
+///
+/// # Safety
+/// Same safety requirements as [memcpy_2d_async]
+pub unsafe fn memcpy_2d_sync(copy_params: &sys::CUDA_MEMCPY2D) -> Result<(), DriverError> {
+    sys::cuMemcpy2D_v2(copy_params).result()
+}
+
+/// Copies 3D memory with stream ordered semantics.
+///
+/// The `copy_params` struct specifies source/destination memory types, pointers,
+/// pitches, heights, and the 3D region to copy.
+///
+/// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g1f5e25d5f88a15b45e6c0c6d3ee4ef0a)
+///
+/// # Safety
+/// 1. All pointers in `copy_params` must be valid for their specified memory types
+/// 2. Source and destination regions must not overlap (unless they're the same memory)
+/// 3. Pitches and heights must be large enough for the volume being copied
+/// 4. Memory must not have been freed
+pub unsafe fn memcpy_3d_async(
+    copy_params: &sys::CUDA_MEMCPY3D,
+    stream: sys::CUstream,
+) -> Result<(), DriverError> {
+    sys::cuMemcpy3DAsync_v2(copy_params, stream).result()
+}
+
+/// Copies 3D memory synchronously.
+///
+/// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g1f5e25d5f88a15b45e6c0c6d3ee4ef0a)
+///
+/// # Safety
+/// Same safety requirements as [memcpy_3d_async]
+pub unsafe fn memcpy_3d_sync(copy_params: &sys::CUDA_MEMCPY3D) -> Result<(), DriverError> {
+    sys::cuMemcpy3D_v2(copy_params).result()
 }
 
 /// Returns (free, total) memory in bytes.


### PR DESCRIPTION
**[DRAFT]** Adds low-level support for 2D/3D pitched memory allocation and transfers. Safe API wrappers
   to follow.

  ### Changes
  - **Result layer**: Added wrappers for pitched memory operations:
    - `malloc_pitched()` - Allocate 2D memory with GPU-optimized row alignment
    - `memcpy_2d_async()` / `memcpy_2d_sync()` - 2D memory transfers
    - `memcpy_3d_async()` / `memcpy_3d_sync()` - 3D memory transfers
  - **Example**: Added `11-pitched-memory.rs` demonstrating:
    - Pitched allocation (512-byte aligned rows for 32-byte data)
    - Host <-> Device 2D transfers
    - Sub-region (strided) copying
    - Data verification

  ### Usage (unsafe for now)
  ```rust
  let (device_ptr, pitch) = unsafe {
      result::malloc_pitched(width_bytes, height, elem_size)?
  };

  let copy_params = sys::CUDA_MEMCPY2D { /* ... */ };
  unsafe { result::memcpy_2d_async(&copy_params, stream)? };
  ```

  TODO (before marking ready for review)

  - Design safe API (CudaPitched2D<T>, CudaPitched3D<T> types)
  - Implement builder pattern for copy operations
  - Add safe wrapper methods to CudaStream