### PR TITLE
Initial TRT bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ features = [
     "nvtx",
     "cupti",
     "cutensor",
+    "tensorrt",
 ]
 
 [features]
@@ -87,6 +88,7 @@ cufile = ["driver"]
 nvtx = ["driver"]
 cupti = ["runtime", "driver"]
 cutensor = ["driver"]
+tensorrt = ["driver"]
 
 std = []
 no-std = ["no-std-compat/std"]
@@ -103,3 +105,6 @@ half = { version = "2", optional = true, default-features = false, features = [
 float8 = { version = "0.3.0", optional = true }
 float4 = { version = "0.1.0", optional = true }
 libloading = "0.8"
+
+[build-dependencies]
+cc = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,8 @@ pub mod nvrtc;
 pub mod nvtx;
 #[cfg(feature = "runtime")]
 pub mod runtime;
+#[cfg(feature = "tensorrt")]
+pub mod tensorrt;
 
 pub mod types;
 

--- a/src/tensorrt/mod.rs
+++ b/src/tensorrt/mod.rs
@@ -1,0 +1,6 @@
+//! TensorRT bindings for deep learning inference.
+//!
+//! This module provides Rust bindings to NVIDIA TensorRT for optimized deep learning inference.
+
+pub mod result;
+pub mod sys;

--- a/src/tensorrt/result.rs
+++ b/src/tensorrt/result.rs
@@ -1,0 +1,669 @@
+//! A thin wrapper around [sys] providing [Result]s with [TensorRTError].
+
+use super::sys;
+use std::mem::MaybeUninit;
+
+/// TensorRT error type. Since TensorRT uses boolean returns and logs errors,
+/// we use string-based error messages.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TensorRTError(pub String);
+
+impl TensorRTError {
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for TensorRTError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TensorRT error: {}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TensorRTError {}
+
+// ============================================================================
+// Logger
+// ============================================================================
+
+/// Set the TensorRT log level.
+///
+/// # Safety
+/// This function is safe to call at any time.
+pub fn set_log_level(level: sys::LogSeverity) {
+    unsafe {
+        sys::trt_set_log_level(level);
+    }
+}
+
+// ============================================================================
+// Builder
+// ============================================================================
+
+/// Create a TensorRT builder.
+///
+/// See [TensorRT docs](https://docs.nvidia.com/deeplearning/tensorrt/api/).
+pub fn create_builder() -> Result<*mut sys::IBuilder, TensorRTError> {
+    let builder = unsafe { sys::trt_create_builder() };
+    if builder.is_null() {
+        Err(TensorRTError::new("Failed to create TensorRT builder"))
+    } else {
+        Ok(builder)
+    }
+}
+
+/// Destroy a TensorRT builder.
+///
+/// # Safety
+/// The builder must not have already been freed.
+pub unsafe fn destroy_builder(builder: *mut sys::IBuilder) {
+    sys::trt_destroy_builder(builder);
+}
+
+/// Create a network definition from a builder.
+///
+/// # Safety
+/// The builder must be valid and not freed.
+pub unsafe fn builder_create_network(
+    builder: *mut sys::IBuilder,
+    flags: u32,
+) -> Result<*mut sys::INetworkDefinition, TensorRTError> {
+    let network = sys::trt_builder_create_network(builder, flags);
+    if network.is_null() {
+        Err(TensorRTError::new("Failed to create network definition"))
+    } else {
+        Ok(network)
+    }
+}
+
+/// Create a builder configuration.
+///
+/// # Safety
+/// The builder must be valid and not freed.
+pub unsafe fn builder_create_config(
+    builder: *mut sys::IBuilder,
+) -> Result<*mut sys::IBuilderConfig, TensorRTError> {
+    let config = sys::trt_builder_create_config(builder);
+    if config.is_null() {
+        Err(TensorRTError::new("Failed to create builder config"))
+    } else {
+        Ok(config)
+    }
+}
+
+/// Build a serialized network.
+///
+/// # Safety
+/// The builder, network, and config must all be valid and not freed.
+pub unsafe fn builder_build_serialized_network(
+    builder: *mut sys::IBuilder,
+    network: *mut sys::INetworkDefinition,
+    config: *mut sys::IBuilderConfig,
+) -> Result<*mut sys::IHostMemory, TensorRTError> {
+    let serialized = sys::trt_builder_build_serialized_network(builder, network, config);
+    if serialized.is_null() {
+        Err(TensorRTError::new("Failed to build serialized network"))
+    } else {
+        Ok(serialized)
+    }
+}
+
+/// Set the maximum batch size for the builder.
+///
+/// # Safety
+/// The builder must be valid and not freed.
+pub unsafe fn builder_set_max_batch_size(builder: *mut sys::IBuilder, batch_size: i32) {
+    sys::trt_builder_set_max_batch_size(builder, batch_size);
+}
+
+// ============================================================================
+// Network
+// ============================================================================
+
+/// Destroy a network definition.
+///
+/// # Safety
+/// The network must not have already been freed.
+pub unsafe fn destroy_network(network: *mut sys::INetworkDefinition) {
+    sys::trt_destroy_network(network);
+}
+
+/// Add an input tensor to the network.
+///
+/// # Safety
+/// The network must be valid and not freed. The name must be a valid C string.
+pub unsafe fn network_add_input(
+    network: *mut sys::INetworkDefinition,
+    name: *const std::ffi::c_char,
+    dtype: sys::DataType,
+    dims: *const sys::Dims,
+) -> Result<*mut sys::ITensor, TensorRTError> {
+    let tensor = sys::trt_network_add_input(network, name, dtype, dims);
+    if tensor.is_null() {
+        Err(TensorRTError::new("Failed to add input tensor"))
+    } else {
+        Ok(tensor)
+    }
+}
+
+/// Mark a tensor as a network output.
+///
+/// # Safety
+/// The network and tensor must both be valid and not freed.
+pub unsafe fn network_mark_output(
+    network: *mut sys::INetworkDefinition,
+    tensor: *mut sys::ITensor,
+) {
+    sys::trt_network_mark_output(network, tensor);
+}
+
+/// Get the number of inputs in the network.
+///
+/// # Safety
+/// The network must be valid and not freed.
+pub unsafe fn network_get_nb_inputs(network: *mut sys::INetworkDefinition) -> i32 {
+    sys::trt_network_get_nb_inputs(network)
+}
+
+/// Get the number of outputs in the network.
+///
+/// # Safety
+/// The network must be valid and not freed.
+pub unsafe fn network_get_nb_outputs(network: *mut sys::INetworkDefinition) -> i32 {
+    sys::trt_network_get_nb_outputs(network)
+}
+
+// ============================================================================
+// BuilderConfig
+// ============================================================================
+
+/// Destroy a builder configuration.
+///
+/// # Safety
+/// The config must not have already been freed.
+pub unsafe fn destroy_config(config: *mut sys::IBuilderConfig) {
+    sys::trt_destroy_config(config);
+}
+
+/// Set the memory pool limit for a builder configuration.
+///
+/// # Safety
+/// The config must be valid and not freed.
+pub unsafe fn config_set_memory_pool_limit(
+    config: *mut sys::IBuilderConfig,
+    pool_type: sys::MemoryPoolType,
+    pool_size: usize,
+) {
+    sys::trt_config_set_memory_pool_limit(config, pool_type, pool_size);
+}
+
+// ============================================================================
+// HostMemory
+// ============================================================================
+
+/// Get a pointer to the host memory data.
+///
+/// # Safety
+/// The memory must be valid and not freed.
+pub unsafe fn host_memory_data(mem: *mut sys::IHostMemory) -> *const std::ffi::c_void {
+    sys::trt_host_memory_data(mem)
+}
+
+/// Get the size of the host memory.
+///
+/// # Safety
+/// The memory must be valid and not freed.
+pub unsafe fn host_memory_size(mem: *mut sys::IHostMemory) -> usize {
+    sys::trt_host_memory_size(mem)
+}
+
+/// Destroy host memory.
+///
+/// # Safety
+/// The memory must not have already been freed.
+pub unsafe fn destroy_host_memory(mem: *mut sys::IHostMemory) {
+    sys::trt_destroy_host_memory(mem);
+}
+
+// ============================================================================
+// Runtime
+// ============================================================================
+
+/// Create a TensorRT runtime.
+pub fn create_runtime() -> Result<*mut sys::IRuntime, TensorRTError> {
+    let runtime = unsafe { sys::trt_create_runtime() };
+    if runtime.is_null() {
+        Err(TensorRTError::new("Failed to create TensorRT runtime"))
+    } else {
+        Ok(runtime)
+    }
+}
+
+/// Destroy a TensorRT runtime.
+///
+/// # Safety
+/// The runtime must not have already been freed.
+pub unsafe fn destroy_runtime(runtime: *mut sys::IRuntime) {
+    sys::trt_destroy_runtime(runtime);
+}
+
+/// Deserialize an engine from a blob.
+///
+/// # Safety
+/// The runtime must be valid and not freed. The blob must point to valid serialized engine data.
+pub unsafe fn runtime_deserialize_engine(
+    runtime: *mut sys::IRuntime,
+    blob: *const std::ffi::c_void,
+    size: usize,
+) -> Result<*mut sys::ICudaEngine, TensorRTError> {
+    let engine = sys::trt_runtime_deserialize_engine(runtime, blob, size);
+    if engine.is_null() {
+        Err(TensorRTError::new("Failed to deserialize engine"))
+    } else {
+        Ok(engine)
+    }
+}
+
+// ============================================================================
+// Engine
+// ============================================================================
+
+/// Destroy a CUDA engine.
+///
+/// # Safety
+/// The engine must not have already been freed.
+pub unsafe fn destroy_engine(engine: *mut sys::ICudaEngine) {
+    sys::trt_destroy_engine(engine);
+}
+
+/// Create an execution context from an engine.
+///
+/// # Safety
+/// The engine must be valid and not freed.
+pub unsafe fn engine_create_context(
+    engine: *mut sys::ICudaEngine,
+) -> Result<*mut sys::IExecutionContext, TensorRTError> {
+    let context = sys::trt_engine_create_context(engine);
+    if context.is_null() {
+        Err(TensorRTError::new("Failed to create execution context"))
+    } else {
+        Ok(context)
+    }
+}
+
+/// Get the number of bindings in the engine.
+///
+/// # Safety
+/// The engine must be valid and not freed.
+pub unsafe fn engine_get_nb_bindings(engine: *mut sys::ICudaEngine) -> i32 {
+    sys::trt_engine_get_nb_bindings(engine)
+}
+
+/// Get the name of a tensor by index.
+///
+/// # Safety
+/// The engine must be valid and not freed. The index must be valid.
+pub unsafe fn engine_get_tensor_name(
+    engine: *mut sys::ICudaEngine,
+    index: i32,
+) -> *const std::ffi::c_char {
+    sys::trt_engine_get_tensor_name(engine, index)
+}
+
+/// Check if a binding is an execution binding.
+///
+/// # Safety
+/// The engine must be valid and not freed. The name must be a valid C string.
+pub unsafe fn engine_is_execution_binding(
+    engine: *mut sys::ICudaEngine,
+    name: *const std::ffi::c_char,
+) -> bool {
+    sys::trt_engine_is_execution_binding(engine, name)
+}
+
+/// Get the shape of a tensor.
+///
+/// # Safety
+/// The engine must be valid and not freed. The name must be a valid C string.
+pub unsafe fn engine_get_tensor_shape(
+    engine: *mut sys::ICudaEngine,
+    name: *const std::ffi::c_char,
+) -> sys::Dims {
+    sys::trt_engine_get_tensor_shape(engine, name)
+}
+
+// ============================================================================
+// ExecutionContext
+// ============================================================================
+
+/// Destroy an execution context.
+///
+/// # Safety
+/// The context must not have already been freed.
+pub unsafe fn destroy_context(context: *mut sys::IExecutionContext) {
+    sys::trt_destroy_context(context);
+}
+
+/// Execute inference synchronously with the V2 API.
+///
+/// # Safety
+/// The context must be valid and not freed. Bindings must point to valid device memory.
+pub unsafe fn context_execute_v2(
+    context: *mut sys::IExecutionContext,
+    bindings: *mut *mut std::ffi::c_void,
+) -> Result<(), TensorRTError> {
+    if sys::trt_context_execute_v2(context, bindings) {
+        Ok(())
+    } else {
+        Err(TensorRTError::new("Inference execution failed"))
+    }
+}
+
+/// Set the address of a tensor binding.
+///
+/// # Safety
+/// The context must be valid and not freed. The name must be a valid C string.
+/// The data must point to valid device memory.
+pub unsafe fn context_set_tensor_address(
+    context: *mut sys::IExecutionContext,
+    name: *const std::ffi::c_char,
+    data: *mut std::ffi::c_void,
+) -> Result<(), TensorRTError> {
+    if sys::trt_context_set_tensor_address(context, name, data) {
+        Ok(())
+    } else {
+        Err(TensorRTError::new("Failed to set tensor address"))
+    }
+}
+
+/// Enqueue inference on a CUDA stream (V3 API).
+///
+/// # Safety
+/// The context must be valid and not freed. The stream must be a valid CUDA stream.
+pub unsafe fn context_enqueue_v3(
+    context: *mut sys::IExecutionContext,
+    stream: *mut std::ffi::c_void,
+) -> Result<(), TensorRTError> {
+    if sys::trt_context_enqueue_v3(context, stream) {
+        Ok(())
+    } else {
+        Err(TensorRTError::new("Inference enqueue failed"))
+    }
+}
+
+// ============================================================================
+// Optimization Profile
+// ============================================================================
+
+/// Create an optimization profile.
+///
+/// # Safety
+/// The builder must be valid and not freed.
+pub unsafe fn create_optimization_profile(
+    builder: *mut sys::IBuilder,
+) -> Result<*mut sys::IOptimizationProfile, TensorRTError> {
+    let profile = sys::trt_create_optimization_profile(builder);
+    if profile.is_null() {
+        Err(TensorRTError::new("Failed to create optimization profile"))
+    } else {
+        Ok(profile)
+    }
+}
+
+/// Destroy an optimization profile.
+///
+/// # Safety
+/// The profile must not have already been freed.
+pub unsafe fn destroy_optimization_profile(profile: *mut sys::IOptimizationProfile) {
+    sys::trt_destroy_optimization_profile(profile);
+}
+
+/// Set the shape for an input in an optimization profile.
+///
+/// # Safety
+/// The profile must be valid and not freed. The input_name must be a valid C string.
+pub unsafe fn profile_set_shape(
+    profile: *mut sys::IOptimizationProfile,
+    input_name: *const std::ffi::c_char,
+    min: *const sys::Dims,
+    opt: *const sys::Dims,
+    max: *const sys::Dims,
+) -> Result<(), TensorRTError> {
+    if sys::trt_profile_set_shape(profile, input_name, min, opt, max) {
+        Ok(())
+    } else {
+        Err(TensorRTError::new(
+            "Failed to set optimization profile shape",
+        ))
+    }
+}
+
+/// Add an optimization profile to a builder configuration.
+///
+/// # Safety
+/// The config and profile must both be valid and not freed.
+pub unsafe fn config_add_optimization_profile(
+    config: *mut sys::IBuilderConfig,
+    profile: *mut sys::IOptimizationProfile,
+) -> i32 {
+    sys::trt_config_add_optimization_profile(config, profile)
+}
+
+// ============================================================================
+// ONNX Parser
+// ============================================================================
+
+/// Create an ONNX parser for a network.
+///
+/// # Safety
+/// The network must be valid and not freed.
+pub unsafe fn onnx_create_parser(
+    network: *mut sys::INetworkDefinition,
+) -> Result<*mut sys::IOnnxParser, TensorRTError> {
+    let parser = sys::trt_onnx_create_parser(network);
+    if parser.is_null() {
+        Err(TensorRTError::new("Failed to create ONNX parser"))
+    } else {
+        Ok(parser)
+    }
+}
+
+/// Destroy an ONNX parser.
+///
+/// # Safety
+/// The parser must not have already been freed.
+pub unsafe fn onnx_destroy_parser(parser: *mut sys::IOnnxParser) {
+    sys::trt_onnx_destroy_parser(parser);
+}
+
+/// Parse an ONNX model from a file.
+///
+/// # Safety
+/// The parser must be valid and not freed. The path must be a valid C string pointing to an ONNX file.
+pub unsafe fn onnx_parse_from_file(
+    parser: *mut sys::IOnnxParser,
+    path: *const std::ffi::c_char,
+) -> Result<(), TensorRTError> {
+    if sys::trt_onnx_parse_from_file(parser, path) {
+        Ok(())
+    } else {
+        let nb_errors = sys::trt_onnx_get_nb_errors(parser);
+        if nb_errors > 0 {
+            let error_desc = std::ffi::CStr::from_ptr(sys::trt_onnx_get_error_desc(parser, 0))
+                .to_string_lossy()
+                .into_owned();
+            Err(TensorRTError::new(format!(
+                "ONNX parsing failed: {}",
+                error_desc
+            )))
+        } else {
+            Err(TensorRTError::new("ONNX parsing failed"))
+        }
+    }
+}
+
+/// Parse an ONNX model from a memory buffer.
+///
+/// # Safety
+/// The parser must be valid and not freed. The data must point to valid ONNX model data.
+pub unsafe fn onnx_parse(
+    parser: *mut sys::IOnnxParser,
+    data: *const std::ffi::c_void,
+    size: usize,
+) -> Result<(), TensorRTError> {
+    if sys::trt_onnx_parse(parser, data, size) {
+        Ok(())
+    } else {
+        let nb_errors = sys::trt_onnx_get_nb_errors(parser);
+        if nb_errors > 0 {
+            let error_desc = std::ffi::CStr::from_ptr(sys::trt_onnx_get_error_desc(parser, 0))
+                .to_string_lossy()
+                .into_owned();
+            Err(TensorRTError::new(format!(
+                "ONNX parsing failed: {}",
+                error_desc
+            )))
+        } else {
+            Err(TensorRTError::new("ONNX parsing failed"))
+        }
+    }
+}
+
+/// Get the number of errors from the ONNX parser.
+///
+/// # Safety
+/// The parser must be valid and not freed.
+pub unsafe fn onnx_get_nb_errors(parser: *mut sys::IOnnxParser) -> i32 {
+    sys::trt_onnx_get_nb_errors(parser)
+}
+
+/// Get the description of an error from the ONNX parser.
+///
+/// # Safety
+/// The parser must be valid and not freed. The index must be valid (< nb_errors).
+pub unsafe fn onnx_get_error_desc(
+    parser: *mut sys::IOnnxParser,
+    index: i32,
+) -> *const std::ffi::c_char {
+    sys::trt_onnx_get_error_desc(parser, index)
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Create a Dims structure from a slice of dimensions.
+pub fn make_dims(dims: &[i32]) -> sys::Dims {
+    let mut d = sys::Dims {
+        nbDims: dims.len() as i32,
+        d: [0; 8],
+    };
+    for (i, &dim) in dims.iter().enumerate() {
+        d.d[i] = dim as i64;
+    }
+    unsafe { sys::trt_make_dims(d.nbDims, dims.as_ptr()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_and_destroy_builder() {
+        // Test basic builder creation and destruction
+        let builder = create_builder().expect("Failed to create builder");
+        assert!(!builder.is_null(), "Builder should not be null");
+
+        unsafe {
+            destroy_builder(builder);
+        }
+    }
+
+    #[test]
+    fn test_create_runtime() {
+        // Test runtime creation
+        let runtime = create_runtime().expect("Failed to create runtime");
+        assert!(!runtime.is_null(), "Runtime should not be null");
+
+        unsafe {
+            destroy_runtime(runtime);
+        }
+    }
+
+    #[test]
+    fn test_builder_create_network() {
+        // Test creating a network from a builder
+        let builder = create_builder().expect("Failed to create builder");
+
+        unsafe {
+            // NetworkDefinitionCreationFlag::kEXPLICIT_BATCH = 1
+            let network = builder_create_network(builder, 1).expect("Failed to create network");
+            assert!(!network.is_null(), "Network should not be null");
+
+            // Check network properties
+            let nb_inputs = network_get_nb_inputs(network);
+            let nb_outputs = network_get_nb_outputs(network);
+            assert_eq!(nb_inputs, 0, "New network should have 0 inputs");
+            assert_eq!(nb_outputs, 0, "New network should have 0 outputs");
+
+            destroy_network(network);
+            destroy_builder(builder);
+        }
+    }
+
+    #[test]
+    fn test_builder_create_config() {
+        // Test creating a builder config
+        let builder = create_builder().expect("Failed to create builder");
+
+        unsafe {
+            let config = builder_create_config(builder).expect("Failed to create config");
+            assert!(!config.is_null(), "Config should not be null");
+
+            // Test setting memory pool limit
+            config_set_memory_pool_limit(
+                config,
+                sys::MemoryPoolType::kWORKSPACE,
+                1 << 30, // 1GB
+            );
+
+            destroy_config(config);
+            destroy_builder(builder);
+        }
+    }
+
+    #[test]
+    fn test_make_dims() {
+        // Test dimension creation
+        let dims = make_dims(&[1, 3, 224, 224]);
+        assert_eq!(dims.nbDims, 4);
+        assert_eq!(dims.d[0], 1);
+        assert_eq!(dims.d[1], 3);
+        assert_eq!(dims.d[2], 224);
+        assert_eq!(dims.d[3], 224);
+    }
+
+    #[test]
+    fn test_set_log_level() {
+        // Test setting log level (should not crash)
+        set_log_level(sys::LogSeverity::kWARNING);
+        set_log_level(sys::LogSeverity::kERROR);
+    }
+
+    #[test]
+    fn test_create_optimization_profile() {
+        // Test optimization profile creation
+        let builder = create_builder().expect("Failed to create builder");
+
+        unsafe {
+            let profile = create_optimization_profile(builder)
+                .expect("Failed to create optimization profile");
+            assert!(!profile.is_null(), "Profile should not be null");
+
+            destroy_optimization_profile(profile);
+            destroy_builder(builder);
+        }
+    }
+}

--- a/src/tensorrt/sys/cpp_wrapper/trt_wrapper.cpp
+++ b/src/tensorrt/sys/cpp_wrapper/trt_wrapper.cpp
@@ -1,0 +1,279 @@
+#include <NvInfer.h>
+#include <NvOnnxParser.h>
+#include <iostream>
+#include <cstring>
+
+using namespace nvinfer1;
+using namespace nvonnxparser;
+
+class ConsoleLogger : public ILogger {
+private:
+    Severity minSeverity;
+
+public:
+    ConsoleLogger() : minSeverity(Severity::kWARNING) {}
+
+    void setMinSeverity(Severity severity) {
+        minSeverity = severity;
+    }
+
+    void log(Severity severity, const char* msg) noexcept override {
+        if (severity > minSeverity) return;
+
+        const char* severityStr = "";
+        switch (severity) {
+            case Severity::kINTERNAL_ERROR: severityStr = "INTERNAL_ERROR"; break;
+            case Severity::kERROR: severityStr = "ERROR"; break;
+            case Severity::kWARNING: severityStr = "WARNING"; break;
+            case Severity::kINFO: severityStr = "INFO"; break;
+            case Severity::kVERBOSE: severityStr = "VERBOSE"; break;
+        }
+        std::cerr << "[TRT " << severityStr << "] " << msg << std::endl;
+    }
+};
+
+static ConsoleLogger gLogger;
+
+extern "C" {
+
+IBuilder* trt_create_builder() {
+    return createInferBuilder(gLogger);
+}
+
+void trt_destroy_builder(IBuilder* builder) {
+    if (builder) delete builder;
+}
+
+INetworkDefinition* trt_builder_create_network(IBuilder* builder, uint32_t flags) {
+    if (!builder) return nullptr;
+    return builder->createNetworkV2(flags);
+}
+
+IBuilderConfig* trt_builder_create_config(IBuilder* builder) {
+    if (!builder) return nullptr;
+    return builder->createBuilderConfig();
+}
+
+IHostMemory* trt_builder_build_serialized_network(
+    IBuilder* builder,
+    INetworkDefinition* network,
+    IBuilderConfig* config
+) {
+    if (!builder || !network || !config) return nullptr;
+    return builder->buildSerializedNetwork(*network, *config);
+}
+
+void trt_builder_set_max_batch_size(IBuilder* builder, int32_t batchSize) {
+    (void)builder;
+    (void)batchSize;
+}
+
+void trt_destroy_network(INetworkDefinition* network) {
+    if (network) delete network;
+}
+
+ITensor* trt_network_add_input(
+    INetworkDefinition* network,
+    const char* name,
+    DataType dtype,
+    const Dims* dims
+) {
+    if (!network || !name || !dims) return nullptr;
+    return network->addInput(name, dtype, *dims);
+}
+
+void trt_network_mark_output(INetworkDefinition* network, ITensor* tensor) {
+    if (network && tensor) {
+        network->markOutput(*tensor);
+    }
+}
+
+int32_t trt_network_get_nb_inputs(INetworkDefinition* network) {
+    return network ? network->getNbInputs() : 0;
+}
+
+int32_t trt_network_get_nb_outputs(INetworkDefinition* network) {
+    return network ? network->getNbOutputs() : 0;
+}
+
+void trt_destroy_config(IBuilderConfig* config) {
+    if (config) delete config;
+}
+
+void trt_config_set_memory_pool_limit(IBuilderConfig* config, MemoryPoolType poolType, size_t poolSize) {
+    if (config) {
+        config->setMemoryPoolLimit(poolType, poolSize);
+    }
+}
+
+const void* trt_host_memory_data(IHostMemory* mem) {
+    return mem ? mem->data() : nullptr;
+}
+
+size_t trt_host_memory_size(IHostMemory* mem) {
+    return mem ? mem->size() : 0;
+}
+
+void trt_destroy_host_memory(IHostMemory* mem) {
+    if (mem) delete mem;
+}
+
+IRuntime* trt_create_runtime() {
+    return createInferRuntime(gLogger);
+}
+
+void trt_destroy_runtime(IRuntime* runtime) {
+    if (runtime) delete runtime;
+}
+
+ICudaEngine* trt_runtime_deserialize_engine(
+    IRuntime* runtime,
+    const void* blob,
+    size_t size
+) {
+    if (!runtime || !blob || size == 0) return nullptr;
+    return runtime->deserializeCudaEngine(blob, size);
+}
+
+void trt_destroy_engine(ICudaEngine* engine) {
+    if (engine) delete engine;
+}
+
+IExecutionContext* trt_engine_create_context(ICudaEngine* engine) {
+    if (!engine) return nullptr;
+    return engine->createExecutionContext();
+}
+
+int32_t trt_engine_get_nb_bindings(ICudaEngine* engine) {
+    return engine ? engine->getNbIOTensors() : 0;
+}
+
+const char* trt_engine_get_tensor_name(ICudaEngine* engine, int32_t index) {
+    if (!engine || index < 0) return nullptr;
+    return engine->getIOTensorName(index);
+}
+
+bool trt_engine_is_execution_binding(ICudaEngine* engine, const char* name) {
+    return engine && name && (engine->getTensorIOMode(name) != TensorIOMode::kNONE);
+}
+
+Dims trt_engine_get_tensor_shape(ICudaEngine* engine, const char* name) {
+    if (engine && name) {
+        return engine->getTensorShape(name);
+    }
+    return Dims{0, {0}};
+}
+
+void trt_destroy_context(IExecutionContext* context) {
+    if (context) delete context;
+}
+
+bool trt_context_execute_v2(IExecutionContext* context, void** bindings) {
+    if (!context || !bindings) return false;
+    return context->executeV2(bindings);
+}
+
+bool trt_context_set_tensor_address(IExecutionContext* context, const char* name, void* data) {
+    if (!context || !name) return false;
+    return context->setTensorAddress(name, data);
+}
+
+bool trt_context_enqueue_v3(IExecutionContext* context, void* stream) {
+    if (!context) return false;
+    return context->enqueueV3((cudaStream_t)stream);
+}
+
+Dims trt_make_dims(int32_t nbDims, const int32_t* d) {
+    Dims dims;
+    dims.nbDims = nbDims;
+    for (int i = 0; i < nbDims && i < Dims::MAX_DIMS; i++) {
+        dims.d[i] = d[i];
+    }
+    return dims;
+}
+
+void trt_set_log_level(int32_t level) {
+    ILogger::Severity severity;
+    switch (level) {
+        case 0: severity = ILogger::Severity::kINTERNAL_ERROR; break;
+        case 1: severity = ILogger::Severity::kERROR; break;
+        case 2: severity = ILogger::Severity::kWARNING; break;
+        case 3: severity = ILogger::Severity::kINFO; break;
+        case 4: severity = ILogger::Severity::kVERBOSE; break;
+        default: severity = ILogger::Severity::kWARNING; break;
+    }
+    gLogger.setMinSeverity(severity);
+}
+
+IOptimizationProfile* trt_create_optimization_profile(IBuilder* builder) {
+    if (!builder) return nullptr;
+    return builder->createOptimizationProfile();
+}
+
+void trt_destroy_optimization_profile(IOptimizationProfile* profile) {
+    // Note: IOptimizationProfile is owned by IBuilder and should not be deleted manually
+    // This function exists for API consistency but does nothing
+    (void)profile;
+}
+
+bool trt_profile_set_shape(
+    IOptimizationProfile* profile,
+    const char* input_name,
+    const Dims* min,
+    const Dims* opt,
+    const Dims* max
+) {
+    if (!profile || !input_name || !min || !opt || !max) return false;
+
+    return profile->setDimensions(input_name, OptProfileSelector::kMIN, *min) &&
+           profile->setDimensions(input_name, OptProfileSelector::kOPT, *opt) &&
+           profile->setDimensions(input_name, OptProfileSelector::kMAX, *max);
+}
+
+int32_t trt_config_add_optimization_profile(IBuilderConfig* config, IOptimizationProfile* profile) {
+    if (!config || !profile) return -1;
+    return config->addOptimizationProfile(profile);
+}
+
+IParser* trt_onnx_create_parser(INetworkDefinition* network) {
+    if (!network) return nullptr;
+    return nvonnxparser::createParser(*network, gLogger);
+}
+
+void trt_onnx_destroy_parser(IParser* parser) {
+    if (parser) delete parser;
+}
+
+bool trt_onnx_parse_from_file(IParser* parser, const char* path) {
+    if (!parser || !path) return false;
+    return parser->parseFromFile(path, static_cast<int>(ILogger::Severity::kWARNING));
+}
+
+bool trt_onnx_parse(IParser* parser, const void* data, size_t size) {
+    if (!parser || !data || size == 0) return false;
+    return parser->parse(data, size);
+}
+
+int32_t trt_onnx_get_nb_errors(IParser* parser) {
+    return parser ? parser->getNbErrors() : 0;
+}
+
+const char* trt_onnx_get_error_desc(IParser* parser, int32_t index) {
+    if (!parser || index < 0 || index >= parser->getNbErrors()) return nullptr;
+    IParserError const* error = parser->getError(index);
+    return error ? error->desc() : nullptr;
+}
+
+int32_t trt_onnx_get_error_code(IParser* parser, int32_t index) {
+    if (!parser || index < 0 || index >= parser->getNbErrors()) return -1;
+    IParserError const* error = parser->getError(index);
+    return error ? static_cast<int32_t>(error->code()) : -1;
+}
+
+int32_t trt_onnx_get_error_node(IParser* parser, int32_t index) {
+    if (!parser || index < 0 || index >= parser->getNbErrors()) return -1;
+    IParserError const* error = parser->getError(index);
+    return error ? error->node() : -1;
+}
+
+}

--- a/src/tensorrt/sys/cpp_wrapper/trt_wrapper.h
+++ b/src/tensorrt/sys/cpp_wrapper/trt_wrapper.h
@@ -1,0 +1,141 @@
+// TensorRT C Wrapper Header
+// C-style interface to TensorRT C++ API
+
+#ifndef TRT_WRAPPER_H
+#define TRT_WRAPPER_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct IBuilder IBuilder;
+typedef struct INetworkDefinition INetworkDefinition;
+typedef struct IBuilderConfig IBuilderConfig;
+typedef struct IHostMemory IHostMemory;
+typedef struct IRuntime IRuntime;
+typedef struct ICudaEngine ICudaEngine;
+typedef struct IExecutionContext IExecutionContext;
+typedef struct ITensor ITensor;
+
+typedef enum {
+    kFLOAT = 0,
+    kHALF = 1,
+    kINT8 = 2,
+    kINT32 = 3,
+    kBOOL = 4,
+} DataType;
+
+typedef enum {
+    kWORKSPACE = 0,
+    kDLA_MANAGED_SRAM = 1,
+    kDLA_LOCAL_DRAM = 2,
+    kDLA_GLOBAL_DRAM = 3,
+} MemoryPoolType;
+
+typedef struct {
+    int32_t nbDims;
+    int64_t d[8];
+} Dims;
+
+// Builder
+IBuilder* trt_create_builder();
+void trt_destroy_builder(IBuilder* builder);
+INetworkDefinition* trt_builder_create_network(IBuilder* builder, uint32_t flags);
+IBuilderConfig* trt_builder_create_config(IBuilder* builder);
+IHostMemory* trt_builder_build_serialized_network(
+    IBuilder* builder,
+    INetworkDefinition* network,
+    IBuilderConfig* config
+);
+void trt_builder_set_max_batch_size(IBuilder* builder, int32_t batchSize);
+
+// Network
+void trt_destroy_network(INetworkDefinition* network);
+ITensor* trt_network_add_input(
+    INetworkDefinition* network,
+    const char* name,
+    DataType dtype,
+    const Dims* dims
+);
+void trt_network_mark_output(INetworkDefinition* network, ITensor* tensor);
+int32_t trt_network_get_nb_inputs(INetworkDefinition* network);
+int32_t trt_network_get_nb_outputs(INetworkDefinition* network);
+
+// Config
+void trt_destroy_config(IBuilderConfig* config);
+void trt_config_set_memory_pool_limit(IBuilderConfig* config, MemoryPoolType poolType, size_t poolSize);
+
+// HostMemory
+const void* trt_host_memory_data(IHostMemory* mem);
+size_t trt_host_memory_size(IHostMemory* mem);
+void trt_destroy_host_memory(IHostMemory* mem);
+
+// Runtime
+IRuntime* trt_create_runtime();
+void trt_destroy_runtime(IRuntime* runtime);
+ICudaEngine* trt_runtime_deserialize_engine(IRuntime* runtime, const void* blob, size_t size);
+
+// Engine
+void trt_destroy_engine(ICudaEngine* engine);
+IExecutionContext* trt_engine_create_context(ICudaEngine* engine);
+int32_t trt_engine_get_nb_bindings(ICudaEngine* engine);
+const char* trt_engine_get_tensor_name(ICudaEngine* engine, int32_t index);
+bool trt_engine_is_execution_binding(ICudaEngine* engine, const char* name);
+Dims trt_engine_get_tensor_shape(ICudaEngine* engine, const char* name);
+
+// ExecutionContext
+void trt_destroy_context(IExecutionContext* context);
+bool trt_context_execute_v2(IExecutionContext* context, void** bindings);
+bool trt_context_set_tensor_address(IExecutionContext* context, const char* name, void* data);
+bool trt_context_enqueue_v3(IExecutionContext* context, void* stream);
+
+// Helpers
+Dims trt_make_dims(int32_t nbDims, const int32_t* d);
+
+// Logger
+typedef enum {
+    kINTERNAL_ERROR = 0,
+    kERROR = 1,
+    kWARNING = 2,
+    kINFO = 3,
+    kVERBOSE = 4,
+} LogSeverity;
+
+void trt_set_log_level(LogSeverity level);
+
+// Optimization Profile
+typedef struct IOptimizationProfile IOptimizationProfile;
+
+IOptimizationProfile* trt_create_optimization_profile(IBuilder* builder);
+void trt_destroy_optimization_profile(IOptimizationProfile* profile);
+bool trt_profile_set_shape(
+    IOptimizationProfile* profile,
+    const char* input_name,
+    const Dims* min,
+    const Dims* opt,
+    const Dims* max
+);
+int32_t trt_config_add_optimization_profile(IBuilderConfig* config, IOptimizationProfile* profile);
+
+// ONNX Parser
+typedef struct IOnnxParser IOnnxParser;
+typedef struct IParserError IParserError;
+
+IOnnxParser* trt_onnx_create_parser(INetworkDefinition* network);
+void trt_onnx_destroy_parser(IOnnxParser* parser);
+bool trt_onnx_parse_from_file(IOnnxParser* parser, const char* path);
+bool trt_onnx_parse(IOnnxParser* parser, const void* data, size_t size);
+int32_t trt_onnx_get_nb_errors(IOnnxParser* parser);
+const char* trt_onnx_get_error_desc(IOnnxParser* parser, int32_t index);
+int32_t trt_onnx_get_error_code(IOnnxParser* parser, int32_t index);
+int32_t trt_onnx_get_error_node(IOnnxParser* parser, int32_t index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/tensorrt/sys/mod.rs
+++ b/src/tensorrt/sys/mod.rs
@@ -1,0 +1,199 @@
+#![cfg_attr(feature = "no-std", no_std)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+#[cfg(feature = "no-std")]
+extern crate alloc;
+#[cfg(feature = "no-std")]
+extern crate no_std_compat as std;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum DataType {
+    kFLOAT = 0,
+    kHALF = 1,
+    kINT8 = 2,
+    kINT32 = 3,
+    kBOOL = 4,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum LogSeverity {
+    kINTERNAL_ERROR = 0,
+    kERROR = 1,
+    kWARNING = 2,
+    kINFO = 3,
+    kVERBOSE = 4,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum MemoryPoolType {
+    kWORKSPACE = 0,
+    kDLA_MANAGED_SRAM = 1,
+    kDLA_LOCAL_DRAM = 2,
+    kDLA_GLOBAL_DRAM = 3,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct Dims {
+    pub nbDims: i32,
+    pub d: [i64; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IBuilder {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IBuilderConfig {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ICudaEngine {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IExecutionContext {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IHostMemory {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct INetworkDefinition {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IOnnxParser {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IOptimizationProfile {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IParserError {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct IRuntime {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ITensor {
+    _unused: [u8; 0],
+}
+// TensorRT wrapper is always statically linked, so always use direct extern declarations
+extern "C" {
+    pub fn trt_builder_build_serialized_network(
+        builder: *mut IBuilder,
+        network: *mut INetworkDefinition,
+        config: *mut IBuilderConfig,
+    ) -> *mut IHostMemory;
+    pub fn trt_builder_create_config(builder: *mut IBuilder) -> *mut IBuilderConfig;
+    pub fn trt_builder_create_network(
+        builder: *mut IBuilder,
+        flags: u32,
+    ) -> *mut INetworkDefinition;
+    pub fn trt_builder_set_max_batch_size(builder: *mut IBuilder, batchSize: i32);
+    pub fn trt_config_add_optimization_profile(
+        config: *mut IBuilderConfig,
+        profile: *mut IOptimizationProfile,
+    ) -> i32;
+    pub fn trt_config_set_memory_pool_limit(
+        config: *mut IBuilderConfig,
+        poolType: MemoryPoolType,
+        poolSize: usize,
+    );
+    pub fn trt_context_enqueue_v3(
+        context: *mut IExecutionContext,
+        stream: *mut ::core::ffi::c_void,
+    ) -> bool;
+    pub fn trt_context_execute_v2(
+        context: *mut IExecutionContext,
+        bindings: *mut *mut ::core::ffi::c_void,
+    ) -> bool;
+    pub fn trt_context_set_tensor_address(
+        context: *mut IExecutionContext,
+        name: *const ::core::ffi::c_char,
+        data: *mut ::core::ffi::c_void,
+    ) -> bool;
+    pub fn trt_create_builder() -> *mut IBuilder;
+    pub fn trt_create_optimization_profile(builder: *mut IBuilder) -> *mut IOptimizationProfile;
+    pub fn trt_create_runtime() -> *mut IRuntime;
+    pub fn trt_destroy_builder(builder: *mut IBuilder);
+    pub fn trt_destroy_config(config: *mut IBuilderConfig);
+    pub fn trt_destroy_context(context: *mut IExecutionContext);
+    pub fn trt_destroy_engine(engine: *mut ICudaEngine);
+    pub fn trt_destroy_host_memory(mem: *mut IHostMemory);
+    pub fn trt_destroy_network(network: *mut INetworkDefinition);
+    pub fn trt_destroy_optimization_profile(profile: *mut IOptimizationProfile);
+    pub fn trt_destroy_runtime(runtime: *mut IRuntime);
+    pub fn trt_engine_create_context(engine: *mut ICudaEngine) -> *mut IExecutionContext;
+    pub fn trt_engine_get_nb_bindings(engine: *mut ICudaEngine) -> i32;
+    pub fn trt_engine_get_tensor_name(
+        engine: *mut ICudaEngine,
+        index: i32,
+    ) -> *const ::core::ffi::c_char;
+    pub fn trt_engine_get_tensor_shape(
+        engine: *mut ICudaEngine,
+        name: *const ::core::ffi::c_char,
+    ) -> Dims;
+    pub fn trt_engine_is_execution_binding(
+        engine: *mut ICudaEngine,
+        name: *const ::core::ffi::c_char,
+    ) -> bool;
+    pub fn trt_host_memory_data(mem: *mut IHostMemory) -> *const ::core::ffi::c_void;
+    pub fn trt_host_memory_size(mem: *mut IHostMemory) -> usize;
+    pub fn trt_make_dims(nbDims: i32, d: *const i32) -> Dims;
+    pub fn trt_network_add_input(
+        network: *mut INetworkDefinition,
+        name: *const ::core::ffi::c_char,
+        dtype: DataType,
+        dims: *const Dims,
+    ) -> *mut ITensor;
+    pub fn trt_network_get_nb_inputs(network: *mut INetworkDefinition) -> i32;
+    pub fn trt_network_get_nb_outputs(network: *mut INetworkDefinition) -> i32;
+    pub fn trt_network_mark_output(network: *mut INetworkDefinition, tensor: *mut ITensor);
+    pub fn trt_onnx_create_parser(network: *mut INetworkDefinition) -> *mut IOnnxParser;
+    pub fn trt_onnx_destroy_parser(parser: *mut IOnnxParser);
+    pub fn trt_onnx_get_error_code(parser: *mut IOnnxParser, index: i32) -> i32;
+    pub fn trt_onnx_get_error_desc(
+        parser: *mut IOnnxParser,
+        index: i32,
+    ) -> *const ::core::ffi::c_char;
+    pub fn trt_onnx_get_error_node(parser: *mut IOnnxParser, index: i32) -> i32;
+    pub fn trt_onnx_get_nb_errors(parser: *mut IOnnxParser) -> i32;
+    pub fn trt_onnx_parse(
+        parser: *mut IOnnxParser,
+        data: *const ::core::ffi::c_void,
+        size: usize,
+    ) -> bool;
+    pub fn trt_onnx_parse_from_file(
+        parser: *mut IOnnxParser,
+        path: *const ::core::ffi::c_char,
+    ) -> bool;
+    pub fn trt_profile_set_shape(
+        profile: *mut IOptimizationProfile,
+        input_name: *const ::core::ffi::c_char,
+        min: *const Dims,
+        opt: *const Dims,
+        max: *const Dims,
+    ) -> bool;
+    pub fn trt_runtime_deserialize_engine(
+        runtime: *mut IRuntime,
+        blob: *const ::core::ffi::c_void,
+        size: usize,
+    ) -> *mut ICudaEngine;
+    pub fn trt_set_log_level(level: LogSeverity);
+}

--- a/src/tensorrt/sys/wrapper.h
+++ b/src/tensorrt/sys/wrapper.h
@@ -1,0 +1,1 @@
+#include "cpp_wrapper/trt_wrapper.h"


### PR DESCRIPTION
This PR aims to add support for TensorRT to cudarc.

As TensorRT is a C++ only lib, bindgen automatic generation does not work here, so a cpp wrapper is created to flatten TensorRT into C code.

Right now, we are not downloading redist files from nvidia, that would be a big TODO.

Working ATM:
* Some basic tests
* TensorRT linked and working with CUDA 13 and CUDA 12

Implementation details:
* TensorRT thin wrapper always statically linked (Very basic wrapper, I dont see the benefit of trying to dynamic load it, and CC only supports static lib generation)
* TensorRT code not being fetched on bindings_generator

Missing:
* Feature gating TRT code in the cpp wrapper depending on the cuda version, maybe passing some defines onto the header coming from rust feature flags
* Expand the trt wrapper to expose more TRT features, this is only a small POC
* Fix some deprecation warnings on the TRT plugin code
* Safe wrappers (This is a big one)

@chelsea0x3b maybe you can check it out and just check if the implementation logic is right or if maybe another path should be taken to implement this