### PR TITLE
Peer to peer

### DIFF
--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -1620,7 +1620,6 @@ pub mod mem_pool {
 mod tests {
     use super::super::safe::{CudaContext, CudaSlice};
     use super::*;
-    use std::println;
 
     #[test]
     #[ignore = "must be executed with multiple gpus"]

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -1652,12 +1652,9 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "must be executed with  gpus"]
     fn re_associate_context_for_memory_op() -> Result<(), DriverError> {
         let ctx1 = CudaContext::new(0)?;
-        if device::get_count()? < 2 {
-            println!("Skip test because not enough cuda devices");
-            return Ok(());
-        }
         let stream1 = ctx1.default_stream();
         let a: CudaSlice<f64> = stream1.alloc_zeros::<f64>(10)?;
 

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -1623,12 +1623,9 @@ mod tests {
     use std::println;
 
     #[test]
+    #[ignore = "must be executed with multiple gpus"]
     fn peer_transfer_contexts() -> Result<(), DriverError> {
         let ctx1 = CudaContext::new(0)?;
-        if device::get_count()? < 2 {
-            println!("Skip test because not enough cuda devices");
-            return Ok(());
-        }
         let stream1 = ctx1.default_stream();
         let a: CudaSlice<f64> = stream1.alloc_zeros::<f64>(10)?;
 

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -1652,7 +1652,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "must be executed with  gpus"]
+    #[ignore = "must be executed with multiple gpus"]
     fn re_associate_context_for_memory_op() -> Result<(), DriverError> {
         let ctx1 = CudaContext::new(0)?;
         let stream1 = ctx1.default_stream();

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -1628,7 +1628,7 @@ impl CudaStream {
         let src_ctx = src.stream().context();
         let dst_ctx = self.context();
 
-        let (src, _record_src) = src.device_ptr(self);
+        let (src, _record_src) = src.device_ptr(src.stream());
         let (dst, _record_dst) = dst.device_ptr_mut(self);
 
         if src_ctx == dst_ctx {

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -1627,20 +1627,20 @@ impl CudaStream {
 
         // NOTE: Although we want the current stream to wait on src to be ready,
         // we can't use src.device_ptr(self). When `_record_src` is dropped,
-        // we record an event from the src_stream onto dst_stream. This is not
-        // allowed in CUDA, and will return a CUDA_ERROR_INVALID_HANDLE.
+        // we record an event from the src_stream onto dst_stream (i.e., self). This is not
+        // allowed in CUDA, and will return a CUDA_ERROR_INVALID_HANDLE
+        // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1gf3ee63561a7a371fa9d4dc0e31f94afd
         let (src_ptr, _record_src) = src.device_ptr(src.stream());
         let (dst_ptr, _record_dst) = dst.device_ptr_mut(self);
 
         if src_ctx == dst_ctx {
             unsafe { result::memcpy_dtod_async(dst_ptr, src_ptr, num_bytes, self.cu_stream) }
         } else {
-            // NOTE: Although we can't record events from other streams onto this stream,
-            // we can *wait* on events from others streams on this streams. To verify that
-            // src is ready, we'll create an event from src_stream and wait on it in this
-            // stream.
-            // OPTIM: Ideally we could wait on the src.events, but we can artificially
-            // insert an event which would guarantee src is available
+            // NOTE: Although we can't record events on streams they weren't created on,
+            // we can *wait* on events from any stream. We can leverage this and wait on
+            // a src event.
+            // OPTIM: Ideally we could wait on the src write_events, but we can artificially
+            // insert an event which guarantees src is available.
             self.wait(&src.stream().record_event(None)?);
             unsafe {
                 result::memcpy_peer_async(

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -1627,21 +1627,21 @@ impl CudaStream {
 
         // NOTE: Although we want the current stream to wait on src to be ready,
         // we can't use src.device_ptr(self). When `_record_src` is dropped,
-        // we record an event from the src_stream onto dst_stream. This is not
-        // allowed in CUDA, and will return a CUDA_ERROR_INVALID_HANDLE.
+        // we record an event from the src_stream onto dst_stream (i.e., self). This is not
+        // allowed in CUDA, and will return a CUDA_ERROR_INVALID_HANDLE
+        // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1gf3ee63561a7a371fa9d4dc0e31f94afd
         let (src_ptr, _record_src) = src.device_ptr(src.stream());
         let (dst_ptr, _record_dst) = dst.device_ptr_mut(self);
 
         if src_ctx == dst_ctx {
             unsafe { result::memcpy_dtod_async(dst_ptr, src_ptr, num_bytes, self.cu_stream) }
         } else {
-            // NOTE: Although we can't record events from other streams onto this stream,
-            // we can *wait* on events from others streams on this streams. To verify that
-            // src is ready, we'll create an event from src_stream and wait on it in this
-            // stream.
-            // OPTIM: Ideally we could wait on the src.events, but we can artificially
-            // insert an event which would guarantee src is available
-            self.wait(&src.stream().record_event(None)?);
+            // NOTE: Although we can't record events on streams they weren't created on,
+            // we can *wait* on events from any stream. We can leverage this and wait on
+            // a src event.
+            // OPTIM: Ideally we could wait on the src write_events, but we can artificially
+            // insert an event which guarantees src is available.
+            self.wait(&src.stream().record_event(None)?)?;
             unsafe {
                 result::memcpy_peer_async(
                     dst_ctx.cu_ctx,

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -764,9 +764,6 @@ impl CudaStream {
     ///
     /// See [cuda docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__STREAM.html#group__CUDA__STREAM_1g6a898b652dfc6aa1d5c8d97062618b2f)
     pub fn wait(&self, event: &CudaEvent) -> Result<(), DriverError> {
-        if self.ctx != event.ctx {
-            return Err(DriverError(sys::cudaError_enum::CUDA_ERROR_INVALID_CONTEXT));
-        }
         self.ctx.bind_to_thread()?;
         unsafe {
             result::stream::wait_event(
@@ -1628,18 +1625,29 @@ impl CudaStream {
         let src_ctx = src.stream().context();
         let dst_ctx = self.context();
 
-        let (src, _record_src) = src.device_ptr(src.stream());
-        let (dst, _record_dst) = dst.device_ptr_mut(self);
+        // NOTE: Although we want the current stream to wait on src to be ready,
+        // we can't use src.device_ptr(self). When `_record_src` is dropped,
+        // we record an event from the src_stream onto dst_stream. This is not
+        // allowed in CUDA, and will return a CUDA_ERROR_INVALID_HANDLE.
+        let (src_ptr, _record_src) = src.device_ptr(src.stream());
+        let (dst_ptr, _record_dst) = dst.device_ptr_mut(self);
 
         if src_ctx == dst_ctx {
-            unsafe { result::memcpy_dtod_async(dst, src, num_bytes, self.cu_stream) }
+            unsafe { result::memcpy_dtod_async(dst_ptr, src_ptr, num_bytes, self.cu_stream) }
         } else {
+            // NOTE: Although we can't record events from other streams onto this stream,
+            // we can *wait* on events from others streams on this streams. To verify that
+            // src is ready, we'll create an event from src_stream and wait on it in this
+            // stream.
+            // OPTIM: Ideally we could wait on the src.events, but we can artificially
+            // insert an event which would guarantee src is available
+            self.wait(&src.stream().record_event(None)?);
             unsafe {
                 result::memcpy_peer_async(
                     dst_ctx.cu_ctx,
-                    dst,
+                    dst_ptr,
                     src_ctx.cu_ctx,
-                    src,
+                    src_ptr,
                     num_bytes,
                     self.cu_stream,
                 )

--- a/src/driver/safe/core.rs
+++ b/src/driver/safe/core.rs
@@ -1625,17 +1625,18 @@ impl CudaStream {
         let src_ctx = src.stream().context();
         let dst_ctx = self.context();
 
-        // NOTE: Although we want the current stream to wait on src to be ready,
-        // we can't use src.device_ptr(self). When `_record_src` is dropped,
-        // we record an event from the src_stream onto dst_stream (i.e., self). This is not
-        // allowed in CUDA, and will return a CUDA_ERROR_INVALID_HANDLE
-        // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1gf3ee63561a7a371fa9d4dc0e31f94afd
-        let (src_ptr, _record_src) = src.device_ptr(src.stream());
-        let (dst_ptr, _record_dst) = dst.device_ptr_mut(self);
-
         if src_ctx == dst_ctx {
+            let (src_ptr, _record_src) = src.device_ptr(self);
+            let (dst_ptr, _record_dst) = dst.device_ptr_mut(self);
             unsafe { result::memcpy_dtod_async(dst_ptr, src_ptr, num_bytes, self.cu_stream) }
         } else {
+            // NOTE: Although we want the current stream to wait on src to be ready,
+            // we can't use src.device_ptr(self). When `_record_src` is dropped,
+            // we record an event from the src_stream onto dst_stream (i.e., self). This is not
+            // allowed in CUDA, and will return a CUDA_ERROR_INVALID_HANDLE
+            // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1gf3ee63561a7a371fa9d4dc0e31f94afd
+            let (src_ptr, _record_src) = src.device_ptr(src.stream());
+            let (dst_ptr, _record_dst) = dst.device_ptr_mut(self);
             // NOTE: Although we can't record events on streams they weren't created on,
             // we can *wait* on events from any stream. We can leverage this and wait on
             // a src event.

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -817,4 +817,90 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
             .expect_err("Should've had device side assert");
         Ok(())
     }
+
+    /// Test that memcpy_dtod (peer path) waits for the src stream to finish before copying.
+    ///
+    /// Uses slow_worker to occupy stream1 for long enough that stream2's peer copy
+    /// would race ahead and read stale zeros if the fix is absent.
+    #[cfg(feature = "nvrtc")]
+    #[cfg(any(
+        feature = "cuda-12050",
+        feature = "cuda-12060",
+        feature = "cuda-12080",
+        feature = "cuda-12090",
+        feature = "cuda-13000",
+        feature = "cuda-13010"
+    ))]
+    #[test]
+    fn test_peer_memcpy_waits_for_src_stream() -> Result<(), DriverError> {
+        use crate::driver::CudaContext;
+
+        let ptx = compile_ptx_with_opts(SLOW_KERNELS, Default::default()).unwrap();
+
+        // Primary vs non-primary gives distinct cu_ctx → memcpy_dtod takes the peer path.
+        let ctx1 = CudaContext::new(0)?;
+        let ctx2 = CudaContext::new(1)?;
+
+        let module = ctx1.load_module(ptx)?;
+        let slow_worker = module.load_function("slow_worker")?;
+
+        let stream1 = ctx1.new_stream()?;
+        let stream2 = ctx2.new_stream()?;
+
+        let n = 1000usize;
+
+        // src is 1.0s: slow_worker will accumulate 1M * 1.0 = 1e6 into tmp_out.
+        // tmp_out starts at 0.0, so result is only non-zero if the copy happens after the kernel.
+        let src = stream1.clone_htod(&vec![1.0f32; n])?;
+
+        let mut tmp_out = stream1.alloc_zeros::<f32>(1)?;
+        let mut dst = stream2.alloc_zeros::<f32>(1)?;
+
+        stream1.synchronize()?;
+        stream2.synchronize()?;
+
+        // Queue slow_worker on stream1: reads 1.0s from src and writes ~1e6 to tmp_out.
+        // Spins for 1M iterations, keeping stream1 busy while stream2 races below.
+        let numel = src.len();
+        unsafe {
+            stream1
+                .launch_builder(&slow_worker)
+                .arg(&src)
+                .arg(&numel)
+                .arg(&mut tmp_out)
+                .launch(LaunchConfig::for_num_elems(1))?
+        };
+
+        // Peer-copy tmp_out to dst on stream2 immediately, without waiting for stream1.
+        // Without the fix: copies the initial 0.0 (kernel not done yet).
+        // With the fix: copies the kernel result ~1e6.
+        stream2.memcpy_dtod(&tmp_out, &mut dst)?;
+
+        // Non-pinned Vec forces an implicit sync of stream2 on the D2H copy.
+        let result = stream2.clone_dtoh(&dst)?;
+        let truth = stream1.clone_dtoh(&tmp_out)?;
+
+        stream2.memcpy_dtod(&tmp_out, &mut dst)?;
+
+        let result2 = stream2.clone_dtoh(&dst)?;
+
+        println!("truth: {truth:?}");
+        println!("result: {result:?}");
+        println!("result2: {result2:?}");
+        assert!(
+            result2 == truth,
+            "peer copy might be broken?; result={} truth={}",
+            result2[0],
+            truth[0]
+        );
+
+        assert!(
+            result == truth,
+            "peer copy read pre-kernel data; result={} truth={}",
+            result[0],
+            truth[0]
+        );
+
+        Ok(())
+    }
 }

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -852,7 +852,7 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
 
         // src is 1.0s: slow_worker will accumulate 1M * 1.0 = 1e6 into tmp_out.
         // tmp_out starts at 0.0, so result is only non-zero if the copy happens after the kernel.
-        let src = stream1.clone_htod(&vec![1.0f32; n])?;
+        let src = stream1.clone_htod(&std::vec![1.0f32; n])?;
 
         let mut tmp_out = stream1.alloc_zeros::<f32>(1)?;
         let mut dst = stream2.alloc_zeros::<f32>(1)?;

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -832,6 +832,7 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
         feature = "cuda-13010"
     ))]
     #[test]
+    #[ignore = "must be executed with multiple gpus"]
     fn test_peer_memcpy_waits_for_src_stream() -> Result<(), DriverError> {
         use crate::driver::CudaContext;
 
@@ -872,21 +873,17 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
         };
 
         // Peer-copy tmp_out to dst on stream2 immediately, without waiting for stream1.
-        // Without the fix: copies the initial 0.0 (kernel not done yet).
-        // With the fix: copies the kernel result ~1e6.
         stream2.memcpy_dtod(&tmp_out, &mut dst)?;
 
-        // Non-pinned Vec forces an implicit sync of stream2 on the D2H copy.
         let result = stream2.clone_dtoh(&dst)?;
         let truth = stream1.clone_dtoh(&tmp_out)?;
 
-        stream2.memcpy_dtod(&tmp_out, &mut dst)?;
+        //synchronize and then re-pull from device
+        stream1.synchronize()?;
+        stream2.synchronize()?;
 
         let result2 = stream2.clone_dtoh(&dst)?;
 
-        println!("truth: {truth:?}");
-        println!("result: {result:?}");
-        println!("result2: {result2:?}");
         assert!(
             result2 == truth,
             "peer copy might be broken?; result={} truth={}",
@@ -896,7 +893,7 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
 
         assert!(
             result == truth,
-            "peer copy read pre-kernel data; result={} truth={}",
+            "peer copy read from pre-kernel data; result={} truth={}",
             result[0],
             truth[0]
         );

--- a/src/driver/safe/launch.rs
+++ b/src/driver/safe/launch.rs
@@ -872,21 +872,17 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
         };
 
         // Peer-copy tmp_out to dst on stream2 immediately, without waiting for stream1.
-        // Without the fix: copies the initial 0.0 (kernel not done yet).
-        // With the fix: copies the kernel result ~1e6.
         stream2.memcpy_dtod(&tmp_out, &mut dst)?;
 
-        // Non-pinned Vec forces an implicit sync of stream2 on the D2H copy.
         let result = stream2.clone_dtoh(&dst)?;
         let truth = stream1.clone_dtoh(&tmp_out)?;
 
-        stream2.memcpy_dtod(&tmp_out, &mut dst)?;
+        //synchronize and then re-pull from device
+        stream1.synchronize()?;
+        stream2.synchronize()?;
 
         let result2 = stream2.clone_dtoh(&dst)?;
 
-        println!("truth: {truth:?}");
-        println!("result: {result:?}");
-        println!("result2: {result2:?}");
         assert!(
             result2 == truth,
             "peer copy might be broken?; result={} truth={}",
@@ -896,7 +892,7 @@ extern \"C\" __global__ void slow_worker(const float *data, const size_t len, fl
 
         assert!(
             result == truth,
-            "peer copy read pre-kernel data; result={} truth={}",
+            "peer copy read from pre-kernel data; result={} truth={}",
             result[0],
             truth[0]
         );


### PR DESCRIPTION
This PR addresses #559, and re-allows for peer to peer copy. It makes three main changes:
1.  The old code tried to record an event from the src stream onto the self (dst) stream, which was causing errors. I moved to recording the event on the src.stream(), and to capture the intended waiting, I created+recorded a new event to wait on.
2. Additionally, the wait function was returning a driver error when the context differed, but I believe we can wait on events from different contexts: [docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1gcf64e420275a8141b1f12bfce3f478f9).  I wasn't running into any problems in my test I added.
3. Added ignore flags to the tests that required multiple GPUs so they don't seem like they're passing if they're not run

`cargo test --features cuda-13000` worked for me aside from the `test_pinned_copy_is_faster`, which was failing for me even on main.

Apologies for all the small commits, they can/should be squashed.