### PR TITLE
Add CUDA stream priority API

### DIFF
--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -672,6 +672,44 @@ pub mod stream {
         }
     }
 
+    /// Creates a stream with the specified kind and priority.
+    ///
+    /// Lower numerical values indicate higher priority. Use [`get_priority_range`]
+    /// to query the valid range for the current context.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__STREAM.html#group__CUDA__STREAM_1g95c1a8c7c3dacb13091692dd9c7f7471)
+    pub fn create_with_priority(
+        kind: StreamKind,
+        priority: i32,
+    ) -> Result<sys::CUstream, DriverError> {
+        let mut stream = MaybeUninit::uninit();
+        unsafe {
+            sys::cuStreamCreateWithPriority(stream.as_mut_ptr(), kind.flags() as u32, priority)
+                .result()?;
+            Ok(stream.assume_init())
+        }
+    }
+
+    /// Queries the range of stream priorities for the current context.
+    ///
+    /// Returns `(least_priority, greatest_priority)` matching the CUDA driver
+    /// API parameter order. Note that in CUDA, numerically **smaller** values
+    /// mean **higher** priority, so `greatest_priority <= least_priority`.
+    /// For example, a return value of `(0, -5)` means priority -5 is the
+    /// highest and 0 is the lowest.
+    ///
+    /// If the device does not support stream priorities, both values will be 0.
+    ///
+    /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g137920ab61a71be6ce67f32ba4f72354)
+    pub fn get_priority_range() -> Result<(i32, i32), DriverError> {
+        let mut least = MaybeUninit::uninit();
+        let mut greatest = MaybeUninit::uninit();
+        unsafe {
+            sys::cuCtxGetStreamPriorityRange(least.as_mut_ptr(), greatest.as_mut_ptr()).result()?;
+            Ok((least.assume_init(), greatest.assume_init()))
+        }
+    }
+
     /// Wait until a stream's tasks are completed.
     ///
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__STREAM.html#group__CUDA__STREAM_1g15e49dd91ec15991eb7c0a741beb7dad)

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -672,12 +672,30 @@ impl CudaContext {
     /// This will swap the calling context to multi stream mode [CudaContext::is_in_multi_stream_mode()].
     /// If the context is not already in multiple stream mode, then this function will also call [CudaContext::synchronize()].
     pub fn new_stream(self: &Arc<Self>) -> Result<Arc<CudaStream>, DriverError> {
+        self.new_stream_with_priority(0)
+    }
+
+    /// Create a new [sys::CUstream_flags::CU_STREAM_NON_BLOCKING] stream with the
+    /// specified priority.
+    ///
+    /// Lower numerical values indicate higher priority. Use
+    /// [`result::stream::get_priority_range`] to query the valid range.
+    ///
+    /// This will swap the calling context to multi stream mode
+    /// [`CudaContext::is_in_multi_stream_mode()`].
+    pub fn new_stream_with_priority(
+        self: &Arc<Self>,
+        priority: i32,
+    ) -> Result<Arc<CudaStream>, DriverError> {
         self.bind_to_thread()?;
         let prev_num_streams = self.num_streams.fetch_add(1, Ordering::Relaxed);
         if prev_num_streams == 0 && self.is_event_tracking() {
             self.synchronize()?;
         }
-        let cu_stream = result::stream::create(result::stream::StreamKind::NonBlocking)?;
+        let cu_stream = result::stream::create_with_priority(
+            result::stream::StreamKind::NonBlocking,
+            priority,
+        )?;
         Ok(Arc::new(CudaStream {
             cu_stream,
             ctx: self.clone(),

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -672,7 +672,16 @@ impl CudaContext {
     /// This will swap the calling context to multi stream mode [CudaContext::is_in_multi_stream_mode()].
     /// If the context is not already in multiple stream mode, then this function will also call [CudaContext::synchronize()].
     pub fn new_stream(self: &Arc<Self>) -> Result<Arc<CudaStream>, DriverError> {
-        self.new_stream_with_priority(0)
+        self.bind_to_thread()?;
+        let prev_num_streams = self.num_streams.fetch_add(1, Ordering::Relaxed);
+        if prev_num_streams == 0 && self.is_event_tracking() {
+            self.synchronize()?;
+        }
+        let cu_stream = result::stream::create(result::stream::StreamKind::NonBlocking)?;
+        Ok(Arc::new(CudaStream {
+            cu_stream,
+            ctx: self.clone(),
+        }))
     }
 
     /// Create a new [sys::CUstream_flags::CU_STREAM_NON_BLOCKING] stream with the


### PR DESCRIPTION
## Summary

This adds safe wrappers for the CUDA stream priority API:

- `result::stream::create_with_priority()`: wraps `cuStreamCreateWithPriority`
- `result::stream::get_priority_range()`: wraps `cuCtxGetStreamPriorityRange`
- `CudaContext::new_stream_with_priority()`: safe wrapper with the same lifecycle management as `new_stream()`

## Motivation

Stream priorities are useful when running inference workloads alongside a game engine or other real-time renderer on the same GPU. By assigning different priorities to the compute and rendering streams, the CUDA driver can make better scheduling decisions and reduce frame drops.

The underlying driver functions (`cuStreamCreateWithPriority`, `cuCtxGetStreamPriorityRange`) have been stable since CUDA 5.0 and are widely used, but cudarc doesn't expose them yet.

## Implementation

The safe wrapper (`new_stream_with_priority`) follows the same pattern as the existing `new_stream()`:
- Binds the context to the calling thread
- Increments the stream counter (entering multi-stream mode and disabling single-stream optimizations)
- Creates a non-blocking stream with the requested priority
- Returns an `Arc<CudaStream>` with proper lifecycle management

The `get_priority_range()` function is exposed at the `result` level only, since it is a context-level query that callers will typically use once to validate a priority value before creating a stream.