### PR TITLE
driver: add result-level memory pool wrappers

### DIFF
--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -1499,7 +1499,7 @@ pub mod mem_pool {
     ///
     /// # Safety
     /// 1. Pool and stream must be valid.
-    /// 2. The returned memory is unset, which may be invalid for `T`.
+    /// 2. The returned memory is uninitialized.
     pub unsafe fn alloc_async(
         pool: sys::CUmemoryPool,
         num_bytes: usize,


### PR DESCRIPTION
driver: add result-level memory pool wrappers

Add result::mem_pool module wrapping the core cuMemPool* functions:
create, destroy, trim_to, get_attribute, set_attribute, alloc_async.

Add get_default_mem_pool, get_mem_pool, set_mem_pool to result::device
for the cuDeviceGet/SetMemPool functions.

This is the result layer for memory pool support. Safe-level
wrappers (CudaMemPool type, CudaStream::alloc_from_pool, etc.) to
follow in a separate PR.

Related: #536 