### PR TITLE
Deprecate memcpy_stod,memcpy_dtov. Adds clone_htod,clone_dtoh

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ let ctx = cudarc::driver::CudaContext::new(0)?;
 let stream = ctx.default_stream();
 
 // copy a rust slice to the device
-let inp = stream.memcpy_stod(&[1.0f32; 100])?;
+let inp = stream.clone_htod(&[1.0f32; 100])?;
 
 // or allocate directly
 let mut out = stream.alloc_zeros::<f32>(100)?;
@@ -95,7 +95,7 @@ unsafe { builder.launch(LaunchConfig::for_num_elems(100)) }?;
 And of course it's easy to copy things back to host after you're done:
 
 ```rust
-let out_host: Vec<f32> = stream.memcpy_dtov(&out)?;
+let out_host: Vec<f32> = stream.clone_dtoh(&out)?;
 assert_eq!(out_host, [1.0; 100].map(f32::sin));
 ```
 

--- a/examples/01-allocate.rs
+++ b/examples/01-allocate.rs
@@ -11,8 +11,8 @@ fn main() -> Result<(), DriverError> {
     let _: CudaSlice<f64> = stream.alloc_zeros::<f64>(10)?;
 
     // initialize with slices!
-    let _: CudaSlice<usize> = stream.memcpy_stod(&[0; 10])?;
-    let _: CudaSlice<u32> = stream.memcpy_stod(&[1, 2, 3])?;
+    let _: CudaSlice<usize> = stream.clone_htod(&[0; 10])?;
+    let _: CudaSlice<u32> = stream.clone_htod(&[1, 2, 3])?;
 
     Ok(())
 }

