### PR TITLE
fix: add support for cufft 12.x

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,12 +206,14 @@ pub(crate) fn get_lib_name_candidates(lib_name: &str) -> std::vec::Vec<std::stri
         // See issue #242
         std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_10{DLL_SUFFIX}"),
         std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_11{DLL_SUFFIX}"),
+        std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_12{DLL_SUFFIX}"),
         // See issue #246
         std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_{major}0_0{DLL_SUFFIX}"),
         // See issue #260
         std::format!("{DLL_PREFIX}{lib_name}{pointer_width}_9{DLL_SUFFIX}"),
         // See issue #274
         std::format!("{DLL_PREFIX}{lib_name}{DLL_SUFFIX}.{major}"),
+        std::format!("{DLL_PREFIX}{lib_name}{DLL_SUFFIX}.12"),
         std::format!("{DLL_PREFIX}{lib_name}{DLL_SUFFIX}.11"),
         std::format!("{DLL_PREFIX}{lib_name}{DLL_SUFFIX}.10"),
         // See issue #296


### PR DESCRIPTION
Hi @chelsea0x3b,

This is a fix to add search paths to make `cufft64_12.dll` or `libcufft.so.12` work.