### PR TITLE
Add total_mem() and mem_get_info() safe methods to CudaContext

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -116,7 +116,6 @@ impl CudaContext {
         Ok((capability_major, capability_minor))
     }
 
-    /// Get the underlying [sys::CUdevice] of this [CudaContext].
     /// Get the total memory available on this device, in bytes.
     pub fn total_mem(&self) -> Result<usize, DriverError> {
         self.check_err()?;
@@ -130,6 +129,7 @@ impl CudaContext {
         self.bind_to_thread()?;
         result::mem_get_info()
     }
+    /// Get the underlying [sys::CUdevice] of this [CudaContext].
     ///
     /// # Safety
     /// While this function is marked as safe, actually using the


### PR DESCRIPTION
(I have been looking at this project for some time now, just to learn. Came across this issue today. First time contributing, please let me know if I am doing something wrong)

result::device::total_mem() and result::mem_get_info() exisst but don't
have safe-level wrappers on CudaContext. Users have to drop down to the
result layer and handle context binding themselves.

This adds two methods to CudaContext following the same pattern as
name(), uuid(), compute_capability():

  * total_mem(&self): wraps result::device::total_mem(), uses
    check_err()
  * mem_get_info(&self): wraps result::mem_get_info(), uses
    bind_to_thread() to ensure the query targets the correct context

Also updated test_post_alloc_memory to use ctx.mem_get_info() instead
of calling result::mem_get_info() directly.