### PR TITLE
Skip event recording and waiting when event tracking is disabled

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -776,11 +776,13 @@ unsafe impl<T> Sync for CudaSlice<T> {}
 impl<T> Drop for CudaSlice<T> {
     fn drop(&mut self) {
         let ctx = &self.stream.ctx;
-        if let Some(read) = self.read.as_ref() {
-            ctx.record_err(self.stream.wait(read));
-        }
-        if let Some(write) = self.write.as_ref() {
-            ctx.record_err(self.stream.wait(write));
+        if ctx.is_event_tracking() {
+            if let Some(read) = self.read.as_ref() {
+                ctx.record_err(self.stream.wait(read));
+            }
+            if let Some(write) = self.write.as_ref() {
+                ctx.record_err(self.stream.wait(write));
+            }
         }
         if ctx.has_async_alloc {
             ctx.record_err(unsafe {
@@ -1146,10 +1148,12 @@ impl<T> DevicePtr<T> for CudaSlice<T> {
                 stream.ctx.record_err(stream.wait(write));
             }
         }
-        (
-            self.cu_device_ptr,
-            SyncOnDrop::record_event(&self.read, stream),
-        )
+        let sync = if self.stream.context().is_event_tracking() {
+            SyncOnDrop::record_event(&self.read, stream)
+        } else {
+            SyncOnDrop::Sync(None)
+        };
+        (self.cu_device_ptr, sync)
     }
 }
 
@@ -1160,7 +1164,12 @@ impl<T> DevicePtr<T> for CudaView<'_, T> {
                 stream.ctx.record_err(stream.wait(write));
             }
         }
-        (self.ptr, SyncOnDrop::record_event(self.read, stream))
+        let sync = if self.stream.context().is_event_tracking() {
+            SyncOnDrop::record_event(self.read, stream)
+        } else {
+            SyncOnDrop::Sync(None)
+        };
+        (self.ptr, sync)
     }
 }
 
@@ -1171,7 +1180,12 @@ impl<T> DevicePtr<T> for CudaViewMut<'_, T> {
                 stream.ctx.record_err(stream.wait(write));
             }
         }
-        (self.ptr, SyncOnDrop::record_event(self.read, stream))
+        let sync = if self.stream.context().is_event_tracking() {
+            SyncOnDrop::record_event(self.read, stream)
+        } else {
+            SyncOnDrop::Sync(None)
+        };
+        (self.ptr, sync)
     }
 }
 
@@ -1210,10 +1224,12 @@ impl<T> DevicePtrMut<T> for CudaSlice<T> {
                 stream.ctx.record_err(stream.wait(write));
             }
         }
-        (
-            self.cu_device_ptr,
-            SyncOnDrop::record_event(&self.write, stream),
-        )
+        let sync = if self.stream.context().is_event_tracking() {
+            SyncOnDrop::record_event(&self.write, stream)
+        } else {
+            SyncOnDrop::Sync(None)
+        };
+        (self.cu_device_ptr, sync)
     }
 }
 
@@ -1230,7 +1246,12 @@ impl<T> DevicePtrMut<T> for CudaViewMut<'_, T> {
                 stream.ctx.record_err(stream.wait(write));
             }
         }
-        (self.ptr, SyncOnDrop::record_event(self.write, stream))
+        let sync = if self.stream.context().is_event_tracking() {
+            SyncOnDrop::record_event(self.write, stream)
+        } else {
+            SyncOnDrop::Sync(None)
+        };
+        (self.ptr, sync)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a hang that occurs when `disable_event_tracking()` is called after CudaSlices have already been allocated.

## Problem

When `disable_event_tracking()` is called on a CudaContext, any CudaSlices that were allocated before the call still hold `Some(CudaEvent)` in their `read`/`write` fields. Two things go wrong with these "stale" events:

1. **Drop for CudaSlice** calls `stream.wait(read)` and `stream.wait(write)` on them, which can hang because the events were recorded on a different stream or in a different synchronization context that no longer makes sense.
2. **DevicePtr / DevicePtrMut impls** return `SyncOnDrop::record_event(...)` which calls `cuEventRecord` on these stale events, also causing hangs.

This is a real problem for workloads that start with event tracking enabled (the default), do some setup allocations, and then disable event tracking for a performance-critical hot loop (e.g., CUDA graph capture/replay in ML inference, where events are not needed and add unnecessary overhead).

## Fix

Gate on `is_event_tracking()` in:
- `Drop for CudaSlice`: skip `stream.wait(read/write)` when tracking is disabled
- `DevicePtr` impls for `CudaSlice`, `CudaView`, `CudaViewMut`: return `SyncOnDrop::Sync(None)` instead of recording an event
- `DevicePtrMut` impls for `CudaSlice`, `CudaViewMut`: same

When event tracking is disabled, synchronization is the caller's responsibility anyway (that is the whole point of opting out), so skipping these operations is both correct and consistent with the API contract.