### PR TITLE
Replace CUmemAllocationHandleType enum with u32

### DIFF
--- a/bindings_generator/src/main.rs
+++ b/bindings_generator/src/main.rs
@@ -39,6 +39,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "driver",
@@ -67,6 +68,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec!["CUmemAllocationHandleType_enum"],
         },
         ModuleConfig {
             cudarc_name: "cublas",
@@ -99,6 +101,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "cublaslt",
@@ -119,6 +122,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "curand",
@@ -139,6 +143,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "nvrtc",
@@ -169,6 +174,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "cudnn",
@@ -185,6 +191,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "nccl",
@@ -201,6 +208,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "cusparse",
@@ -259,6 +267,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "cusolver",
@@ -280,6 +289,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             min_cuda_version: None,
             // cusolverDn.h transitively includes cublas_v2.h
             module_dependencies: vec!["cublas", "cusparse"],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "cusolvermg",
@@ -297,6 +307,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             min_cuda_version: None,
             // cusolverMg.h transitively includes cublas_v2.h
             module_dependencies: vec!["cublas", "cusparse"],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "cufile",
@@ -313,6 +324,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "nvtx",
@@ -333,6 +345,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "cupti",
@@ -384,6 +397,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec!["use crate::driver::sys::*;", "use crate::runtime::sys::*;"],
             min_cuda_version: None,
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "cutensor",
@@ -400,6 +414,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: Some("cuda-12000"),
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
         ModuleConfig {
             cudarc_name: "cufft",
@@ -416,6 +431,7 @@ fn create_modules() -> Vec<ModuleConfig> {
             raw_lines: vec![],
             min_cuda_version: Some("cuda-12000"),
             module_dependencies: vec![],
+            bitflag_enums: vec![],
         },
     ]
 }