--- a/examples/02-copy.rs
+++ b/examples/02-copy.rs
@@ -15,11 +15,11 @@ fn main() -> Result<(), DriverError> {
     // you can use any type of slice
     stream.memcpy_htod(&[3.0; 10], &mut b)?;
 
-    // you can transfer back using memcpy_dtov
-    let mut a_host: Vec<f64> = stream.memcpy_dtov(&a)?;
+    // you can transfer back using clone_dtoh
+    let mut a_host: Vec<f64> = stream.clone_dtoh(&a)?;
     assert_eq!(a_host, [0.0; 10]);
 
-    let b_host = stream.memcpy_dtov(&b)?;
+    let b_host = stream.clone_dtoh(&b)?;
     assert_eq!(b_host, [3.0; 10]);
 
     // or transfer into a pre allocated slice

--- a/examples/03-launch-kernel.rs
+++ b/examples/03-launch-kernel.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), DriverError> {
 
     let a_host = [1.0, 2.0, 3.0];
 
-    let a_dev = stream.memcpy_stod(&a_host)?;
+    let a_dev = stream.clone_htod(&a_host)?;
     let mut b_dev = a_dev.clone();
 
     // we use a buidler pattern to launch kernels.
@@ -27,8 +27,8 @@ fn main() -> Result<(), DriverError> {
     launch_args.arg(&n);
     unsafe { launch_args.launch(cfg) }?;
 
-    let a_host_2 = stream.memcpy_dtov(&a_dev)?;
-    let b_host = stream.memcpy_dtov(&b_dev)?;
+    let a_host_2 = stream.clone_dtoh(&a_dev)?;
+    let b_host = stream.clone_dtoh(&b_dev)?;
 
     println!("Found {b_host:?}");
     println!("Expected {:?}", a_host.map(f32::sin));

--- a/examples/04-streams.rs
+++ b/examples/04-streams.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), DriverError> {
 
     let n = 3i32;
     let a_host = [1.0, 2.0, 3.0];
-    let a_dev = stream.memcpy_stod(&a_host)?;
+    let a_dev = stream.clone_htod(&a_host)?;
     let mut b_dev = stream.alloc_zeros::<f32>(n as usize)?;
 
     // we can safely create a second stream using [CudaStream::fork()].
@@ -34,8 +34,8 @@ fn main() -> Result<(), DriverError> {
     // a_dev doesn't need to synchronize at all since we specified it is just
     // being read from.
     // b_dev DOES need to be synchronized, because it was mutated on a different stream.
-    let a_host_2 = stream.memcpy_dtov(&a_dev)?;
-    let b_host = stream.memcpy_dtov(&b_dev)?;
+    let a_host_2 = stream.clone_dtoh(&a_dev)?;
+    let b_host = stream.clone_dtoh(&b_dev)?;
 
     println!("Found {b_host:?}");
     println!("Expected {:?}", a_host.map(f32::sin));

--- a/examples/07-build-workflow/src/main.rs
+++ b/examples/07-build-workflow/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), DriverError> {
     let my_structs = vec![MyStruct { data: [1.0; 4] }; n];
 
     // copy to GPU
-    let mut gpu_my_structs = stream.memcpy_stod(&my_structs)?;
+    let mut gpu_my_structs = stream.clone_htod(&my_structs)?;
 
     println!("Time taken to initialise data: {:.2?}", now.elapsed());
 
@@ -65,7 +65,7 @@ fn main() -> Result<(), DriverError> {
 
     println!("Time taken to call kernel: {:.2?}", now.elapsed());
 
-    let my_structs = stream.memcpy_dtov(&gpu_my_structs)?;
+    let my_structs = stream.clone_dtoh(&gpu_my_structs)?;
 
     assert!(my_structs.iter().all(|i| i.data == [2.0; 4]));
 

--- a/examples/09-constant-memory.rs
+++ b/examples/09-constant-memory.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), DriverError> {
     let n = input.len();
 
     // Copy input to device
-    let input_dev = stream.memcpy_stod(&input)?;
+    let input_dev = stream.clone_htod(&input)?;
     let mut output_dev = stream.alloc_zeros::<f32>(n)?;
 
     // Launch kernel
@@ -48,7 +48,7 @@ fn main() -> Result<(), DriverError> {
     }?;
 
     // Copy results back
-    let output = stream.memcpy_dtov(&output_dev)?;
+    let output = stream.clone_dtoh(&output_dev)?;
 
     // Verify results
     println!("\nPolynomial evaluation (1.0 + 2.0*x + 3.0*x^2 + 4.0*x^3):");

--- a/examples/cufile-copy.rs
+++ b/examples/cufile-copy.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     handle.sync_read(0, &mut buf)?;
 
-    let verify_dst = stream.memcpy_dtov(&buf)?;
+    let verify_dst = stream.clone_dtoh(&buf)?;
     assert_eq!(verify_dst, data);
 
     Ok(())

--- a/examples/matmul-kernel.rs
+++ b/examples/matmul-kernel.rs
@@ -37,9 +37,9 @@ fn main() -> Result<(), DriverError> {
     let b_host = [1.0f32, 2.0, 3.0, 4.0];
     let mut c_host = [0.0f32; 4];
 
-    let a_dev = stream.memcpy_stod(&a_host)?;
-    let b_dev = stream.memcpy_stod(&b_host)?;
-    let mut c_dev = stream.memcpy_stod(&c_host)?;
+    let a_dev = stream.clone_htod(&a_host)?;
+    let b_dev = stream.clone_htod(&b_host)?;
+    let mut c_dev = stream.clone_htod(&c_host)?;
 
     println!("Copied in {:?}", start.elapsed());
 

--- a/src/cublas/safe/asum.rs
+++ b/src/cublas/safe/asum.rs
@@ -104,7 +104,7 @@ mod tests {
             let mut expected = result;
             sasum_truth(x, &mut actual, n, incx);
 
-            let x = stream.memcpy_stod(x).unwrap();
+            let x = stream.clone_htod(x).unwrap();
             unsafe {
                 blas.asum(
                     AsumConfig {
@@ -144,7 +144,7 @@ mod tests {
             let mut expected = result;
             dasum_truth(x, &mut actual, n, incx);
 
-            let x = stream.memcpy_stod(x).unwrap();
+            let x = stream.clone_htod(x).unwrap();
             unsafe {
                 blas.asum(
                     AsumConfig {

--- a/src/cublas/safe/gemm.rs
+++ b/src/cublas/safe/gemm.rs
@@ -410,13 +410,13 @@ mod tests {
         );
 
         #[rustfmt::skip]
-        let a_dev = stream.memcpy_stod(&[
+        let a_dev = stream.clone_htod(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ].map(half::f16::from_f32)).unwrap();
         #[rustfmt::skip]
-        let b_dev = stream.memcpy_stod(&[
+        let b_dev = stream.clone_htod(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
@@ -444,7 +444,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
+        let c_host = stream.clone_dtoh(&c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];
@@ -457,13 +457,13 @@ mod tests {
         }
 
         #[rustfmt::skip]
-        let a_dev = stream.memcpy_stod(&[
+        let a_dev = stream.clone_htod(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ].map(half::bf16::from_f32)).unwrap();
         #[rustfmt::skip]
-        let b_dev = stream.memcpy_stod(&[
+        let b_dev = stream.clone_htod(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
@@ -490,7 +490,7 @@ mod tests {
             )
         }
         .unwrap();
-        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
+        let c_host = stream.clone_dtoh(&c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];
@@ -526,13 +526,13 @@ mod tests {
         gemm_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = stream.memcpy_stod(&[
+        let a_dev = stream.clone_htod(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ]).unwrap();
         #[rustfmt::skip]
-        let b_dev = stream.memcpy_stod(&[
+        let b_dev = stream.clone_htod(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
@@ -560,7 +560,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
+        let c_host = stream.clone_dtoh(&c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 assert!((c_host[m * N + n] - c[m][n]) <= 1e-6);
@@ -591,14 +591,14 @@ mod tests {
         gemm_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = stream.memcpy_stod(&[
+        let a_dev = stream.clone_htod(&[
             -0.70925030, -1.01357541, -0.64827034,
             2.18493467, -0.61584842, -1.43844327,
             -1.34792593, 0.68840750, -0.48057214,
             1.22180992, 1.16245157, 0.01253436,
         ]).unwrap();
         #[rustfmt::skip]
-        let b_dev = stream.memcpy_stod(&[
+        let b_dev = stream.clone_htod(&[
             -0.72735474, 1.35931170,
             1.71798307, -0.13296247,
             0.26855612, -1.95189980,
@@ -625,7 +625,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
+        let c_host = stream.clone_dtoh(&c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 assert!((c_host[m * N + n] - c[m][n]) <= 1e-10);

--- a/src/cublas/safe/gemv.rs
+++ b/src/cublas/safe/gemv.rs
@@ -132,11 +132,11 @@ mod tests {
         gemv_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = stream.memcpy_stod(&[
+        let a_dev = stream.clone_htod(&[
             0.9314776, 0.10300648, -0.620774, 1.527075, 0.0259804,
             0.16820757, -0.94463515, -1.3850101, 1.0600523, 1.5124008,
         ]).unwrap();
-        let b_dev = stream.memcpy_stod(&b).unwrap();
+        let b_dev = stream.clone_htod(&b).unwrap();
         let mut c_dev = stream.alloc_zeros(M).unwrap();
         unsafe {
             blas.gemv(
@@ -157,7 +157,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
+        let c_host = stream.clone_dtoh(&c_dev).unwrap();
         for i in 0..M {
             assert!((c_host[i] - c[i]).abs() <= 1e-6);
         }
@@ -186,7 +186,7 @@ mod tests {
         gemv_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-        let a_dev = stream.memcpy_stod(&[
+        let a_dev = stream.clone_htod(&[
             0.96151888, -0.36771390, 0.94069099,
             2.20621538, -0.16479775, -1.78425562,
             0.41080803, -0.56567699, -0.72781092,
@@ -196,7 +196,7 @@ mod tests {
             -1.84258616, 0.24096519, -0.04563522,
             -0.53364468, -1.07902217, 0.46823528,
         ]).unwrap();
-        let b_dev = stream.memcpy_stod(&b).unwrap();
+        let b_dev = stream.clone_htod(&b).unwrap();
         let mut c_dev = stream.alloc_zeros(M).unwrap();
         unsafe {
             blas.gemv(
@@ -217,7 +217,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
+        let c_host = stream.clone_dtoh(&c_dev).unwrap();
         for i in 0..M {
             assert!((c_host[i] - c[i]).abs() <= 1e-8);
         }

--- a/src/cublaslt/safe.rs
+++ b/src/cublaslt/safe.rs
@@ -525,20 +525,20 @@ mod tests {
         matmul_truth(1.0, &a, &b, 0.0, &mut c);
 
         #[rustfmt::skip]
-            let a_dev = stream.memcpy_stod(&[
+        let a_dev = stream.clone_htod(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
             -1.6661372, -0.4568837, -0.9043474, 0.39125723,
         ]).unwrap();
         #[rustfmt::skip]
-            let b_dev = stream.memcpy_stod(&[
+        let b_dev = stream.clone_htod(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629,
             3.4746711, -1.0930681, 0.16502666, -0.59988785, 0.41375792,
         ]).unwrap();
         #[rustfmt::skip]
-            let bias = stream.alloc_zeros::<f32>(N).unwrap();
+        let bias = stream.alloc_zeros::<f32>(N).unwrap();
 
         let mut c_dev = stream.alloc_zeros::<f32>(M * N).unwrap();
         unsafe {
@@ -570,7 +570,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
+        let c_host = stream.clone_dtoh(&c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];
@@ -650,12 +650,12 @@ mod tests {
         );
 
         #[rustfmt::skip]
-            let a_dev = stream.memcpy_stod(&[
+            let a_dev = stream.clone_htod(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
         ].map(half::f16::from_f32)).unwrap();
         #[rustfmt::skip]
-            let b_dev = stream.memcpy_stod(&[
+            let b_dev = stream.clone_htod(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938, -1.6661372,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096, -0.4568837,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629, -0.9043474,
@@ -691,7 +691,7 @@ mod tests {
         }
         .unwrap();
 
-        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
+        let c_host = stream.clone_dtoh(&c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];
@@ -704,12 +704,12 @@ mod tests {
         }
 
         #[rustfmt::skip]
-            let a_dev = stream.memcpy_stod(&[
+            let a_dev = stream.clone_htod(&[
             -0.5944882, 1.8055636, 0.52204555, -0.00397902,
             -0.38346434, -0.38013917, 0.4198623, -0.22479166,
         ].map(half::bf16::from_f32)).unwrap();
         #[rustfmt::skip]
-            let b_dev = stream.memcpy_stod(&[
+            let b_dev = stream.clone_htod(&[
             1.1292169, -0.13450263, 0.62789696, -0.5685516, 0.21946938, -1.6661372,
             1.0585804, -0.39789402, 0.90205914, 0.989318, -0.3443096, -0.4568837,
             1.3412506, 0.3059701, -0.9714474, -0.36113533, -1.6809629, -0.9043474,
@@ -744,7 +744,7 @@ mod tests {
             )
         }
         .unwrap();
-        let c_host = stream.memcpy_dtov(&c_dev).unwrap();
+        let c_host = stream.clone_dtoh(&c_dev).unwrap();
         for m in 0..M {
             for n in 0..N {
                 let found = c_host[m * N + n];

--- a/src/cudnn/safe/mod.rs
+++ b/src/cudnn/safe/mod.rs
@@ -161,12 +161,12 @@ mod tests {
         // dimensions
 
         // Create input, filter and output tensors
-        let x = stream.memcpy_stod(&vec![1.0f32; 100 * 128 * 32]).unwrap();
+        let x = stream.clone_htod(&vec![1.0f32; 100 * 128 * 32]).unwrap();
         let x_desc = cudnn.create_4d_tensor::<f32>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             [100, 128, 32, 1],
         )?;
-        let filter = stream.memcpy_stod(&vec![1.0f32; 256 * 128 * 3]).unwrap();
+        let filter = stream.clone_htod(&vec![1.0f32; 256 * 128 * 3]).unwrap();
         let filter_desc = cudnn.create_nd_filter::<f32>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             &[256, 128, 3, 1],
@@ -199,7 +199,7 @@ mod tests {
                 op.launch(algo, Some(&mut workspace), (1.0, 0.0), &x, &filter, &mut y)?;
             }
 
-            let y_host = stream.memcpy_dtov(&y).unwrap();
+            let y_host = stream.clone_dtoh(&y).unwrap();
             assert_eq!(y_host.len(), 100 * 256 * 30);
             assert_eq!(y_host[0], 128.0 * 3.0);
         }
@@ -222,14 +222,14 @@ mod tests {
 
         // Create input, filter and output tensors
         let x = stream
-            .memcpy_stod(&vec![1.0f32; 32 * 3 * 64 * 64 * 64])
+            .clone_htod(&vec![1.0f32; 32 * 3 * 64 * 64 * 64])
             .unwrap();
         let x_desc = cudnn.create_nd_tensor::<f32>(
             &[32, 3, 64, 64, 64],
             &[3 * 64 * 64 * 64, 64 * 64 * 64, 64 * 64, 64, 1],
         )?;
         let filter = stream
-            .memcpy_stod(&vec![1.0f32; 32 * 3 * 4 * 4 * 4])
+            .clone_htod(&vec![1.0f32; 32 * 3 * 4 * 4 * 4])
             .unwrap();
         let filter_desc = cudnn.create_nd_filter::<f32>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
@@ -261,7 +261,7 @@ mod tests {
                 op.launch(algo, Some(&mut workspace), (1.0, 0.0), &x, &filter, &mut y)?;
             }
 
-            let y_host = stream.memcpy_dtov(&y).unwrap();
+            let y_host = stream.clone_dtoh(&y).unwrap();
             assert_eq!(y_host.len(), 32 * 32 * 61 * 61 * 61);
             assert_eq!(y_host[0], 3.0 * 4.0 * 4.0 * 4.0);
         }
@@ -276,7 +276,7 @@ mod tests {
         let cudnn = Cudnn::new(stream.clone()).unwrap();
 
         let a = stream
-            .memcpy_stod(&std::vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .clone_htod(&std::vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0])
             .unwrap();
         let mut c = stream.alloc_zeros::<f32>(1).unwrap();
 
@@ -303,7 +303,7 @@ mod tests {
 
         unsafe { op.launch(&mut workspace, (1.0, 0.0), &a, &mut c) }.unwrap();
 
-        let c_host = stream.memcpy_dtov(&c).unwrap();
+        let c_host = stream.clone_dtoh(&c).unwrap();
         assert_eq!(c_host.len(), 1);
         assert_eq!(c_host[0], 21.0);
     }
@@ -323,20 +323,20 @@ mod tests {
 
         // Create input, filter and output tensors
         let x = stream
-            .memcpy_stod(&vec![1.0f32; 32 * 3 * 64 * 64 * 64])
+            .clone_htod(&vec![1.0f32; 32 * 3 * 64 * 64 * 64])
             .unwrap();
         let x_desc = cudnn.create_nd_tensor::<f32>(
             &[32, 3, 64, 64, 64],
             &[3 * 64 * 64 * 64, 64 * 64 * 64, 64 * 64, 64, 1],
         )?;
         let filter = stream
-            .memcpy_stod(&vec![1.0f32; 32 * 3 * 4 * 4 * 4])
+            .clone_htod(&vec![1.0f32; 32 * 3 * 4 * 4 * 4])
             .unwrap();
         let filter_desc = cudnn.create_nd_filter::<f32>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             &[32, 3, 4, 4, 4],
         )?;
-        let bias = stream.memcpy_stod(&[1.0f32; 32]).unwrap();
+        let bias = stream.clone_htod(&[1.0f32; 32]).unwrap();
         let bias_desc = cudnn.create_nd_tensor::<f32>(&[1, 32, 1, 1, 1], &[32, 1, 1, 1, 1])?;
         let activation_desc = cudnn.create_activation::<f32>(
             cudnn::sys::cudnnActivationMode_t::CUDNN_ACTIVATION_RELU,
@@ -344,7 +344,7 @@ mod tests {
             f64::MAX,
         )?;
         let z = stream
-            .memcpy_stod(&vec![0.0f32; 32 * 32 * 61 * 61 * 61])
+            .clone_htod(&vec![0.0f32; 32 * 32 * 61 * 61 * 61])
             .unwrap();
         let z_desc = cudnn.create_nd_tensor::<f32>(
             &[32, 32, 61, 61, 61],
@@ -388,7 +388,7 @@ mod tests {
                 )?;
             }
 
-            let y_host = stream.memcpy_dtov(&y).unwrap();
+            let y_host = stream.clone_dtoh(&y).unwrap();
             assert_eq!(y_host.len(), 32 * 32 * 61 * 61 * 61);
             assert_eq!(y_host[0], 3.0 * 4.0 * 4.0 * 4.0 + 1.0);
         }
@@ -412,7 +412,7 @@ mod tests {
 
         // Create input, filter and output tensors
         let x = stream
-            .memcpy_stod(&[
+            .clone_htod(&[
                 1.0, 1.0, 2.0, 4.0, 5.0, 6.0, 7.0, 8.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 4.0,
             ])
             .unwrap();
@@ -432,7 +432,7 @@ mod tests {
                 op.launch((1.0, 0.0), &x, &mut y)?;
             }
 
-            let y_host = stream.memcpy_dtov(&y).unwrap();
+            let y_host = stream.clone_dtoh(&y).unwrap();
             assert_eq!(y_host.len(), 32 * 3 * 2 * 2);
             assert_eq!(y_host[0], 6.0);
         }
@@ -453,7 +453,7 @@ mod tests {
         )?;
 
         // Create input, filter and output tensors
-        let x = stream.memcpy_stod(&[-1.0, 2.0, -3.0, 100.0]).unwrap();
+        let x = stream.clone_htod(&[-1.0, 2.0, -3.0, 100.0]).unwrap();
         let x_desc = cudnn.create_nd_tensor::<f32>(&[1, 1, 2, 2], &[2 * 2, 2 * 2, 2, 1])?;
         let mut y = stream.alloc_zeros::<f32>(4).unwrap();
         let y_desc = cudnn.create_nd_tensor::<f32>(&[1, 1, 2, 2], &[2 * 2, 2 * 2, 2, 1])?;
@@ -470,7 +470,7 @@ mod tests {
                 op.launch((1.0, 0.0), &x, &mut y)?;
             }
 
-            let y_host = stream.memcpy_dtov(&y).unwrap();
+            let y_host = stream.clone_dtoh(&y).unwrap();
             assert_eq!(y_host.len(), 2 * 2);
             assert_eq!(y_host[0], 0.0);
             assert_eq!(y_host[1], 2.0);
@@ -491,7 +491,7 @@ mod tests {
             .create_softmax::<f32>(cudnn::sys::cudnnSoftmaxMode_t::CUDNN_SOFTMAX_MODE_INSTANCE)?;
 
         // Create input, filter and output tensors.
-        let x = stream.memcpy_stod(&[1.0, 2.0, 3.0, 4.0]).unwrap();
+        let x = stream.clone_htod(&[1.0, 2.0, 3.0, 4.0]).unwrap();
         let x_desc = cudnn.create_nd_tensor::<f32>(&[1, 1, 2, 2], &[2 * 2, 2 * 2, 2, 1])?;
         let mut y = stream.alloc_zeros::<f32>(4).unwrap();
         let y_desc = cudnn.create_nd_tensor::<f32>(&[1, 1, 2, 2], &[2 * 2, 2 * 2, 2, 1])?;
@@ -512,7 +512,7 @@ mod tests {
                 )?;
             }
 
-            let y_host = stream.memcpy_dtov(&y).unwrap();
+            let y_host = stream.clone_dtoh(&y).unwrap();
             assert_eq!(y_host.len(), 2 * 2);
             assert_eq!(y_host[0], 0.0320586);
             assert_eq!(y_host[1], 0.08714432);

--- a/src/cufile/safe.rs
+++ b/src/cufile/safe.rs
@@ -408,7 +408,7 @@ mod tests {
         let mut handle = cufile.register(file)?;
 
         let data = [0u8, 1, 2, 3, 4];
-        let buf = stream.memcpy_stod(&data).unwrap();
+        let buf = stream.clone_htod(&data).unwrap();
         let written = handle.sync_write(0, &buf)?;
         assert_eq!(written, data.len() as isize);
 
@@ -434,7 +434,7 @@ mod tests {
         assert_eq!(read, data.len() as isize);
 
         // NOTE: asserting device equals our data
-        let host_buf = stream.memcpy_dtov(&buf).unwrap();
+        let host_buf = stream.clone_dtoh(&buf).unwrap();
         assert_eq!(&host_buf, &data);
 
         // NOTE: asserting file is unchanged
@@ -462,7 +462,7 @@ mod tests {
         for i in 0..(1024 * 1024) {
             data.push((i % 256) as u8);
         }
-        let buf = stream.memcpy_stod(&data).unwrap();
+        let buf = stream.clone_htod(&data).unwrap();
 
         let cufile = Cufile::new()?;
         let file = std::fs::File::create("/tmp/cudarc-cufile-test_dtof_async").unwrap();
@@ -507,7 +507,7 @@ mod tests {
         assert_eq!(read, data.len() as isize);
 
         // NOTE: asserting device equals our data
-        let host_buf = stream.memcpy_dtov(&buf).unwrap();
+        let host_buf = stream.clone_dtoh(&buf).unwrap();
         assert_eq!(&host_buf, &data);
 
         // NOTE: asserting file is unchanged

--- a/src/curand/safe.rs
+++ b/src/curand/safe.rs
@@ -139,7 +139,7 @@ mod tests {
         let mut a_dev = stream.alloc_zeros::<T>(n).unwrap();
         let rng = CudaRng::new(seed, stream.clone()).unwrap();
         rng.fill_with_uniform(&mut a_dev).unwrap();
-        stream.memcpy_dtov(&a_dev).unwrap()
+        stream.clone_dtoh(&a_dev).unwrap()
     }
 
     fn gen_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
@@ -156,7 +156,7 @@ mod tests {
         let mut a_dev = stream.alloc_zeros::<T>(n).unwrap();
         let rng = CudaRng::new(seed, stream.clone()).unwrap();
         rng.fill_with_normal(&mut a_dev, mean, std).unwrap();
-        stream.memcpy_dtov(&a_dev).unwrap()
+        stream.clone_dtoh(&a_dev).unwrap()
     }
 
     fn gen_log_normal<T: ValidAsZeroBits + Clone + Default + Unpin + DeviceRepr>(
@@ -173,7 +173,7 @@ mod tests {
         let mut a_dev = stream.alloc_zeros::<T>(n).unwrap();
         let rng = CudaRng::new(seed, stream.clone()).unwrap();
         rng.fill_with_log_normal(&mut a_dev, mean, std).unwrap();
-        stream.memcpy_dtov(&a_dev).unwrap()
+        stream.clone_dtoh(&a_dev).unwrap()
     }
 
     #[test]
@@ -190,8 +190,8 @@ mod tests {
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
         b_rng.fill_with_uniform(&mut b_dev).unwrap();
 
-        let a_host = stream.memcpy_dtov(&a_dev).unwrap();
-        let b_host = stream.memcpy_dtov(&b_dev).unwrap();
+        let a_host = stream.clone_dtoh(&a_dev).unwrap();
+        let b_host = stream.clone_dtoh(&b_dev).unwrap();
         assert_eq!(a_host, b_host);
     }
 
@@ -209,8 +209,8 @@ mod tests {
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
         b_rng.fill_with_uniform(&mut b_dev).unwrap();
 
-        let a_host = stream.memcpy_dtov(&a_dev).unwrap();
-        let b_host = stream.memcpy_dtov(&b_dev).unwrap();
+        let a_host = stream.clone_dtoh(&a_dev).unwrap();
+        let b_host = stream.clone_dtoh(&b_dev).unwrap();
         assert_ne!(a_host, b_host);
     }
 
@@ -225,12 +225,12 @@ mod tests {
         a_rng.set_seed(42).unwrap();
         a_rng.set_offset(0).unwrap();
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
-        let a_host = stream.memcpy_dtov(&a_dev).unwrap();
+        let a_host = stream.clone_dtoh(&a_dev).unwrap();
 
         a_rng.set_seed(42).unwrap();
         a_rng.set_offset(0).unwrap();
         a_rng.fill_with_uniform(&mut a_dev).unwrap();
-        let b_host = stream.memcpy_dtov(&a_dev).unwrap();
+        let b_host = stream.clone_dtoh(&a_dev).unwrap();
 
         assert_eq!(a_host, b_host);
     }

--- a/src/cusolver/sys_test.rs
+++ b/src/cusolver/sys_test.rs
@@ -22,7 +22,7 @@ fn test_ssyevd() {
     let stream = ctx.default_stream();
     let n: usize = 5;
     let a: Vec<f32> = (0..n * n).map(|i| i as f32).collect();
-    let a = stream.memcpy_stod(&a).unwrap();
+    let a = stream.clone_htod(&a).unwrap();
     let lda = n;
     let w = stream.alloc_zeros::<f32>(n).unwrap();
     let work = stream.alloc_zeros::<f32>(1024).unwrap();
@@ -54,8 +54,8 @@ fn test_ssyevd() {
     };
     assert_eq!(stat, cusolverStatus_t::CUSOLVER_STATUS_SUCCESS);
 
-    let a = stream.memcpy_dtov(&a).unwrap();
-    let w = stream.memcpy_dtov(&w).unwrap();
+    let a = stream.clone_dtoh(&a).unwrap();
+    let w = stream.clone_dtoh(&w).unwrap();
 
     // reference value
     #[rustfmt::skip]

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -18,17 +18,17 @@
 //! let stream = ctx.default_stream();
 //! ```
 //!
-//! 3. Allocate device memory with [CudaStream::memcpy_stod()]/[CudaStream::memcpy_htod], [CudaStream::alloc_zeros()].
+//! 3. Allocate device memory with [CudaStream::clone_htod()]/[CudaStream::memcpy_htod], [CudaStream::alloc_zeros()].
 //!
 //! ```rust
 //! # use cudarc::driver::*;
 //! # let ctx = CudaContext::new(0).unwrap();
 //! # let stream = ctx.default_stream();
 //! let a_dev: CudaSlice<f32> = stream.alloc_zeros(10).unwrap();
-//! let b_dev: CudaSlice<f32> = stream.memcpy_stod(&[0.0; 10]).unwrap();
+//! let b_dev: CudaSlice<f32> = stream.clone_htod(&[0.0; 10]).unwrap();
 //! ```
 //!
-//! 3. Transfer to host memory with [CudaStream::memcpy_dtov()], or [CudaStream::memcpy_dtoh()]
+//! 3. Transfer to host memory with [CudaStream::clone_dtoh()], or [CudaStream::memcpy_dtoh()]
 //!
 //! ```rust
 //! # use cudarc::driver::*;
@@ -38,7 +38,7 @@
 //! let mut a_host: [f32; 10] = [1.0; 10];
 //! stream.memcpy_dtoh(&a_dev, &mut a_host);
 //! assert_eq!(a_host, [0.0; 10]);
-//! let a_host: Vec<f32> = stream.memcpy_dtov(&a_dev).unwrap();
+//! let a_host: Vec<f32> = stream.clone_dtoh(&a_dev).unwrap();
 //! assert_eq!(&a_host, &[0.0; 10]);
 //! ```
 //!

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -353,7 +353,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
 
         let a_host = [-1.0f32, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8];
 
-        let a_dev = stream.memcpy_stod(&a_host).unwrap();
+        let a_dev = stream.clone_htod(&a_host).unwrap();
         let mut b_dev = a_dev.clone();
 
         unsafe {
@@ -366,7 +366,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
         }
         .unwrap();
 
-        let b_host = stream.memcpy_dtov(&b_dev).unwrap();
+        let b_host = stream.clone_dtoh(&b_dev).unwrap();
 
         for (a_i, b_i) in a_host.iter().zip(b_host.iter()) {
             let expected = a_i.sin();
@@ -390,7 +390,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
             let mut a = Vec::with_capacity(numel);
             a.resize(numel, 1.0f32);
 
-            let a = stream.memcpy_stod(&a).unwrap();
+            let a = stream.clone_htod(&a).unwrap();
             let mut b = stream.alloc_zeros::<f32>(numel).unwrap();
             unsafe {
                 stream
@@ -402,7 +402,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
             }
             .unwrap();
 
-            let b = stream.memcpy_dtov(&b).unwrap();
+            let b = stream.clone_dtoh(&b).unwrap();
             for v in b {
                 assert_eq!(v, 0.841471);
             }
@@ -420,7 +420,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
         let f = module.load_function("sin_kernel").unwrap();
 
         let a_host = [-1.0f32, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8];
-        let a_dev = stream.memcpy_stod(&a_host).unwrap();
+        let a_dev = stream.clone_htod(&a_host).unwrap();
         let mut b_dev = a_dev.clone();
 
         for i in 0..5 {
@@ -439,7 +439,7 @@ extern \"C\" __global__ void sin_kernel(float *out, const float *inp, size_t num
             .unwrap();
         }
 
-        let b_host = stream.memcpy_dtov(&b_dev).unwrap();
+        let b_host = stream.clone_dtoh(&b_dev).unwrap();
 
         for (a_i, b_i) in a_host.iter().zip(b_host.iter()) {
             let expected = a_i.sin();
@@ -795,7 +795,7 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
     fn test_device_side_assert() -> Result<(), DriverError> {
         let ctx = CudaContext::new(0)?;
         let stream = ctx.new_stream()?;
-        let inp = stream.memcpy_stod(&[1.0f32; 100])?;
+        let inp = stream.clone_htod(&[1.0f32; 100])?;
         let mut out = stream.alloc_zeros::<f32>(100)?;
         let ptx = crate::nvrtc::compile_ptx(
             "

--- a/src/driver/safe/unified_memory.rs
+++ b/src/driver/safe/unified_memory.rs
@@ -856,14 +856,14 @@ extern \"C\" __global__ void kernel(float *buf) {
         }
 
         // check usage as device ptr
-        let vs = stream1.memcpy_dtov(&a)?;
+        let vs = stream1.clone_dtoh(&a)?;
         for i in 0..100 {
             assert_eq!(vs[i], i as f32);
         }
 
         // check usage as host ptr
-        let b = stream1.memcpy_stod(&a)?;
-        let vs = stream1.memcpy_dtov(&b)?;
+        let b = stream1.clone_htod(&a)?;
+        let vs = stream1.clone_dtoh(&b)?;
         for i in 0..100 {
             assert_eq!(vs[i], i as f32);
         }
@@ -936,14 +936,14 @@ extern \"C\" __global__ void kernel(float *buf) {
         }
 
         // check usage as device ptr
-        let vs = stream1.memcpy_dtov(&a)?;
+        let vs = stream1.clone_dtoh(&a)?;
         for i in 0..100 {
             assert_eq!(vs[i], i as f32);
         }
 
         // check usage as host ptr
-        let b = stream1.memcpy_stod(&a)?;
-        let vs = stream1.memcpy_dtov(&b)?;
+        let b = stream1.clone_htod(&a)?;
+        let vs = stream1.clone_dtoh(&b)?;
         for i in 0..100 {
             assert_eq!(vs[i], i as f32);
         }
@@ -1017,14 +1017,14 @@ extern \"C\" __global__ void kernel(float *buf) {
         }
 
         // check usage as device ptr
-        let vs = stream2.memcpy_dtov(&a)?;
+        let vs = stream2.clone_dtoh(&a)?;
         for i in 0..100 {
             assert_eq!(vs[i], i as f32);
         }
 
         // check usage as host ptr
-        let b = stream2.memcpy_stod(&a)?;
-        let vs = stream2.memcpy_dtov(&b)?;
+        let b = stream2.clone_htod(&a)?;
+        let vs = stream2.clone_dtoh(&b)?;
         for i in 0..100 {
             assert_eq!(vs[i], i as f32);
         }
@@ -1096,7 +1096,7 @@ extern \"C\" __global__ void kernel(float *buf) {
 
         // Verify the result
         stream.synchronize()?;
-        let result = stream.memcpy_dtov(&big)?;
+        let result = stream.clone_dtoh(&big)?;
         assert_eq!(
             result,
             [-1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8]
@@ -1124,8 +1124,8 @@ extern \"C\" __global__ void kernel(float *buf) {
         assert_eq!(left.len(), 5);
         assert_eq!(right.len(), 5);
 
-        let left_data = stream.memcpy_dtov(&left)?;
-        let right_data = stream.memcpy_dtov(&right)?;
+        let left_data = stream.clone_dtoh(&left)?;
+        let right_data = stream.clone_dtoh(&right)?;
         assert_eq!(left_data, [0.0, 1.0, 2.0, 3.0, 4.0]);
         assert_eq!(right_data, [5.0, 6.0, 7.0, 8.0, 9.0]);
 
@@ -1140,7 +1140,7 @@ extern \"C\" __global__ void kernel(float *buf) {
 
         // Verify only left half was modified
         stream.synchronize()?;
-        let result = stream.memcpy_dtov(&unified)?;
+        let result = stream.clone_dtoh(&unified)?;
         assert_eq!(result, [0.0, 0.0, 0.0, 0.0, 0.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
 
         Ok(())
@@ -1164,12 +1164,12 @@ extern \"C\" __global__ void kernel(float *buf) {
 
         // Initially in GLOBAL mode - both streams should work
         let view1 = unified.slice(0..50);
-        let data1 = stream1.memcpy_dtov(&view1)?;
+        let data1 = stream1.clone_dtoh(&view1)?;
         assert_eq!(data1[0], 0.0);
         assert_eq!(data1[49], 49.0);
 
         let view2 = unified.slice(50..100);
-        let data2 = stream2.memcpy_dtov(&view2)?;
+        let data2 = stream2.clone_dtoh(&view2)?;
         assert_eq!(data2[0], 50.0);
         assert_eq!(data2[49], 99.0);
 
@@ -1180,7 +1180,7 @@ extern \"C\" __global__ void kernel(float *buf) {
         stream1.synchronize()?;
 
         // Verify the write succeeded
-        let verify_data = stream1.memcpy_dtov(&unified)?;
+        let verify_data = stream1.clone_dtoh(&unified)?;
         for i in 0..10 {
             assert_eq!(
                 verify_data[i], i as f32,
@@ -1204,11 +1204,11 @@ extern \"C\" __global__ void kernel(float *buf) {
         let view_single = unified.slice(0..50);
 
         // Access with attached stream (stream2) should work
-        let data_ok = stream2.memcpy_dtov(&view_single)?;
+        let data_ok = stream2.clone_dtoh(&view_single)?;
         assert_eq!(data_ok[0], 0.0);
 
         // Access with different stream (stream1) should record an error
-        let _ = stream1.memcpy_dtov(&view_single);
+        let _ = stream1.clone_dtoh(&view_single);
         // The error is recorded in the context, not returned synchronously
         assert!(
             ctx.check_err().is_err(),
@@ -1222,7 +1222,7 @@ extern \"C\" __global__ void kernel(float *buf) {
         stream2.synchronize()?;
 
         // Verify the write succeeded
-        let verify_data2 = stream2.memcpy_dtov(&unified)?;
+        let verify_data2 = stream2.clone_dtoh(&unified)?;
         for i in 30..40 {
             assert_eq!(
                 verify_data2[i], 777.0,

--- a/src/nccl/result.rs
+++ b/src/nccl/result.rs
@@ -328,7 +328,7 @@ mod tests {
         for i in 0..n_devices {
             let ctx = CudaContext::new(i).unwrap();
             let stream = ctx.default_stream();
-            let slice = stream.memcpy_stod(&vec![(i + 1) as f32 * 1.0; n]).unwrap();
+            let slice = stream.clone_htod(&vec![(i + 1) as f32 * 1.0; n]).unwrap();
             sendslices.push(slice);
             let slice = stream.alloc_zeros::<f32>(n).unwrap();
             recvslices.push(slice);
@@ -364,7 +364,7 @@ mod tests {
             // Get the current device context
             let ctx = CudaContext::new(i).unwrap();
             let stream = ctx.default_stream();
-            let out = stream.memcpy_dtov(recv).unwrap();
+            let out = stream.clone_dtoh(recv).unwrap();
             assert_eq!(out, vec![(n_devices * (n_devices + 1)) as f32 / 2.0; n]);
         }
     }
@@ -380,7 +380,7 @@ mod tests {
                 std::thread::spawn(move || {
                     let ctx = CudaContext::new(i).unwrap();
                     let stream = ctx.default_stream();
-                    let sendslice = stream.memcpy_stod(&vec![(i + 1) as f32 * 1.0; n]).unwrap();
+                    let sendslice = stream.clone_htod(&vec![(i + 1) as f32 * 1.0; n]).unwrap();
                     let recvslice = stream.alloc_zeros::<f32>(n).unwrap();
                     let mut comm = MaybeUninit::uninit();
                     unsafe {

--- a/src/nccl/safe.rs
+++ b/src/nccl/safe.rs
@@ -477,12 +477,12 @@ mod tests {
                     let ctx = CudaContext::new(i).unwrap();
                     let stream = ctx.default_stream();
                     let comm = Comm::from_rank(stream.clone(), i, n_devices, id).unwrap();
-                    let slice = stream.memcpy_stod(&vec![(i + 1) as f32 * 1.0; n]).unwrap();
+                    let slice = stream.clone_htod(&vec![(i + 1) as f32 * 1.0; n]).unwrap();
                     let mut slice_receive = stream.alloc_zeros::<f32>(n).unwrap();
                     comm.all_reduce(&slice, &mut slice_receive, &ReduceOp::Sum)
                         .unwrap();
 
-                    let out = stream.memcpy_dtov(&slice_receive).unwrap();
+                    let out = stream.clone_dtoh(&slice_receive).unwrap();
 
                     assert_eq!(out, vec![(n_devices * (n_devices + 1)) as f32 / 2.0; n]);
                 })
@@ -506,7 +506,7 @@ mod tests {
                     let ctx = CudaContext::new(i).unwrap();
                     let stream = ctx.default_stream();
                     let comm = Comm::from_rank(stream.clone(), i, n_devices, id).unwrap();
-                    let slice = stream.memcpy_stod(&vec![(i + 1) as f32 * 1.0; n]).unwrap();
+                    let slice = stream.clone_htod(&vec![(i + 1) as f32 * 1.0; n]).unwrap();
                     let mut slice_receive = stream.alloc_zeros::<f32>(n).unwrap();
                     let slice_view = slice.slice(..);
                     let mut slice_receive_view = slice_receive.slice_mut(..);
@@ -514,7 +514,7 @@ mod tests {
                     comm.all_reduce(&slice_view, &mut slice_receive_view, &ReduceOp::Sum)
                         .unwrap();
 
-                    let out = stream.memcpy_dtov(&slice_receive).unwrap();
+                    let out = stream.clone_dtoh(&slice_receive).unwrap();
 
                     assert_eq!(out, vec![(n_devices * (n_devices + 1)) as f32 / 2.0; n]);
                 })


### PR DESCRIPTION
Better aligning these methods with the other stream copy methods & clone_dtod.

Also doing some internal simplifications with the views