### PR TITLE
Add context configuration APIs

### DIFF
--- a/examples/12-context-config.rs
+++ b/examples/12-context-config.rs
@@ -1,0 +1,81 @@
+use cudarc::driver::sys;
+use cudarc::driver::CudaContext;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let dev = CudaContext::new(0)?;
+
+    println!("=== Context Limits ===");
+
+    // Query stack size limit
+    let stack_size = dev.get_limit(sys::CUlimit::CU_LIMIT_STACK_SIZE)?;
+    println!("Stack size per thread: {} bytes", stack_size);
+
+    // Query malloc heap size
+    let malloc_heap_size = dev.get_limit(sys::CUlimit::CU_LIMIT_MALLOC_HEAP_SIZE)?;
+    println!(
+        "Malloc heap size: {} bytes ({} MB)",
+        malloc_heap_size,
+        malloc_heap_size / 1024 / 1024
+    );
+
+    // Query printf buffer size
+    let printf_fifo_size = dev.get_limit(sys::CUlimit::CU_LIMIT_PRINTF_FIFO_SIZE)?;
+    println!(
+        "Printf buffer size: {} bytes ({} KB)",
+        printf_fifo_size,
+        printf_fifo_size / 1024
+    );
+
+    // Query device runtime sync depth
+    let dev_runtime_sync_depth = dev.get_limit(sys::CUlimit::CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH)?;
+    println!("Device runtime sync depth: {}", dev_runtime_sync_depth);
+
+    // Query device runtime pending launch count
+    let dev_runtime_pending_launch_count =
+        dev.get_limit(sys::CUlimit::CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT)?;
+    println!(
+        "Device runtime pending launch count: {}",
+        dev_runtime_pending_launch_count
+    );
+
+    println!("\n=== Cache Configuration ===");
+
+    // Query cache config
+    let cache_config = dev.get_cache_config()?;
+    let cache_str = match cache_config {
+        sys::CUfunc_cache::CU_FUNC_CACHE_PREFER_NONE => "No preference",
+        sys::CUfunc_cache::CU_FUNC_CACHE_PREFER_SHARED => "Prefer shared memory",
+        sys::CUfunc_cache::CU_FUNC_CACHE_PREFER_L1 => "Prefer L1 cache",
+        sys::CUfunc_cache::CU_FUNC_CACHE_PREFER_EQUAL => "Equal L1/shared",
+    };
+    println!("Current cache config: {:?} ({})", cache_config, cache_str);
+
+    println!("\n=== Testing Limit Modification ===");
+
+    // Demonstrate setting a limit - increase stack size
+    let new_stack_size = stack_size * 2;
+    println!("Setting stack size to {} bytes...", new_stack_size);
+    dev.set_limit(sys::CUlimit::CU_LIMIT_STACK_SIZE, new_stack_size)?;
+
+    let updated_stack_size = dev.get_limit(sys::CUlimit::CU_LIMIT_STACK_SIZE)?;
+    println!("Updated stack size: {} bytes", updated_stack_size);
+
+    // Restore original
+    dev.set_limit(sys::CUlimit::CU_LIMIT_STACK_SIZE, stack_size)?;
+    println!("Restored stack size to {} bytes", stack_size);
+
+    println!("\n=== Testing Cache Config Modification ===");
+
+    // Set cache config to prefer shared memory
+    println!("Setting cache config to prefer shared memory...");
+    dev.set_cache_config(sys::CUfunc_cache::CU_FUNC_CACHE_PREFER_SHARED)?;
+
+    let updated_cache_config = dev.get_cache_config()?;
+    println!("Updated cache config: {:?}", updated_cache_config);
+
+    // Restore original
+    dev.set_cache_config(cache_config)?;
+    println!("Restored cache config to {:?}", cache_config);
+
+    Ok(())
+}

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -460,6 +460,42 @@ pub mod ctx {
     pub fn synchronize() -> Result<(), DriverError> {
         unsafe { sys::cuCtxSynchronize() }.result()
     }
+
+    /// Gets the value of a context limit.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g9f2d47d1745752aa16da4f8d6b7f6f06)
+    pub fn get_limit(limit: sys::CUlimit) -> Result<usize, DriverError> {
+        let mut value = MaybeUninit::uninit();
+        unsafe {
+            sys::cuCtxGetLimit(value.as_mut_ptr(), limit).result()?;
+            Ok(value.assume_init())
+        }
+    }
+
+    /// Sets the value of a context limit.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1gf9496524a98e2ee1896d4b97d4c7ef32)
+    pub fn set_limit(limit: sys::CUlimit, value: usize) -> Result<(), DriverError> {
+        unsafe { sys::cuCtxSetLimit(limit, value).result() }
+    }
+
+    /// Gets the cache configuration preference.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g40b6b141698f76b6bc8f4d3b1f0d85e7)
+    pub fn get_cache_config() -> Result<sys::CUfunc_cache, DriverError> {
+        let mut config = MaybeUninit::uninit();
+        unsafe {
+            sys::cuCtxGetCacheConfig(config.as_mut_ptr()).result()?;
+            Ok(config.assume_init())
+        }
+    }
+
+    /// Sets the cache configuration preference.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g54699acb1e6b97eee1535e59a738229a)
+    pub fn set_cache_config(config: sys::CUfunc_cache) -> Result<(), DriverError> {
+        unsafe { sys::cuCtxSetCacheConfig(config).result() }
+    }
 }
 
 pub mod stream {

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -183,6 +183,49 @@ impl CudaContext {
         result::ctx::set_flags(flags)
     }
 
+    /// Gets the value of a context limit.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g9f2d47d1745752aa16da7ed0d111b6a8)
+    pub fn get_limit(&self, limit: sys::CUlimit) -> Result<usize, DriverError> {
+        self.bind_to_thread()?;
+        result::ctx::get_limit(limit)
+    }
+
+    /// Sets the value of a context limit.
+    ///
+    /// Common limits:
+    /// - `CU_LIMIT_STACK_SIZE` - Stack size for each thread
+    /// - `CU_LIMIT_PRINTF_FIFO_SIZE` - Size of printf buffer
+    /// - `CU_LIMIT_MALLOC_HEAP_SIZE` - Heap size for malloc() in kernels
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g0651954dfb9788173e60a9af7201e65a)
+    pub fn set_limit(&self, limit: sys::CUlimit, value: usize) -> Result<(), DriverError> {
+        self.bind_to_thread()?;
+        result::ctx::set_limit(limit, value)
+    }
+
+    /// Gets the L1/shared memory cache configuration preference.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g40b6b141698f76744dea6e39b9a25360)
+    pub fn get_cache_config(&self) -> Result<sys::CUfunc_cache, DriverError> {
+        self.bind_to_thread()?;
+        result::ctx::get_cache_config()
+    }
+
+    /// Sets the L1/shared memory cache configuration preference.
+    ///
+    /// Options:
+    /// - `CU_FUNC_CACHE_PREFER_NONE` - No preference
+    /// - `CU_FUNC_CACHE_PREFER_SHARED` - Prefer larger shared memory, smaller L1
+    /// - `CU_FUNC_CACHE_PREFER_L1` - Prefer larger L1, smaller shared memory
+    /// - `CU_FUNC_CACHE_PREFER_EQUAL` - Equal split between L1 and shared
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g54699acf7e2ef27279d013ca2095f4a3)
+    pub fn set_cache_config(&self, config: sys::CUfunc_cache) -> Result<(), DriverError> {
+        self.bind_to_thread()?;
+        result::ctx::set_cache_config(config)
+    }
+
     /// Whether multiple streams have been created in this context. If so,
     /// the [CudaSlice::read] and [CudaSlice::write] events will be activated.
     ///


### PR DESCRIPTION
Add safe wrappers for CUDA context configuration, including:
  - Context limits (stack size, malloc heap, printf buffer, runtime sync depth, pending launch count)
  - Cache configuration (L1/shared memory balance preferences)