@@ -447,6 +463,10 @@ struct ModuleConfig {
     /// Modules with dependencies are processed in a second wave, after all independent
     /// modules have been downloaded, extracted, and had bindings generated.
     module_dependencies: Vec<&'static str>,
+    /// C enum names that are bitflags (values are powers of 2 meant to be OR-ed together).
+    /// These are generated as transparent newtypes instead of Rust enums so that bitwise OR
+    /// is well-defined, and `BitOr`/`BitOrAssign` impls are emitted for them.
+    bitflag_enums: Vec<&'static str>,
 }
 
 impl ModuleConfig {
@@ -521,6 +541,10 @@ impl ModuleConfig {
 
         for &raw_line in self.raw_lines.iter() {
             builder = builder.raw_line(raw_line);
+        }
+
+        for &n in self.bitflag_enums.iter() {
+            builder = builder.newtype_enum(n);
         }
 
         let parent_sysdir = Path::new("..")

--- a/bindings_generator/src/merge.rs
+++ b/bindings_generator/src/merge.rs
@@ -165,12 +165,14 @@ struct BindingMerger {
 
     lib_names: Vec<String>,
     n_versions: usize,
+    bitflag_types: Vec<String>,
 }
 
 impl BindingMerger {
-    pub fn new(lib_names: Vec<String>) -> Self {
+    pub fn new(lib_names: Vec<String>, bitflag_types: Vec<String>) -> Self {
         Self {
             lib_names,
+            bitflag_types,
             n_versions: 0,
             ..Default::default()
         }
@@ -236,6 +238,42 @@ impl BindingMerger {
         Ok(())
     }
 
+    fn generate_bitflag_impls(&self) -> TokenStream {
+        let mut output = TokenStream::new();
+        for type_name in &self.bitflag_types {
+            let Some(info) = self.structs.get(type_name.as_str()) else {
+                continue;
+            };
+            let all_versions: Vec<&Version> = info.declarations.keys().collect();
+            if all_versions.is_empty() {
+                continue;
+            }
+            let features: Vec<String> = all_versions.iter().map(|v| version_to_feature(v)).collect();
+            let type_ident: proc_macro2::Ident = syn::parse_str(type_name).unwrap();
+            let cfg = if all_versions.len() == self.n_versions {
+                quote! {}
+            } else {
+                quote! { #[cfg(any(#(feature = #features),*))] }
+            };
+            output.extend(quote! {
+                #cfg
+                impl ::core::ops::BitOr for #type_ident {
+                    type Output = Self;
+                    fn bitor(self, rhs: Self) -> Self {
+                        Self(self.0 | rhs.0)
+                    }
+                }
+                #cfg
+                impl ::core::ops::BitOrAssign for #type_ident {
+                    fn bitor_assign(&mut self, rhs: Self) {
+                        self.0 |= rhs.0;
+                    }
+                }
+            });
+        }
+        output
+    }
+
     pub fn generate_unified_bindings(&self) -> TokenStream {
         let enums = self.write_to_output(&self.enums).expect("Write to output");
         let impls = self.write_to_output(&self.impls).expect("Write to output");
@@ -249,6 +287,7 @@ impl BindingMerger {
         let functions = self
             .write_to_output(&self.functions)
             .expect("Write to output");
+        let bitflag_impls = self.generate_bitflag_impls();
 
         let lib_names = &self.lib_names;
 
@@ -280,6 +319,8 @@ impl BindingMerger {
             #structs
 
             #impls
+
+            #bitflag_impls
 
             #unions
 
@@ -465,9 +506,10 @@ pub fn merge<P: AsRef<Path>>(
     binding_dir: P,
     output_filename: P,
     lib_names: Vec<String>,
+    bitflag_types: Vec<String>,
 ) -> Result<()> {
     let binding_dir = binding_dir.as_ref();
-    let mut merger = BindingMerger::new(lib_names);
+    let mut merger = BindingMerger::new(lib_names, bitflag_types);
 
     let entries = fs::read_dir(binding_dir)?;
     for entry in entries {
@@ -520,6 +562,7 @@ pub fn merge_bindings(modules: &[ModuleConfig]) -> Result<()> {
             format!("out/{}/sys/linked", config.cudarc_name),
             format!("../src/{}/sys/mod.rs", config.cudarc_name),
             config.libs.iter().map(|&s| s.into()).collect(),
+            config.bitflag_enums.iter().map(|&s| s.into()).collect(),
         )?;
     }
     Ok(())

--- a/src/driver/sys/mod.rs
+++ b/src/driver/sys/mod.rs
@@ -5661,46 +5661,6 @@ pub enum CUmemAllocationGranularity_flags_enum {
     feature = "cuda-11080",
     feature = "cuda-12000",
     feature = "cuda-12010",
-    feature = "cuda-12020"
-))]
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
-pub enum CUmemAllocationHandleType_enum {
-    CU_MEM_HANDLE_TYPE_NONE = 0,
-    CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = 1,
-    CU_MEM_HANDLE_TYPE_WIN32 = 2,
-    CU_MEM_HANDLE_TYPE_WIN32_KMT = 4,
-    CU_MEM_HANDLE_TYPE_MAX = 2147483647,
-}
-#[cfg(any(
-    feature = "cuda-12030",
-    feature = "cuda-12040",
-    feature = "cuda-12050",
-    feature = "cuda-12060",
-    feature = "cuda-12080",
-    feature = "cuda-12090",
-    feature = "cuda-13000",
-    feature = "cuda-13010",
-    feature = "cuda-13020"
-))]
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
-pub enum CUmemAllocationHandleType_enum {
-    CU_MEM_HANDLE_TYPE_NONE = 0,
-    CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = 1,
-    CU_MEM_HANDLE_TYPE_WIN32 = 2,
-    CU_MEM_HANDLE_TYPE_WIN32_KMT = 4,
-    CU_MEM_HANDLE_TYPE_FABRIC = 8,
-    CU_MEM_HANDLE_TYPE_MAX = 2147483647,
-}
-#[cfg(any(
-    feature = "cuda-11040",
-    feature = "cuda-11050",
-    feature = "cuda-11060",
-    feature = "cuda-11070",
-    feature = "cuda-11080",
-    feature = "cuda-12000",
-    feature = "cuda-12010",
     feature = "cuda-12020",
     feature = "cuda-12030",
     feature = "cuda-12040",
@@ -9076,6 +9036,9 @@ pub struct CUmemAccessDesc_st {
     pub location: CUmemLocation,
     pub flags: CUmemAccess_flags,
 }
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUmemAllocationHandleType_enum(pub ::core::ffi::c_uint);
 #[cfg(any(
     feature = "cuda-11040",
     feature = "cuda-11050",
@@ -9530,10 +9493,56 @@ impl CUdevice_attribute_enum {
     pub const CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED: CUdevice_attribute_enum =
         CUdevice_attribute_enum::CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED;
 }
+#[cfg(any(
+    feature = "cuda-12030",
+    feature = "cuda-12040",
+    feature = "cuda-12050",
+    feature = "cuda-12060",
+    feature = "cuda-12080",
+    feature = "cuda-12090",
+    feature = "cuda-13000",
+    feature = "cuda-13010",
+    feature = "cuda-13020"
+))]
+impl CUmemAllocationHandleType_enum {
+    pub const CU_MEM_HANDLE_TYPE_FABRIC: CUmemAllocationHandleType_enum =
+        CUmemAllocationHandleType_enum(8);
+}
+impl CUmemAllocationHandleType_enum {
+    pub const CU_MEM_HANDLE_TYPE_MAX: CUmemAllocationHandleType_enum =
+        CUmemAllocationHandleType_enum(2147483647);
+}
+impl CUmemAllocationHandleType_enum {
+    pub const CU_MEM_HANDLE_TYPE_NONE: CUmemAllocationHandleType_enum =
+        CUmemAllocationHandleType_enum(0);
+}
+impl CUmemAllocationHandleType_enum {
+    pub const CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR: CUmemAllocationHandleType_enum =
+        CUmemAllocationHandleType_enum(1);
+}
+impl CUmemAllocationHandleType_enum {
+    pub const CU_MEM_HANDLE_TYPE_WIN32: CUmemAllocationHandleType_enum =
+        CUmemAllocationHandleType_enum(2);
+}
+impl CUmemAllocationHandleType_enum {
+    pub const CU_MEM_HANDLE_TYPE_WIN32_KMT: CUmemAllocationHandleType_enum =
+        CUmemAllocationHandleType_enum(4);
+}
 #[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 impl CUmemLocationType_enum {
     pub const CU_MEM_LOCATION_TYPE_NONE: CUmemLocationType_enum =
         CUmemLocationType_enum::CU_MEM_LOCATION_TYPE_INVALID;
+}
+impl ::core::ops::BitOr for CUmemAllocationHandleType_enum {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+impl ::core::ops::BitOrAssign for CUmemAllocationHandleType_enum {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]


### PR DESCRIPTION
replace CUmemAllocationHandleType enum with transparent u32 newtype to allow bitwise OR without UB