### PR TITLE
Implement `DeviceRepr` for arrays

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -827,6 +827,8 @@ unsafe impl DeviceRepr for float4::E8M0 {}
 #[cfg(feature = "f4")]
 unsafe impl ValidAsZeroBits for float4::E8M0 {}
 
+unsafe impl<const N: usize, T> DeviceRepr for [T; N] where T: DeviceRepr {}
+
 /// Base trait for abstracting over [CudaSlice]/[CudaView]/[CudaViewMut].
 ///
 /// Don't use this directly - use [DevicePtr]/[DevicePtrMut].


### PR DESCRIPTION
It's safe because Rust array elements are stored contiguously, without any extra padding:

https://doc.rust-lang.org/reference/type-layout.html#r-layout.array