### PR TITLE
Make CudaSlice::cu_device_ptr public

### DIFF
--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -762,7 +762,20 @@ impl CudaStream {
 /// This object is thread safe.
 #[derive(Debug)]
 pub struct CudaSlice<T> {
-    pub(crate) cu_device_ptr: sys::CUdeviceptr,
+    /// Raw CUDA device pointer.
+    ///
+    /// This is public for advanced use cases like direct `cuMemcpyDtoDAsync` calls
+    /// that bypass cudarc's event tracking.
+    ///
+    /// # Safety
+    ///
+    /// The pointer is owned by the `CudaSlice` and will be freed when it is dropped.
+    /// The caller **must** ensure that this pointer is not used after the `CudaSlice`
+    /// has been dropped, otherwise it will be a dangling pointer.
+    ///
+    /// The caller is also responsible for all synchronization when using this pointer.
+    /// Using this pointer directly bypasses cudarc's automatic stream synchronization.
+    pub cu_device_ptr: sys::CUdeviceptr,
     pub(crate) len: usize,
     pub(crate) read: Option<CudaEvent>,
     pub(crate) write: Option<CudaEvent>,


### PR DESCRIPTION
## Summary

Makes the `cu_device_ptr` field on `CudaSlice<T>` public (was `pub(crate)`).

## Motivation

There are legitimate cases where a caller needs the raw `CUdeviceptr` to perform a `cuMemcpyDtoDAsync` (or similar driver-level memcpy) directly, without going through the event tracking machinery.

The current way to get the raw pointer is through the `DevicePtr` trait, but that returns a `SyncOnDrop` guard that records events. When event tracking is disabled (via `disable_event_tracking()`), this is unnecessary overhead and the guard serves no purpose. Having direct access to the raw pointer lets callers who have already opted out of event tracking perform raw memcpy operations without the ceremony.

This is consistent with the general cudarc philosophy of providing safe defaults while still allowing advanced users to drop down to the driver level when needed. The field is already `pub(crate)`, so it is used internally without restriction. Making it `pub` just extends the same access to downstream crates.

## Changes

One-line change: `pub(crate) cu_device_ptr` becomes `pub cu_device_ptr` on `CudaSlice<T>`.