### PR TITLE
Add cuSPARSE safe wrapper

### DIFF
--- a/src/cusparse/mod.rs
+++ b/src/cusparse/mod.rs
@@ -2,3 +2,5 @@
 pub mod sys;
 
 pub mod result;
+pub mod safe;
+pub use safe::*;

--- a/src/cusparse/result.rs
+++ b/src/cusparse/result.rs
@@ -1,9 +1,10 @@
-use std::mem::MaybeUninit;
+use core::ffi::c_void;
+use core::mem::MaybeUninit;
 
 use super::sys;
 
-/// Wrapper around [sys::CUresult]. See
-/// nvidia's [CUresult docs](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1gc6c391505e117393cc2558fff6bfc2e9)
+/// Wrapper around [sys::cusparseStatus_t]. See
+/// nvidia's [cusparseStatus_t docs](https://docs.nvidia.com/cuda/cusparse/#cusparseStatus_t)
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct CusparseError(pub sys::cusparseStatus_t);
 
@@ -17,6 +18,59 @@ impl sys::cusparseStatus_t {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::fmt::Display for CusparseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CusparseError {}
+
+/// Features covering CUDA 11.040 through 11.080 (the "legacy generic API" range).
+macro_rules! cfg_cuda_11 {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(
+                feature = "cuda-11040",
+                feature = "cuda-11050",
+                feature = "cuda-11060",
+                feature = "cuda-11070",
+                feature = "cuda-11080"
+            ))]
+            $item
+        )*
+    };
+}
+
+/// Features covering CUDA 12.000+.
+macro_rules! cfg_cuda_12 {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(
+                feature = "cuda-12000",
+                feature = "cuda-12010",
+                feature = "cuda-12020",
+                feature = "cuda-12030",
+                feature = "cuda-12040",
+                feature = "cuda-12050",
+                feature = "cuda-12060",
+                feature = "cuda-12080",
+                feature = "cuda-12090",
+                feature = "cuda-13000",
+                feature = "cuda-13010",
+                feature = "cuda-13020"
+            ))]
+            $item
+        )*
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Handle management
+// ---------------------------------------------------------------------------
+
 /// See [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsecreate)
 pub fn create() -> Result<sys::cusparseHandle_t, CusparseError> {
     let mut handle = MaybeUninit::uninit();
@@ -27,10 +81,926 @@ pub fn create() -> Result<sys::cusparseHandle_t, CusparseError> {
 }
 
 /// See [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsedestroy)
+///
 /// # Safety
-/// Ensure `handle` has not been freed already
+/// `handle` must not have been freed already.
 pub unsafe fn destroy(handle: sys::cusparseHandle_t) -> Result<(), CusparseError> {
     sys::cusparseDestroy(handle).result()
+}
+
+/// Sets the stream cuSPARSE will use. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsesetstream)
+///
+/// # Safety
+/// `handle` and `stream` must be valid.
+pub unsafe fn set_stream(
+    handle: sys::cusparseHandle_t,
+    stream: sys::cudaStream_t,
+) -> Result<(), CusparseError> {
+    sys::cusparseSetStream(handle, stream).result()
+}
+
+/// Gets the stream cuSPARSE is using. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsegetstream)
+///
+/// # Safety
+/// `handle` must be valid.
+pub unsafe fn get_stream(
+    handle: sys::cusparseHandle_t,
+) -> Result<sys::cudaStream_t, CusparseError> {
+    let mut stream = MaybeUninit::uninit();
+    sys::cusparseGetStream(handle, stream.as_mut_ptr()).result()?;
+    Ok(stream.assume_init())
+}
+
+/// Gets the pointer mode. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsegetpointermode)
+///
+/// # Safety
+/// `handle` must be valid.
+pub unsafe fn get_pointer_mode(
+    handle: sys::cusparseHandle_t,
+) -> Result<sys::cusparsePointerMode_t, CusparseError> {
+    let mut mode = MaybeUninit::uninit();
+    sys::cusparseGetPointerMode(handle, mode.as_mut_ptr()).result()?;
+    Ok(mode.assume_init())
+}
+
+/// Sets the pointer mode. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsesetpointermode)
+///
+/// # Safety
+/// `handle` must be valid.
+pub unsafe fn set_pointer_mode(
+    handle: sys::cusparseHandle_t,
+    mode: sys::cusparsePointerMode_t,
+) -> Result<(), CusparseError> {
+    sys::cusparseSetPointerMode(handle, mode).result()
+}
+
+// ---------------------------------------------------------------------------
+// Sparse matrix descriptors (CSR, CSC, COO)
+// ---------------------------------------------------------------------------
+
+/// Creates a CSR sparse matrix descriptor. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsecreatecsr)
+///
+/// # Safety
+/// `csr_row_offsets`, `csr_col_ind`, and `csr_values` must be valid device pointers.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn create_csr(
+    rows: i64,
+    cols: i64,
+    nnz: i64,
+    csr_row_offsets: *mut c_void,
+    csr_col_ind: *mut c_void,
+    csr_values: *mut c_void,
+    csr_row_offsets_type: sys::cusparseIndexType_t,
+    csr_col_ind_type: sys::cusparseIndexType_t,
+    idx_base: sys::cusparseIndexBase_t,
+    value_type: sys::cudaDataType,
+) -> Result<sys::cusparseSpMatDescr_t, CusparseError> {
+    let mut descr = MaybeUninit::uninit();
+    sys::cusparseCreateCsr(
+        descr.as_mut_ptr(),
+        rows,
+        cols,
+        nnz,
+        csr_row_offsets,
+        csr_col_ind,
+        csr_values,
+        csr_row_offsets_type,
+        csr_col_ind_type,
+        idx_base,
+        value_type,
+    )
+    .result()?;
+    Ok(descr.assume_init())
+}
+
+/// Creates a CSC sparse matrix descriptor. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsecreatecsc)
+///
+/// # Safety
+/// `csc_col_offsets`, `csc_row_ind`, and `csc_values` must be valid device pointers.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn create_csc(
+    rows: i64,
+    cols: i64,
+    nnz: i64,
+    csc_col_offsets: *mut c_void,
+    csc_row_ind: *mut c_void,
+    csc_values: *mut c_void,
+    csc_col_offsets_type: sys::cusparseIndexType_t,
+    csc_row_ind_type: sys::cusparseIndexType_t,
+    idx_base: sys::cusparseIndexBase_t,
+    value_type: sys::cudaDataType,
+) -> Result<sys::cusparseSpMatDescr_t, CusparseError> {
+    let mut descr = MaybeUninit::uninit();
+    sys::cusparseCreateCsc(
+        descr.as_mut_ptr(),
+        rows,
+        cols,
+        nnz,
+        csc_col_offsets,
+        csc_row_ind,
+        csc_values,
+        csc_col_offsets_type,
+        csc_row_ind_type,
+        idx_base,
+        value_type,
+    )
+    .result()?;
+    Ok(descr.assume_init())
+}
+
+/// Creates a COO sparse matrix descriptor. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsecreatecoo)
+///
+/// # Safety
+/// `coo_row_ind`, `coo_col_ind`, and `coo_values` must be valid device pointers.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn create_coo(
+    rows: i64,
+    cols: i64,
+    nnz: i64,
+    coo_row_ind: *mut c_void,
+    coo_col_ind: *mut c_void,
+    coo_values: *mut c_void,
+    coo_idx_type: sys::cusparseIndexType_t,
+    idx_base: sys::cusparseIndexBase_t,
+    value_type: sys::cudaDataType,
+) -> Result<sys::cusparseSpMatDescr_t, CusparseError> {
+    let mut descr = MaybeUninit::uninit();
+    sys::cusparseCreateCoo(
+        descr.as_mut_ptr(),
+        rows,
+        cols,
+        nnz,
+        coo_row_ind,
+        coo_col_ind,
+        coo_values,
+        coo_idx_type,
+        idx_base,
+        value_type,
+    )
+    .result()?;
+    Ok(descr.assume_init())
+}
+
+cfg_cuda_11! {
+    /// Destroys a sparse matrix descriptor. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsedestroyspmat)
+    ///
+    /// # Safety
+    /// `descr` must not have been freed already.
+    pub unsafe fn destroy_sp_mat(descr: sys::cusparseSpMatDescr_t) -> Result<(), CusparseError> {
+        sys::cusparseDestroySpMat(descr).result()
+    }
+}
+cfg_cuda_12! {
+    /// Destroys a sparse matrix descriptor. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsedestroyspmat)
+    ///
+    /// # Safety
+    /// `descr` must not have been freed already.
+    pub unsafe fn destroy_sp_mat(descr: sys::cusparseSpMatDescr_t) -> Result<(), CusparseError> {
+        sys::cusparseDestroySpMat(descr as sys::cusparseConstSpMatDescr_t).result()
+    }
+}
+
+cfg_cuda_11! {
+    /// Gets the size (rows, cols, nnz) of a sparse matrix. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmatgetsize)
+    ///
+    /// # Safety
+    /// `descr` must be a valid sparse matrix descriptor.
+    pub unsafe fn sp_mat_get_size(
+        descr: sys::cusparseSpMatDescr_t,
+    ) -> Result<(i64, i64, i64), CusparseError> {
+        let mut rows = MaybeUninit::uninit();
+        let mut cols = MaybeUninit::uninit();
+        let mut nnz = MaybeUninit::uninit();
+        sys::cusparseSpMatGetSize(descr, rows.as_mut_ptr(), cols.as_mut_ptr(), nnz.as_mut_ptr())
+            .result()?;
+        Ok((rows.assume_init(), cols.assume_init(), nnz.assume_init()))
+    }
+}
+cfg_cuda_12! {
+    /// Gets the size (rows, cols, nnz) of a sparse matrix. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmatgetsize)
+    ///
+    /// # Safety
+    /// `descr` must be a valid sparse matrix descriptor.
+    pub unsafe fn sp_mat_get_size(
+        descr: sys::cusparseSpMatDescr_t,
+    ) -> Result<(i64, i64, i64), CusparseError> {
+        let mut rows = MaybeUninit::uninit();
+        let mut cols = MaybeUninit::uninit();
+        let mut nnz = MaybeUninit::uninit();
+        sys::cusparseSpMatGetSize(
+            descr as sys::cusparseConstSpMatDescr_t,
+            rows.as_mut_ptr(),
+            cols.as_mut_ptr(),
+            nnz.as_mut_ptr(),
+        )
+        .result()?;
+        Ok((rows.assume_init(), cols.assume_init(), nnz.assume_init()))
+    }
+}
+
+cfg_cuda_11! {
+    /// Gets the format of a sparse matrix. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmatgetformat)
+    ///
+    /// # Safety
+    /// `descr` must be a valid sparse matrix descriptor.
+    pub unsafe fn sp_mat_get_format(
+        descr: sys::cusparseSpMatDescr_t,
+    ) -> Result<sys::cusparseFormat_t, CusparseError> {
+        let mut format = MaybeUninit::uninit();
+        sys::cusparseSpMatGetFormat(descr, format.as_mut_ptr()).result()?;
+        Ok(format.assume_init())
+    }
+}
+cfg_cuda_12! {
+    /// Gets the format of a sparse matrix. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmatgetformat)
+    ///
+    /// # Safety
+    /// `descr` must be a valid sparse matrix descriptor.
+    pub unsafe fn sp_mat_get_format(
+        descr: sys::cusparseSpMatDescr_t,
+    ) -> Result<sys::cusparseFormat_t, CusparseError> {
+        let mut format = MaybeUninit::uninit();
+        sys::cusparseSpMatGetFormat(
+            descr as sys::cusparseConstSpMatDescr_t,
+            format.as_mut_ptr(),
+        )
+        .result()?;
+        Ok(format.assume_init())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sparse vector descriptors
+// ---------------------------------------------------------------------------
+
+/// Creates a sparse vector descriptor. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsecreatespvec)
+///
+/// # Safety
+/// `indices` and `values` must be valid device pointers.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn create_sp_vec(
+    size: i64,
+    nnz: i64,
+    indices: *mut c_void,
+    values: *mut c_void,
+    idx_type: sys::cusparseIndexType_t,
+    idx_base: sys::cusparseIndexBase_t,
+    value_type: sys::cudaDataType,
+) -> Result<sys::cusparseSpVecDescr_t, CusparseError> {
+    let mut descr = MaybeUninit::uninit();
+    sys::cusparseCreateSpVec(
+        descr.as_mut_ptr(),
+        size,
+        nnz,
+        indices,
+        values,
+        idx_type,
+        idx_base,
+        value_type,
+    )
+    .result()?;
+    Ok(descr.assume_init())
+}
+
+cfg_cuda_11! {
+    /// Destroys a sparse vector descriptor. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsedestroyspvec)
+    ///
+    /// # Safety
+    /// `descr` must not have been freed already.
+    pub unsafe fn destroy_sp_vec(descr: sys::cusparseSpVecDescr_t) -> Result<(), CusparseError> {
+        sys::cusparseDestroySpVec(descr).result()
+    }
+}
+cfg_cuda_12! {
+    /// Destroys a sparse vector descriptor. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsedestroyspvec)
+    ///
+    /// # Safety
+    /// `descr` must not have been freed already.
+    pub unsafe fn destroy_sp_vec(descr: sys::cusparseSpVecDescr_t) -> Result<(), CusparseError> {
+        sys::cusparseDestroySpVec(descr as sys::cusparseConstSpVecDescr_t).result()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dense descriptors
+// ---------------------------------------------------------------------------
+
+/// Creates a dense vector descriptor. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsecreatednvec)
+///
+/// # Safety
+/// `values` must be a valid device pointer.
+pub unsafe fn create_dn_vec(
+    size: i64,
+    values: *mut c_void,
+    value_type: sys::cudaDataType,
+) -> Result<sys::cusparseDnVecDescr_t, CusparseError> {
+    let mut descr = MaybeUninit::uninit();
+    sys::cusparseCreateDnVec(descr.as_mut_ptr(), size, values, value_type).result()?;
+    Ok(descr.assume_init())
+}
+
+cfg_cuda_11! {
+    /// Destroys a dense vector descriptor. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsedestroydnvec)
+    ///
+    /// # Safety
+    /// `descr` must not have been freed already.
+    pub unsafe fn destroy_dn_vec(descr: sys::cusparseDnVecDescr_t) -> Result<(), CusparseError> {
+        sys::cusparseDestroyDnVec(descr).result()
+    }
+}
+cfg_cuda_12! {
+    /// Destroys a dense vector descriptor. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsedestroydnvec)
+    ///
+    /// # Safety
+    /// `descr` must not have been freed already.
+    pub unsafe fn destroy_dn_vec(descr: sys::cusparseDnVecDescr_t) -> Result<(), CusparseError> {
+        sys::cusparseDestroyDnVec(descr as sys::cusparseConstDnVecDescr_t).result()
+    }
+}
+
+/// Creates a dense matrix descriptor. See
+/// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsecreatedmnat)
+///
+/// # Safety
+/// `values` must be a valid device pointer.
+pub unsafe fn create_dn_mat(
+    rows: i64,
+    cols: i64,
+    ld: i64,
+    values: *mut c_void,
+    value_type: sys::cudaDataType,
+    order: sys::cusparseOrder_t,
+) -> Result<sys::cusparseDnMatDescr_t, CusparseError> {
+    let mut descr = MaybeUninit::uninit();
+    sys::cusparseCreateDnMat(descr.as_mut_ptr(), rows, cols, ld, values, value_type, order)
+        .result()?;
+    Ok(descr.assume_init())
+}
+
+cfg_cuda_11! {
+    /// Destroys a dense matrix descriptor. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsedestroydnmat)
+    ///
+    /// # Safety
+    /// `descr` must not have been freed already.
+    pub unsafe fn destroy_dn_mat(descr: sys::cusparseDnMatDescr_t) -> Result<(), CusparseError> {
+        sys::cusparseDestroyDnMat(descr).result()
+    }
+}
+cfg_cuda_12! {
+    /// Destroys a dense matrix descriptor. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsedestroydnmat)
+    ///
+    /// # Safety
+    /// `descr` must not have been freed already.
+    pub unsafe fn destroy_dn_mat(descr: sys::cusparseDnMatDescr_t) -> Result<(), CusparseError> {
+        sys::cusparseDestroyDnMat(descr as sys::cusparseConstDnMatDescr_t).result()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core operations: SpMV
+// ---------------------------------------------------------------------------
+
+cfg_cuda_11! {
+    /// Computes the required buffer size for [spmv]. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmv)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn spmv_buffer_size(
+        handle: sys::cusparseHandle_t,
+        op_a: sys::cusparseOperation_t,
+        alpha: *const c_void,
+        mat_a: sys::cusparseSpMatDescr_t,
+        vec_x: sys::cusparseDnVecDescr_t,
+        beta: *const c_void,
+        vec_y: sys::cusparseDnVecDescr_t,
+        compute_type: sys::cudaDataType,
+        alg: sys::cusparseSpMVAlg_t,
+    ) -> Result<usize, CusparseError> {
+        let mut buffer_size = MaybeUninit::uninit();
+        sys::cusparseSpMV_bufferSize(
+            handle,
+            op_a,
+            alpha,
+            mat_a,
+            vec_x,
+            beta,
+            vec_y,
+            compute_type,
+            alg,
+            buffer_size.as_mut_ptr(),
+        )
+        .result()?;
+        Ok(buffer_size.assume_init())
+    }
+}
+cfg_cuda_12! {
+    /// Computes the required buffer size for [spmv]. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmv)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn spmv_buffer_size(
+        handle: sys::cusparseHandle_t,
+        op_a: sys::cusparseOperation_t,
+        alpha: *const c_void,
+        mat_a: sys::cusparseSpMatDescr_t,
+        vec_x: sys::cusparseDnVecDescr_t,
+        beta: *const c_void,
+        vec_y: sys::cusparseDnVecDescr_t,
+        compute_type: sys::cudaDataType,
+        alg: sys::cusparseSpMVAlg_t,
+    ) -> Result<usize, CusparseError> {
+        let mut buffer_size = MaybeUninit::uninit();
+        sys::cusparseSpMV_bufferSize(
+            handle,
+            op_a,
+            alpha,
+            mat_a as sys::cusparseConstSpMatDescr_t,
+            vec_x as sys::cusparseConstDnVecDescr_t,
+            beta,
+            vec_y,
+            compute_type,
+            alg,
+            buffer_size.as_mut_ptr(),
+        )
+        .result()?;
+        Ok(buffer_size.assume_init())
+    }
+}
+
+cfg_cuda_11! {
+    /// Sparse matrix - dense vector multiplication: y = alpha * op(A) * x + beta * y. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmv)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. `external_buffer` must
+    /// be at least as large as reported by [spmv_buffer_size].
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn spmv(
+        handle: sys::cusparseHandle_t,
+        op_a: sys::cusparseOperation_t,
+        alpha: *const c_void,
+        mat_a: sys::cusparseSpMatDescr_t,
+        vec_x: sys::cusparseDnVecDescr_t,
+        beta: *const c_void,
+        vec_y: sys::cusparseDnVecDescr_t,
+        compute_type: sys::cudaDataType,
+        alg: sys::cusparseSpMVAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseSpMV(
+            handle,
+            op_a,
+            alpha,
+            mat_a,
+            vec_x,
+            beta,
+            vec_y,
+            compute_type,
+            alg,
+            external_buffer,
+        )
+        .result()
+    }
+}
+cfg_cuda_12! {
+    /// Sparse matrix - dense vector multiplication: y = alpha * op(A) * x + beta * y. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmv)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. `external_buffer` must
+    /// be at least as large as reported by [spmv_buffer_size].
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn spmv(
+        handle: sys::cusparseHandle_t,
+        op_a: sys::cusparseOperation_t,
+        alpha: *const c_void,
+        mat_a: sys::cusparseSpMatDescr_t,
+        vec_x: sys::cusparseDnVecDescr_t,
+        beta: *const c_void,
+        vec_y: sys::cusparseDnVecDescr_t,
+        compute_type: sys::cudaDataType,
+        alg: sys::cusparseSpMVAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseSpMV(
+            handle,
+            op_a,
+            alpha,
+            mat_a as sys::cusparseConstSpMatDescr_t,
+            vec_x as sys::cusparseConstDnVecDescr_t,
+            beta,
+            vec_y,
+            compute_type,
+            alg,
+            external_buffer,
+        )
+        .result()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core operations: SpMM
+// ---------------------------------------------------------------------------
+
+cfg_cuda_11! {
+    /// Computes the required buffer size for [spmm]. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmm)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn spmm_buffer_size(
+        handle: sys::cusparseHandle_t,
+        op_a: sys::cusparseOperation_t,
+        op_b: sys::cusparseOperation_t,
+        alpha: *const c_void,
+        mat_a: sys::cusparseSpMatDescr_t,
+        mat_b: sys::cusparseDnMatDescr_t,
+        beta: *const c_void,
+        mat_c: sys::cusparseDnMatDescr_t,
+        compute_type: sys::cudaDataType,
+        alg: sys::cusparseSpMMAlg_t,
+    ) -> Result<usize, CusparseError> {
+        let mut buffer_size = MaybeUninit::uninit();
+        sys::cusparseSpMM_bufferSize(
+            handle,
+            op_a,
+            op_b,
+            alpha,
+            mat_a,
+            mat_b,
+            beta,
+            mat_c,
+            compute_type,
+            alg,
+            buffer_size.as_mut_ptr(),
+        )
+        .result()?;
+        Ok(buffer_size.assume_init())
+    }
+}
+cfg_cuda_12! {
+    /// Computes the required buffer size for [spmm]. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmm)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn spmm_buffer_size(
+        handle: sys::cusparseHandle_t,
+        op_a: sys::cusparseOperation_t,
+        op_b: sys::cusparseOperation_t,
+        alpha: *const c_void,
+        mat_a: sys::cusparseSpMatDescr_t,
+        mat_b: sys::cusparseDnMatDescr_t,
+        beta: *const c_void,
+        mat_c: sys::cusparseDnMatDescr_t,
+        compute_type: sys::cudaDataType,
+        alg: sys::cusparseSpMMAlg_t,
+    ) -> Result<usize, CusparseError> {
+        let mut buffer_size = MaybeUninit::uninit();
+        sys::cusparseSpMM_bufferSize(
+            handle,
+            op_a,
+            op_b,
+            alpha,
+            mat_a as sys::cusparseConstSpMatDescr_t,
+            mat_b as sys::cusparseConstDnMatDescr_t,
+            beta,
+            mat_c,
+            compute_type,
+            alg,
+            buffer_size.as_mut_ptr(),
+        )
+        .result()?;
+        Ok(buffer_size.assume_init())
+    }
+}
+
+cfg_cuda_11! {
+    /// Sparse matrix - dense matrix multiplication: C = alpha * op(A) * op(B) + beta * C. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmm)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. `external_buffer` must
+    /// be at least as large as reported by [spmm_buffer_size].
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn spmm(
+        handle: sys::cusparseHandle_t,
+        op_a: sys::cusparseOperation_t,
+        op_b: sys::cusparseOperation_t,
+        alpha: *const c_void,
+        mat_a: sys::cusparseSpMatDescr_t,
+        mat_b: sys::cusparseDnMatDescr_t,
+        beta: *const c_void,
+        mat_c: sys::cusparseDnMatDescr_t,
+        compute_type: sys::cudaDataType,
+        alg: sys::cusparseSpMMAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseSpMM(
+            handle,
+            op_a,
+            op_b,
+            alpha,
+            mat_a,
+            mat_b,
+            beta,
+            mat_c,
+            compute_type,
+            alg,
+            external_buffer,
+        )
+        .result()
+    }
+}
+cfg_cuda_12! {
+    /// Sparse matrix - dense matrix multiplication: C = alpha * op(A) * op(B) + beta * C. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparsespmm)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. `external_buffer` must
+    /// be at least as large as reported by [spmm_buffer_size].
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn spmm(
+        handle: sys::cusparseHandle_t,
+        op_a: sys::cusparseOperation_t,
+        op_b: sys::cusparseOperation_t,
+        alpha: *const c_void,
+        mat_a: sys::cusparseSpMatDescr_t,
+        mat_b: sys::cusparseDnMatDescr_t,
+        beta: *const c_void,
+        mat_c: sys::cusparseDnMatDescr_t,
+        compute_type: sys::cudaDataType,
+        alg: sys::cusparseSpMMAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseSpMM(
+            handle,
+            op_a,
+            op_b,
+            alpha,
+            mat_a as sys::cusparseConstSpMatDescr_t,
+            mat_b as sys::cusparseConstDnMatDescr_t,
+            beta,
+            mat_c,
+            compute_type,
+            alg,
+            external_buffer,
+        )
+        .result()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Format conversion: SparseToDense
+// ---------------------------------------------------------------------------
+
+cfg_cuda_11! {
+    /// Computes the required buffer size for [sparse_to_dense]. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseSparseToDense)
+    ///
+    /// # Safety
+    /// All handles and descriptors must be valid.
+    pub unsafe fn sparse_to_dense_buffer_size(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseSpMatDescr_t,
+        mat_b: sys::cusparseDnMatDescr_t,
+        alg: sys::cusparseSparseToDenseAlg_t,
+    ) -> Result<usize, CusparseError> {
+        let mut buffer_size = MaybeUninit::uninit();
+        sys::cusparseSparseToDense_bufferSize(
+            handle, mat_a, mat_b, alg, buffer_size.as_mut_ptr(),
+        )
+        .result()?;
+        Ok(buffer_size.assume_init())
+    }
+}
+cfg_cuda_12! {
+    /// Computes the required buffer size for [sparse_to_dense]. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseSparseToDense)
+    ///
+    /// # Safety
+    /// All handles and descriptors must be valid.
+    pub unsafe fn sparse_to_dense_buffer_size(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseSpMatDescr_t,
+        mat_b: sys::cusparseDnMatDescr_t,
+        alg: sys::cusparseSparseToDenseAlg_t,
+    ) -> Result<usize, CusparseError> {
+        let mut buffer_size = MaybeUninit::uninit();
+        sys::cusparseSparseToDense_bufferSize(
+            handle,
+            mat_a as sys::cusparseConstSpMatDescr_t,
+            mat_b,
+            alg,
+            buffer_size.as_mut_ptr(),
+        )
+        .result()?;
+        Ok(buffer_size.assume_init())
+    }
+}
+
+cfg_cuda_11! {
+    /// Converts a sparse matrix to dense format. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseSparseToDense)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. `external_buffer` must
+    /// be at least as large as reported by [sparse_to_dense_buffer_size].
+    pub unsafe fn sparse_to_dense(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseSpMatDescr_t,
+        mat_b: sys::cusparseDnMatDescr_t,
+        alg: sys::cusparseSparseToDenseAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseSparseToDense(handle, mat_a, mat_b, alg, external_buffer).result()
+    }
+}
+cfg_cuda_12! {
+    /// Converts a sparse matrix to dense format. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseSparseToDense)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. `external_buffer` must
+    /// be at least as large as reported by [sparse_to_dense_buffer_size].
+    pub unsafe fn sparse_to_dense(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseSpMatDescr_t,
+        mat_b: sys::cusparseDnMatDescr_t,
+        alg: sys::cusparseSparseToDenseAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseSparseToDense(
+            handle,
+            mat_a as sys::cusparseConstSpMatDescr_t,
+            mat_b,
+            alg,
+            external_buffer,
+        )
+        .result()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Format conversion: DenseToSparse
+// ---------------------------------------------------------------------------
+
+cfg_cuda_11! {
+    /// Computes the required buffer size for dense-to-sparse conversion. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseDenseToSparse)
+    ///
+    /// # Safety
+    /// All handles and descriptors must be valid.
+    pub unsafe fn dense_to_sparse_buffer_size(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseDnMatDescr_t,
+        mat_b: sys::cusparseSpMatDescr_t,
+        alg: sys::cusparseDenseToSparseAlg_t,
+    ) -> Result<usize, CusparseError> {
+        let mut buffer_size = MaybeUninit::uninit();
+        sys::cusparseDenseToSparse_bufferSize(
+            handle, mat_a, mat_b, alg, buffer_size.as_mut_ptr(),
+        )
+        .result()?;
+        Ok(buffer_size.assume_init())
+    }
+}
+cfg_cuda_12! {
+    /// Computes the required buffer size for dense-to-sparse conversion. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseDenseToSparse)
+    ///
+    /// # Safety
+    /// All handles and descriptors must be valid.
+    pub unsafe fn dense_to_sparse_buffer_size(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseDnMatDescr_t,
+        mat_b: sys::cusparseSpMatDescr_t,
+        alg: sys::cusparseDenseToSparseAlg_t,
+    ) -> Result<usize, CusparseError> {
+        let mut buffer_size = MaybeUninit::uninit();
+        sys::cusparseDenseToSparse_bufferSize(
+            handle,
+            mat_a as sys::cusparseConstDnMatDescr_t,
+            mat_b,
+            alg,
+            buffer_size.as_mut_ptr(),
+        )
+        .result()?;
+        Ok(buffer_size.assume_init())
+    }
+}
+
+cfg_cuda_11! {
+    /// Performs analysis for dense-to-sparse conversion. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseDenseToSparse)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. `external_buffer` must
+    /// be at least as large as reported by [dense_to_sparse_buffer_size].
+    pub unsafe fn dense_to_sparse_analysis(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseDnMatDescr_t,
+        mat_b: sys::cusparseSpMatDescr_t,
+        alg: sys::cusparseDenseToSparseAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseDenseToSparse_analysis(handle, mat_a, mat_b, alg, external_buffer).result()
+    }
+}
+cfg_cuda_12! {
+    /// Performs analysis for dense-to-sparse conversion. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseDenseToSparse)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. `external_buffer` must
+    /// be at least as large as reported by [dense_to_sparse_buffer_size].
+    pub unsafe fn dense_to_sparse_analysis(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseDnMatDescr_t,
+        mat_b: sys::cusparseSpMatDescr_t,
+        alg: sys::cusparseDenseToSparseAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseDenseToSparse_analysis(
+            handle,
+            mat_a as sys::cusparseConstDnMatDescr_t,
+            mat_b,
+            alg,
+            external_buffer,
+        )
+        .result()
+    }
+}
+
+cfg_cuda_11! {
+    /// Executes the dense-to-sparse conversion. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseDenseToSparse)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. [dense_to_sparse_analysis]
+    /// must have been called first. `external_buffer` must be at least as large as
+    /// reported by [dense_to_sparse_buffer_size].
+    pub unsafe fn dense_to_sparse_convert(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseDnMatDescr_t,
+        mat_b: sys::cusparseSpMatDescr_t,
+        alg: sys::cusparseDenseToSparseAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseDenseToSparse_convert(handle, mat_a, mat_b, alg, external_buffer).result()
+    }
+}
+cfg_cuda_12! {
+    /// Executes the dense-to-sparse conversion. See
+    /// [cuda docs](https://docs.nvidia.com/cuda/cusparse/#cusparseDenseToSparse)
+    ///
+    /// # Safety
+    /// All handles, descriptors, and pointers must be valid. [dense_to_sparse_analysis]
+    /// must have been called first. `external_buffer` must be at least as large as
+    /// reported by [dense_to_sparse_buffer_size].
+    pub unsafe fn dense_to_sparse_convert(
+        handle: sys::cusparseHandle_t,
+        mat_a: sys::cusparseDnMatDescr_t,
+        mat_b: sys::cusparseSpMatDescr_t,
+        alg: sys::cusparseDenseToSparseAlg_t,
+        external_buffer: *mut c_void,
+    ) -> Result<(), CusparseError> {
+        sys::cusparseDenseToSparse_convert(
+            handle,
+            mat_a as sys::cusparseConstDnMatDescr_t,
+            mat_b,
+            alg,
+            external_buffer,
+        )
+        .result()
+    }
 }
 
 #[cfg(test)]

--- a/src/cusparse/result.rs
+++ b/src/cusparse/result.rs
@@ -451,8 +451,16 @@ pub unsafe fn create_dn_mat(
     order: sys::cusparseOrder_t,
 ) -> Result<sys::cusparseDnMatDescr_t, CusparseError> {
     let mut descr = MaybeUninit::uninit();
-    sys::cusparseCreateDnMat(descr.as_mut_ptr(), rows, cols, ld, values, value_type, order)
-        .result()?;
+    sys::cusparseCreateDnMat(
+        descr.as_mut_ptr(),
+        rows,
+        cols,
+        ld,
+        values,
+        value_type,
+        order,
+    )
+    .result()?;
     Ok(descr.assume_init())
 }
 

--- a/src/cusparse/safe.rs
+++ b/src/cusparse/safe.rs
@@ -1,0 +1,801 @@
+//! Safe abstractions around [crate::cusparse::result] with [CudaSparse].
+
+use super::{result, result::CusparseError, sys};
+use crate::driver::{self, CudaStream};
+use core::ffi::c_void;
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// CudaSparseDataType - maps Rust scalar types to cudaDataType
+// ---------------------------------------------------------------------------
+
+/// Marker trait that associates a Rust scalar type with the corresponding
+/// `cudaDataType` constant used by cuSPARSE generic APIs.
+pub trait CudaSparseDataType: Copy {
+    fn cuda_data_type() -> sys::cudaDataType;
+}
+
+impl CudaSparseDataType for f32 {
+    fn cuda_data_type() -> sys::cudaDataType {
+        sys::cudaDataType::CUDA_R_32F
+    }
+}
+
+impl CudaSparseDataType for f64 {
+    fn cuda_data_type() -> sys::cudaDataType {
+        sys::cudaDataType::CUDA_R_64F
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience enums
+// ---------------------------------------------------------------------------
+
+/// Sparse/dense operation transpose mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Operation {
+    NonTranspose,
+    Transpose,
+    ConjugateTranspose,
+}
+
+impl From<Operation> for sys::cusparseOperation_t {
+    fn from(op: Operation) -> Self {
+        match op {
+            Operation::NonTranspose => sys::cusparseOperation_t::CUSPARSE_OPERATION_NON_TRANSPOSE,
+            Operation::Transpose => sys::cusparseOperation_t::CUSPARSE_OPERATION_TRANSPOSE,
+            Operation::ConjugateTranspose => {
+                sys::cusparseOperation_t::CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE
+            }
+        }
+    }
+}
+
+/// Index data type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IndexType {
+    U16,
+    I32,
+    I64,
+}
+
+impl From<IndexType> for sys::cusparseIndexType_t {
+    fn from(t: IndexType) -> Self {
+        match t {
+            IndexType::U16 => sys::cusparseIndexType_t::CUSPARSE_INDEX_16U,
+            IndexType::I32 => sys::cusparseIndexType_t::CUSPARSE_INDEX_32I,
+            IndexType::I64 => sys::cusparseIndexType_t::CUSPARSE_INDEX_64I,
+        }
+    }
+}
+
+/// Index base (zero or one).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IndexBase {
+    Zero,
+    One,
+}
+
+impl From<IndexBase> for sys::cusparseIndexBase_t {
+    fn from(b: IndexBase) -> Self {
+        match b {
+            IndexBase::Zero => sys::cusparseIndexBase_t::CUSPARSE_INDEX_BASE_ZERO,
+            IndexBase::One => sys::cusparseIndexBase_t::CUSPARSE_INDEX_BASE_ONE,
+        }
+    }
+}
+
+/// Dense matrix storage order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Order {
+    Column,
+    Row,
+}
+
+impl From<Order> for sys::cusparseOrder_t {
+    fn from(o: Order) -> Self {
+        match o {
+            Order::Column => sys::cusparseOrder_t::CUSPARSE_ORDER_COL,
+            Order::Row => sys::cusparseOrder_t::CUSPARSE_ORDER_ROW,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error type that can hold either a cusparse or driver error
+// ---------------------------------------------------------------------------
+
+/// Combined error type for safe cusparse operations that may also invoke
+/// driver allocation/free calls.
+#[derive(Debug)]
+pub enum CudaSparseError {
+    Cusparse(CusparseError),
+    Driver(driver::DriverError),
+}
+
+impl From<CusparseError> for CudaSparseError {
+    fn from(e: CusparseError) -> Self {
+        CudaSparseError::Cusparse(e)
+    }
+}
+
+impl From<driver::DriverError> for CudaSparseError {
+    fn from(e: driver::DriverError) -> Self {
+        CudaSparseError::Driver(e)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for CudaSparseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CudaSparseError::Cusparse(e) => write!(f, "{e}"),
+            CudaSparseError::Driver(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CudaSparseError {}
+
+// ---------------------------------------------------------------------------
+// CudaSparse - main handle wrapper
+// ---------------------------------------------------------------------------
+
+/// Safe wrapper around a cuSPARSE handle ([sys::cusparseHandle_t]).
+///
+/// # Creating a handle
+///
+/// ```rust,ignore
+/// use cudarc::{driver::*, cusparse::*};
+/// let ctx = CudaContext::new(0).unwrap();
+/// let stream = ctx.default_stream();
+/// let sparse = CudaSparse::new(stream).unwrap();
+/// ```
+pub struct CudaSparse {
+    pub(crate) handle: sys::cusparseHandle_t,
+    pub(crate) stream: Arc<CudaStream>,
+}
+
+unsafe impl Send for CudaSparse {}
+unsafe impl Sync for CudaSparse {}
+
+impl CudaSparse {
+    /// Creates a new cuSPARSE handle bound to `stream`.
+    pub fn new(stream: Arc<CudaStream>) -> Result<Self, CusparseError> {
+        let ctx = stream.context();
+        ctx.record_err(ctx.bind_to_thread());
+        let handle = result::create()?;
+        unsafe { result::set_stream(handle, stream.cu_stream() as _) }?;
+        Ok(Self { handle, stream })
+    }
+
+    /// Returns the underlying cuSPARSE handle.
+    pub fn handle(&self) -> sys::cusparseHandle_t {
+        self.handle
+    }
+
+    /// Sets the stream used by this handle.
+    ///
+    /// # Safety
+    /// The caller must ensure the stream is properly synchronised and
+    /// belongs to the same CUDA context.
+    pub unsafe fn set_stream(&mut self, stream: Arc<CudaStream>) -> Result<(), CusparseError> {
+        self.stream = stream;
+        result::set_stream(self.handle, self.stream.cu_stream() as _)
+    }
+
+    /// Sparse matrix-dense vector multiply: `y = alpha * op(A) * x + beta * y`.
+    ///
+    /// Workspace allocation and deallocation is handled internally.
+    #[allow(clippy::too_many_arguments)]
+    pub fn spmv<T: CudaSparseDataType>(
+        &self,
+        op_a: Operation,
+        alpha: &T,
+        mat_a: &SpMatDescr,
+        vec_x: &DnVecDescr,
+        beta: &T,
+        vec_y: &mut DnVecDescr,
+        alg: sys::cusparseSpMVAlg_t,
+    ) -> Result<(), CudaSparseError> {
+        let compute_type = T::cuda_data_type();
+        let op_a_sys: sys::cusparseOperation_t = op_a.into();
+
+        let alpha_ptr = alpha as *const T as *const c_void;
+        let beta_ptr = beta as *const T as *const c_void;
+
+        // 1. Query required workspace size.
+        let buffer_size = unsafe {
+            result::spmv_buffer_size(
+                self.handle,
+                op_a_sys,
+                alpha_ptr,
+                mat_a.descr,
+                vec_x.descr,
+                beta_ptr,
+                vec_y.descr,
+                compute_type,
+                alg,
+            )?
+        };
+
+        // 2. Allocate workspace on GPU.
+        let workspace = if buffer_size > 0 {
+            unsafe { driver::result::malloc_async(self.stream.cu_stream(), buffer_size)? }
+        } else {
+            0
+        };
+
+        // 3. Execute SpMV.
+        let exec_result = unsafe {
+            result::spmv(
+                self.handle,
+                op_a_sys,
+                alpha_ptr,
+                mat_a.descr,
+                vec_x.descr,
+                beta_ptr,
+                vec_y.descr,
+                compute_type,
+                alg,
+                workspace as *mut c_void,
+            )
+        };
+
+        // 4. Free workspace (always, even on error).
+        if buffer_size > 0 {
+            unsafe { driver::result::free_async(workspace, self.stream.cu_stream())? };
+        }
+
+        exec_result?;
+        Ok(())
+    }
+
+    /// Sparse matrix-dense matrix multiply: `C = alpha * op(A) * op(B) + beta * C`.
+    ///
+    /// Workspace allocation and deallocation is handled internally.
+    #[allow(clippy::too_many_arguments)]
+    pub fn spmm<T: CudaSparseDataType>(
+        &self,
+        op_a: Operation,
+        op_b: Operation,
+        alpha: &T,
+        mat_a: &SpMatDescr,
+        mat_b: &DnMatDescr,
+        beta: &T,
+        mat_c: &mut DnMatDescr,
+        alg: sys::cusparseSpMMAlg_t,
+    ) -> Result<(), CudaSparseError> {
+        let compute_type = T::cuda_data_type();
+        let op_a_sys: sys::cusparseOperation_t = op_a.into();
+        let op_b_sys: sys::cusparseOperation_t = op_b.into();
+
+        let alpha_ptr = alpha as *const T as *const c_void;
+        let beta_ptr = beta as *const T as *const c_void;
+
+        // 1. Query required workspace size.
+        let buffer_size = unsafe {
+            result::spmm_buffer_size(
+                self.handle,
+                op_a_sys,
+                op_b_sys,
+                alpha_ptr,
+                mat_a.descr,
+                mat_b.descr,
+                beta_ptr,
+                mat_c.descr,
+                compute_type,
+                alg,
+            )?
+        };
+
+        // 2. Allocate workspace on GPU.
+        let workspace = if buffer_size > 0 {
+            unsafe { driver::result::malloc_async(self.stream.cu_stream(), buffer_size)? }
+        } else {
+            0
+        };
+
+        // 3. Execute SpMM.
+        let exec_result = unsafe {
+            result::spmm(
+                self.handle,
+                op_a_sys,
+                op_b_sys,
+                alpha_ptr,
+                mat_a.descr,
+                mat_b.descr,
+                beta_ptr,
+                mat_c.descr,
+                compute_type,
+                alg,
+                workspace as *mut c_void,
+            )
+        };
+
+        // 4. Free workspace (always, even on error).
+        if buffer_size > 0 {
+            unsafe { driver::result::free_async(workspace, self.stream.cu_stream())? };
+        }
+
+        exec_result?;
+        Ok(())
+    }
+}
+
+impl Drop for CudaSparse {
+    fn drop(&mut self) {
+        let handle = std::mem::replace(&mut self.handle, std::ptr::null_mut());
+        if !handle.is_null() {
+            unsafe { result::destroy(handle) }.unwrap();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Descriptor RAII wrappers
+// ---------------------------------------------------------------------------
+
+/// RAII wrapper around a sparse matrix descriptor (`cusparseSpMatDescr_t`).
+///
+/// Created via [`SpMatDescr::new_csr`], [`SpMatDescr::new_csc`], or
+/// [`SpMatDescr::new_coo`].  Automatically destroyed on drop.
+pub struct SpMatDescr {
+    pub(crate) descr: sys::cusparseSpMatDescr_t,
+}
+
+impl SpMatDescr {
+    /// Creates a CSR sparse matrix descriptor.
+    ///
+    /// # Safety
+    /// `csr_row_offsets`, `csr_col_ind`, and `csr_values` must be valid
+    /// device pointers that remain live for the lifetime of this descriptor.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn new_csr(
+        rows: i64,
+        cols: i64,
+        nnz: i64,
+        csr_row_offsets: *mut c_void,
+        csr_col_ind: *mut c_void,
+        csr_values: *mut c_void,
+        row_offsets_type: IndexType,
+        col_ind_type: IndexType,
+        idx_base: IndexBase,
+        value_type: sys::cudaDataType,
+    ) -> Result<Self, CusparseError> {
+        let descr = result::create_csr(
+            rows,
+            cols,
+            nnz,
+            csr_row_offsets,
+            csr_col_ind,
+            csr_values,
+            row_offsets_type.into(),
+            col_ind_type.into(),
+            idx_base.into(),
+            value_type,
+        )?;
+        Ok(Self { descr })
+    }
+
+    /// Creates a CSC sparse matrix descriptor.
+    ///
+    /// # Safety
+    /// `csc_col_offsets`, `csc_row_ind`, and `csc_values` must be valid
+    /// device pointers that remain live for the lifetime of this descriptor.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn new_csc(
+        rows: i64,
+        cols: i64,
+        nnz: i64,
+        csc_col_offsets: *mut c_void,
+        csc_row_ind: *mut c_void,
+        csc_values: *mut c_void,
+        col_offsets_type: IndexType,
+        row_ind_type: IndexType,
+        idx_base: IndexBase,
+        value_type: sys::cudaDataType,
+    ) -> Result<Self, CusparseError> {
+        let descr = result::create_csc(
+            rows,
+            cols,
+            nnz,
+            csc_col_offsets,
+            csc_row_ind,
+            csc_values,
+            col_offsets_type.into(),
+            row_ind_type.into(),
+            idx_base.into(),
+            value_type,
+        )?;
+        Ok(Self { descr })
+    }
+
+    /// Creates a COO sparse matrix descriptor.
+    ///
+    /// # Safety
+    /// `coo_row_ind`, `coo_col_ind`, and `coo_values` must be valid
+    /// device pointers that remain live for the lifetime of this descriptor.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn new_coo(
+        rows: i64,
+        cols: i64,
+        nnz: i64,
+        coo_row_ind: *mut c_void,
+        coo_col_ind: *mut c_void,
+        coo_values: *mut c_void,
+        coo_idx_type: IndexType,
+        idx_base: IndexBase,
+        value_type: sys::cudaDataType,
+    ) -> Result<Self, CusparseError> {
+        let descr = result::create_coo(
+            rows,
+            cols,
+            nnz,
+            coo_row_ind,
+            coo_col_ind,
+            coo_values,
+            coo_idx_type.into(),
+            idx_base.into(),
+            value_type,
+        )?;
+        Ok(Self { descr })
+    }
+
+    /// Returns the dimensions `(rows, cols, nnz)` of this sparse matrix.
+    pub fn get_size(&self) -> Result<(i64, i64, i64), CusparseError> {
+        unsafe { result::sp_mat_get_size(self.descr) }
+    }
+
+    /// Returns the storage format of this sparse matrix.
+    pub fn get_format(&self) -> Result<sys::cusparseFormat_t, CusparseError> {
+        unsafe { result::sp_mat_get_format(self.descr) }
+    }
+}
+
+impl Drop for SpMatDescr {
+    fn drop(&mut self) {
+        let descr = std::mem::replace(&mut self.descr, std::ptr::null_mut());
+        if !descr.is_null() {
+            unsafe { result::destroy_sp_mat(descr) }.unwrap();
+        }
+    }
+}
+
+/// RAII wrapper around a sparse vector descriptor (`cusparseSpVecDescr_t`).
+pub struct SpVecDescr {
+    pub(crate) descr: sys::cusparseSpVecDescr_t,
+}
+
+impl SpVecDescr {
+    /// Creates a sparse vector descriptor.
+    ///
+    /// # Safety
+    /// `indices` and `values` must be valid device pointers that remain
+    /// live for the lifetime of this descriptor.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn new(
+        size: i64,
+        nnz: i64,
+        indices: *mut c_void,
+        values: *mut c_void,
+        idx_type: IndexType,
+        idx_base: IndexBase,
+        value_type: sys::cudaDataType,
+    ) -> Result<Self, CusparseError> {
+        let descr = result::create_sp_vec(
+            size,
+            nnz,
+            indices,
+            values,
+            idx_type.into(),
+            idx_base.into(),
+            value_type,
+        )?;
+        Ok(Self { descr })
+    }
+}
+
+impl Drop for SpVecDescr {
+    fn drop(&mut self) {
+        let descr = std::mem::replace(&mut self.descr, std::ptr::null_mut());
+        if !descr.is_null() {
+            unsafe { result::destroy_sp_vec(descr) }.unwrap();
+        }
+    }
+}
+
+/// RAII wrapper around a dense vector descriptor (`cusparseDnVecDescr_t`).
+pub struct DnVecDescr {
+    pub(crate) descr: sys::cusparseDnVecDescr_t,
+}
+
+impl DnVecDescr {
+    /// Creates a dense vector descriptor.
+    ///
+    /// # Safety
+    /// `values` must be a valid device pointer that remains live for the
+    /// lifetime of this descriptor.
+    pub unsafe fn new(
+        size: i64,
+        values: *mut c_void,
+        value_type: sys::cudaDataType,
+    ) -> Result<Self, CusparseError> {
+        let descr = result::create_dn_vec(size, values, value_type)?;
+        Ok(Self { descr })
+    }
+}
+
+impl Drop for DnVecDescr {
+    fn drop(&mut self) {
+        let descr = std::mem::replace(&mut self.descr, std::ptr::null_mut());
+        if !descr.is_null() {
+            unsafe { result::destroy_dn_vec(descr) }.unwrap();
+        }
+    }
+}
+
+/// RAII wrapper around a dense matrix descriptor (`cusparseDnMatDescr_t`).
+pub struct DnMatDescr {
+    pub(crate) descr: sys::cusparseDnMatDescr_t,
+}
+
+impl DnMatDescr {
+    /// Creates a dense matrix descriptor.
+    ///
+    /// # Safety
+    /// `values` must be a valid device pointer that remains live for the
+    /// lifetime of this descriptor.
+    pub unsafe fn new(
+        rows: i64,
+        cols: i64,
+        ld: i64,
+        values: *mut c_void,
+        value_type: sys::cudaDataType,
+        order: Order,
+    ) -> Result<Self, CusparseError> {
+        let descr = result::create_dn_mat(rows, cols, ld, values, value_type, order.into())?;
+        Ok(Self { descr })
+    }
+}
+
+impl Drop for DnMatDescr {
+    fn drop(&mut self) {
+        let descr = std::mem::replace(&mut self.descr, std::ptr::null_mut());
+        if !descr.is_null() {
+            unsafe { result::destroy_dn_mat(descr) }.unwrap();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::CudaContext;
+    use std::vec;
+    use std::vec::Vec;
+
+    #[test]
+    fn test_create_and_drop() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let _sparse = CudaSparse::new(stream).unwrap();
+    }
+
+    #[test]
+    fn test_spmv_csr_f32() {
+        // 2x3 CSR matrix:
+        //  [1.0, 0.0, 2.0]
+        //  [0.0, 3.0, 0.0]
+        //
+        // x = [1.0, 2.0, 3.0]
+        // y = A*x = [1*1+2*3, 3*2] = [7.0, 6.0]
+
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let sparse = CudaSparse::new(stream.clone()).unwrap();
+
+        let rows: i64 = 2;
+        let cols: i64 = 3;
+        let nnz: i64 = 3;
+
+        // CSR arrays
+        let row_offsets: Vec<i32> = vec![0, 2, 3]; // rows+1
+        let col_indices: Vec<i32> = vec![0, 2, 1]; // nnz
+        let values: Vec<f32> = vec![1.0, 2.0, 3.0]; // nnz
+
+        let row_offsets_dev = stream.clone_htod(&row_offsets).unwrap();
+        let col_indices_dev = stream.clone_htod(&col_indices).unwrap();
+        let values_dev = stream.clone_htod(&values).unwrap();
+
+        let mat_a = unsafe {
+            SpMatDescr::new_csr(
+                rows,
+                cols,
+                nnz,
+                row_offsets_dev.cu_device_ptr as *mut c_void,
+                col_indices_dev.cu_device_ptr as *mut c_void,
+                values_dev.cu_device_ptr as *mut c_void,
+                IndexType::I32,
+                IndexType::I32,
+                IndexBase::Zero,
+                f32::cuda_data_type(),
+            )
+            .unwrap()
+        };
+
+        let x_data: Vec<f32> = vec![1.0, 2.0, 3.0];
+        let x_dev = stream.clone_htod(&x_data).unwrap();
+        let vec_x = unsafe {
+            DnVecDescr::new(
+                cols,
+                x_dev.cu_device_ptr as *mut c_void,
+                f32::cuda_data_type(),
+            )
+            .unwrap()
+        };
+
+        let y_data: Vec<f32> = vec![0.0, 0.0];
+        let y_dev = stream.clone_htod(&y_data).unwrap();
+        let mut vec_y = unsafe {
+            DnVecDescr::new(
+                rows,
+                y_dev.cu_device_ptr as *mut c_void,
+                f32::cuda_data_type(),
+            )
+            .unwrap()
+        };
+
+        let alpha: f32 = 1.0;
+        let beta: f32 = 0.0;
+
+        sparse
+            .spmv(
+                Operation::NonTranspose,
+                &alpha,
+                &mat_a,
+                &vec_x,
+                &beta,
+                &mut vec_y,
+                sys::cusparseSpMVAlg_t::CUSPARSE_SPMV_ALG_DEFAULT,
+            )
+            .unwrap();
+
+        let y_host: Vec<f32> = stream.clone_dtoh(&y_dev).unwrap();
+        assert!(
+            (y_host[0] - 7.0).abs() < 1e-5,
+            "expected 7.0, got {}",
+            y_host[0]
+        );
+        assert!(
+            (y_host[1] - 6.0).abs() < 1e-5,
+            "expected 6.0, got {}",
+            y_host[1]
+        );
+    }
+
+    #[test]
+    fn test_spmm_csr_f32() {
+        // A (2x3 CSR):
+        //  [1.0, 0.0, 2.0]
+        //  [0.0, 3.0, 0.0]
+        //
+        // B (3x2 dense, column-major):
+        //  [1.0, 4.0]
+        //  [2.0, 5.0]
+        //  [3.0, 6.0]
+        //
+        // C = A * B =
+        //  [1*1+2*3, 1*4+2*6] = [7.0, 16.0]
+        //  [3*2,     3*5    ] = [6.0, 15.0]
+
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let sparse = CudaSparse::new(stream.clone()).unwrap();
+
+        let a_rows: i64 = 2;
+        let a_cols: i64 = 3;
+        let a_nnz: i64 = 3;
+
+        let row_offsets: Vec<i32> = vec![0, 2, 3];
+        let col_indices: Vec<i32> = vec![0, 2, 1];
+        let a_values: Vec<f32> = vec![1.0, 2.0, 3.0];
+
+        let row_offsets_dev = stream.clone_htod(&row_offsets).unwrap();
+        let col_indices_dev = stream.clone_htod(&col_indices).unwrap();
+        let a_values_dev = stream.clone_htod(&a_values).unwrap();
+
+        let mat_a = unsafe {
+            SpMatDescr::new_csr(
+                a_rows,
+                a_cols,
+                a_nnz,
+                row_offsets_dev.cu_device_ptr as *mut c_void,
+                col_indices_dev.cu_device_ptr as *mut c_void,
+                a_values_dev.cu_device_ptr as *mut c_void,
+                IndexType::I32,
+                IndexType::I32,
+                IndexBase::Zero,
+                f32::cuda_data_type(),
+            )
+            .unwrap()
+        };
+
+        let b_rows: i64 = 3;
+        let b_cols: i64 = 2;
+        // Column-major: col0=[1,2,3], col1=[4,5,6]
+        let b_data: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let b_dev = stream.clone_htod(&b_data).unwrap();
+        let mat_b = unsafe {
+            DnMatDescr::new(
+                b_rows,
+                b_cols,
+                b_rows, // ld = rows for column-major
+                b_dev.cu_device_ptr as *mut c_void,
+                f32::cuda_data_type(),
+                Order::Column,
+            )
+            .unwrap()
+        };
+
+        let c_rows: i64 = 2;
+        let c_cols: i64 = 2;
+        let c_data: Vec<f32> = vec![0.0; 4];
+        let c_dev = stream.clone_htod(&c_data).unwrap();
+        let mut mat_c = unsafe {
+            DnMatDescr::new(
+                c_rows,
+                c_cols,
+                c_rows,
+                c_dev.cu_device_ptr as *mut c_void,
+                f32::cuda_data_type(),
+                Order::Column,
+            )
+            .unwrap()
+        };
+
+        let alpha: f32 = 1.0;
+        let beta: f32 = 0.0;
+
+        sparse
+            .spmm(
+                Operation::NonTranspose,
+                Operation::NonTranspose,
+                &alpha,
+                &mat_a,
+                &mat_b,
+                &beta,
+                &mut mat_c,
+                sys::cusparseSpMMAlg_t::CUSPARSE_SPMM_ALG_DEFAULT,
+            )
+            .unwrap();
+
+        let c_host: Vec<f32> = stream.clone_dtoh(&c_dev).unwrap();
+        // Column-major: [c00, c10, c01, c11] = [7, 6, 16, 15]
+        assert!(
+            (c_host[0] - 7.0).abs() < 1e-5,
+            "C[0,0]: expected 7.0, got {}",
+            c_host[0]
+        );
+        assert!(
+            (c_host[1] - 6.0).abs() < 1e-5,
+            "C[1,0]: expected 6.0, got {}",
+            c_host[1]
+        );
+        assert!(
+            (c_host[2] - 16.0).abs() < 1e-5,
+            "C[0,1]: expected 16.0, got {}",
+            c_host[2]
+        );
+        assert!(
+            (c_host[3] - 15.0).abs() < 1e-5,
+            "C[1,1]: expected 15.0, got {}",
+            c_host[3]
+        );
+    }
+}

--- a/src/cusparse/safe.rs
+++ b/src/cusparse/safe.rs
@@ -341,18 +341,28 @@ impl Drop for CudaSparse {
 ///
 /// Created via [`SpMatDescr::new_csr`], [`SpMatDescr::new_csc`], or
 /// [`SpMatDescr::new_coo`].  Automatically destroyed on drop.
+///
+/// Holds an [`Arc<CudaStream>`] to keep the originating CUDA context alive
+/// for the lifetime of the descriptor.  Without this, dropping the device
+/// before the descriptor would leave [`Drop`] calling into a torn-down
+/// context.
 pub struct SpMatDescr {
     pub(crate) descr: sys::cusparseSpMatDescr_t,
+    pub(crate) stream: Arc<CudaStream>,
 }
 
 impl SpMatDescr {
     /// Creates a CSR sparse matrix descriptor.
     ///
+    /// `stream` is retained so the CUDA context outlives this descriptor.
+    ///
     /// # Safety
     /// `csr_row_offsets`, `csr_col_ind`, and `csr_values` must be valid
-    /// device pointers that remain live for the lifetime of this descriptor.
+    /// device pointers in `stream`'s context that remain live for the
+    /// lifetime of this descriptor.
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn new_csr(
+        stream: Arc<CudaStream>,
         rows: i64,
         cols: i64,
         nnz: i64,
@@ -364,6 +374,8 @@ impl SpMatDescr {
         idx_base: IndexBase,
         value_type: sys::cudaDataType,
     ) -> Result<Self, CusparseError> {
+        let ctx = stream.context();
+        ctx.record_err(ctx.bind_to_thread());
         let descr = result::create_csr(
             rows,
             cols,
@@ -376,16 +388,20 @@ impl SpMatDescr {
             idx_base.into(),
             value_type,
         )?;
-        Ok(Self { descr })
+        Ok(Self { descr, stream })
     }
 
     /// Creates a CSC sparse matrix descriptor.
     ///
+    /// `stream` is retained so the CUDA context outlives this descriptor.
+    ///
     /// # Safety
     /// `csc_col_offsets`, `csc_row_ind`, and `csc_values` must be valid
-    /// device pointers that remain live for the lifetime of this descriptor.
+    /// device pointers in `stream`'s context that remain live for the
+    /// lifetime of this descriptor.
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn new_csc(
+        stream: Arc<CudaStream>,
         rows: i64,
         cols: i64,
         nnz: i64,
@@ -397,6 +413,8 @@ impl SpMatDescr {
         idx_base: IndexBase,
         value_type: sys::cudaDataType,
     ) -> Result<Self, CusparseError> {
+        let ctx = stream.context();
+        ctx.record_err(ctx.bind_to_thread());
         let descr = result::create_csc(
             rows,
             cols,
@@ -409,16 +427,20 @@ impl SpMatDescr {
             idx_base.into(),
             value_type,
         )?;
-        Ok(Self { descr })
+        Ok(Self { descr, stream })
     }
 
     /// Creates a COO sparse matrix descriptor.
     ///
+    /// `stream` is retained so the CUDA context outlives this descriptor.
+    ///
     /// # Safety
     /// `coo_row_ind`, `coo_col_ind`, and `coo_values` must be valid
-    /// device pointers that remain live for the lifetime of this descriptor.
+    /// device pointers in `stream`'s context that remain live for the
+    /// lifetime of this descriptor.
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn new_coo(
+        stream: Arc<CudaStream>,
         rows: i64,
         cols: i64,
         nnz: i64,
@@ -429,6 +451,8 @@ impl SpMatDescr {
         idx_base: IndexBase,
         value_type: sys::cudaDataType,
     ) -> Result<Self, CusparseError> {
+        let ctx = stream.context();
+        ctx.record_err(ctx.bind_to_thread());
         let descr = result::create_coo(
             rows,
             cols,
@@ -440,7 +464,7 @@ impl SpMatDescr {
             idx_base.into(),
             value_type,
         )?;
-        Ok(Self { descr })
+        Ok(Self { descr, stream })
     }
 
     /// Returns the dimensions `(rows, cols, nnz)` of this sparse matrix.
@@ -452,30 +476,44 @@ impl SpMatDescr {
     pub fn get_format(&self) -> Result<sys::cusparseFormat_t, CusparseError> {
         unsafe { result::sp_mat_get_format(self.descr) }
     }
+
+    /// Returns the [`Arc<CudaStream>`] retained by this descriptor.
+    pub fn stream(&self) -> &Arc<CudaStream> {
+        &self.stream
+    }
 }
 
 impl Drop for SpMatDescr {
     fn drop(&mut self) {
         let descr = std::mem::replace(&mut self.descr, std::ptr::null_mut());
         if !descr.is_null() {
+            let ctx = self.stream.context();
+            ctx.record_err(ctx.bind_to_thread());
             unsafe { result::destroy_sp_mat(descr) }.unwrap();
         }
     }
 }
 
 /// RAII wrapper around a sparse vector descriptor (`cusparseSpVecDescr_t`).
+///
+/// Holds an [`Arc<CudaStream>`] to keep the originating CUDA context alive
+/// for the lifetime of the descriptor.
 pub struct SpVecDescr {
     pub(crate) descr: sys::cusparseSpVecDescr_t,
+    pub(crate) stream: Arc<CudaStream>,
 }
 
 impl SpVecDescr {
     /// Creates a sparse vector descriptor.
     ///
+    /// `stream` is retained so the CUDA context outlives this descriptor.
+    ///
     /// # Safety
-    /// `indices` and `values` must be valid device pointers that remain
-    /// live for the lifetime of this descriptor.
+    /// `indices` and `values` must be valid device pointers in `stream`'s
+    /// context that remain live for the lifetime of this descriptor.
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn new(
+        stream: Arc<CudaStream>,
         size: i64,
         nnz: i64,
         indices: *mut c_void,
@@ -484,6 +522,8 @@ impl SpVecDescr {
         idx_base: IndexBase,
         value_type: sys::cudaDataType,
     ) -> Result<Self, CusparseError> {
+        let ctx = stream.context();
+        ctx.record_err(ctx.bind_to_thread());
         let descr = result::create_sp_vec(
             size,
             nnz,
@@ -493,7 +533,12 @@ impl SpVecDescr {
             idx_base.into(),
             value_type,
         )?;
-        Ok(Self { descr })
+        Ok(Self { descr, stream })
+    }
+
+    /// Returns the [`Arc<CudaStream>`] retained by this descriptor.
+    pub fn stream(&self) -> &Arc<CudaStream> {
+        &self.stream
     }
 }
 
@@ -501,29 +546,45 @@ impl Drop for SpVecDescr {
     fn drop(&mut self) {
         let descr = std::mem::replace(&mut self.descr, std::ptr::null_mut());
         if !descr.is_null() {
+            let ctx = self.stream.context();
+            ctx.record_err(ctx.bind_to_thread());
             unsafe { result::destroy_sp_vec(descr) }.unwrap();
         }
     }
 }
 
 /// RAII wrapper around a dense vector descriptor (`cusparseDnVecDescr_t`).
+///
+/// Holds an [`Arc<CudaStream>`] to keep the originating CUDA context alive
+/// for the lifetime of the descriptor.
 pub struct DnVecDescr {
     pub(crate) descr: sys::cusparseDnVecDescr_t,
+    pub(crate) stream: Arc<CudaStream>,
 }
 
 impl DnVecDescr {
     /// Creates a dense vector descriptor.
     ///
+    /// `stream` is retained so the CUDA context outlives this descriptor.
+    ///
     /// # Safety
-    /// `values` must be a valid device pointer that remains live for the
-    /// lifetime of this descriptor.
+    /// `values` must be a valid device pointer in `stream`'s context that
+    /// remains live for the lifetime of this descriptor.
     pub unsafe fn new(
+        stream: Arc<CudaStream>,
         size: i64,
         values: *mut c_void,
         value_type: sys::cudaDataType,
     ) -> Result<Self, CusparseError> {
+        let ctx = stream.context();
+        ctx.record_err(ctx.bind_to_thread());
         let descr = result::create_dn_vec(size, values, value_type)?;
-        Ok(Self { descr })
+        Ok(Self { descr, stream })
+    }
+
+    /// Returns the [`Arc<CudaStream>`] retained by this descriptor.
+    pub fn stream(&self) -> &Arc<CudaStream> {
+        &self.stream
     }
 }
 
@@ -531,23 +592,32 @@ impl Drop for DnVecDescr {
     fn drop(&mut self) {
         let descr = std::mem::replace(&mut self.descr, std::ptr::null_mut());
         if !descr.is_null() {
+            let ctx = self.stream.context();
+            ctx.record_err(ctx.bind_to_thread());
             unsafe { result::destroy_dn_vec(descr) }.unwrap();
         }
     }
 }
 
 /// RAII wrapper around a dense matrix descriptor (`cusparseDnMatDescr_t`).
+///
+/// Holds an [`Arc<CudaStream>`] to keep the originating CUDA context alive
+/// for the lifetime of the descriptor.
 pub struct DnMatDescr {
     pub(crate) descr: sys::cusparseDnMatDescr_t,
+    pub(crate) stream: Arc<CudaStream>,
 }
 
 impl DnMatDescr {
     /// Creates a dense matrix descriptor.
     ///
+    /// `stream` is retained so the CUDA context outlives this descriptor.
+    ///
     /// # Safety
-    /// `values` must be a valid device pointer that remains live for the
-    /// lifetime of this descriptor.
+    /// `values` must be a valid device pointer in `stream`'s context that
+    /// remains live for the lifetime of this descriptor.
     pub unsafe fn new(
+        stream: Arc<CudaStream>,
         rows: i64,
         cols: i64,
         ld: i64,
@@ -555,8 +625,15 @@ impl DnMatDescr {
         value_type: sys::cudaDataType,
         order: Order,
     ) -> Result<Self, CusparseError> {
+        let ctx = stream.context();
+        ctx.record_err(ctx.bind_to_thread());
         let descr = result::create_dn_mat(rows, cols, ld, values, value_type, order.into())?;
-        Ok(Self { descr })
+        Ok(Self { descr, stream })
+    }
+
+    /// Returns the [`Arc<CudaStream>`] retained by this descriptor.
+    pub fn stream(&self) -> &Arc<CudaStream> {
+        &self.stream
     }
 }
 
@@ -564,6 +641,8 @@ impl Drop for DnMatDescr {
     fn drop(&mut self) {
         let descr = std::mem::replace(&mut self.descr, std::ptr::null_mut());
         if !descr.is_null() {
+            let ctx = self.stream.context();
+            ctx.record_err(ctx.bind_to_thread());
             unsafe { result::destroy_dn_mat(descr) }.unwrap();
         }
     }
@@ -615,6 +694,7 @@ mod tests {
 
         let mat_a = unsafe {
             SpMatDescr::new_csr(
+                stream.clone(),
                 rows,
                 cols,
                 nnz,
@@ -633,6 +713,7 @@ mod tests {
         let x_dev = stream.clone_htod(&x_data).unwrap();
         let vec_x = unsafe {
             DnVecDescr::new(
+                stream.clone(),
                 cols,
                 x_dev.cu_device_ptr as *mut c_void,
                 f32::cuda_data_type(),
@@ -644,6 +725,7 @@ mod tests {
         let y_dev = stream.clone_htod(&y_data).unwrap();
         let mut vec_y = unsafe {
             DnVecDescr::new(
+                stream.clone(),
                 rows,
                 y_dev.cu_device_ptr as *mut c_void,
                 f32::cuda_data_type(),
@@ -712,6 +794,7 @@ mod tests {
 
         let mat_a = unsafe {
             SpMatDescr::new_csr(
+                stream.clone(),
                 a_rows,
                 a_cols,
                 a_nnz,
@@ -733,6 +816,7 @@ mod tests {
         let b_dev = stream.clone_htod(&b_data).unwrap();
         let mat_b = unsafe {
             DnMatDescr::new(
+                stream.clone(),
                 b_rows,
                 b_cols,
                 b_rows, // ld = rows for column-major
@@ -749,6 +833,7 @@ mod tests {
         let c_dev = stream.clone_htod(&c_data).unwrap();
         let mut mat_c = unsafe {
             DnMatDescr::new(
+                stream.clone(),
                 c_rows,
                 c_cols,
                 c_rows,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 //! | curand | [curand::safe] | [curand::result] | [curand::sys] |
 //! | cudnn | [cudnn::safe] | [cudnn::result] | [cudnn::sys] |
 //! | cufft | [cufft::safe] | [cufft::result] | [cufft::sys] |
-//! | cusparse | - | [cusparse::result] | [cusparse::sys] |
+//! | cusparse | [cusparse::safe] | [cusparse::result] | [cusparse::sys] |
 //! | cusolver | [cusolver::safe] | [cusolver::result] | [cusolver::sys] |
 //! | cusolvermg | [cusolvermg::safe] | [cusolvermg::result] | [cusolvermg::sys] |
 //! | cupti | - | [cupti::result] | [cupti::sys] |


### PR DESCRIPTION
## Add cuSPARSE safe wrapper

cuSPARSE had no `safe.rs` and only 2 functions in `result.rs`.

- **result.rs**: expanded to 26 functions (handle, CSR/CSC/COO/dense descriptors, SpMV, SpMM, sparse-dense conversions). Cfg-gated for CUDA 11 vs 12.
- **safe.rs**: RAII descriptor wrappers, `spmv()`, `spmm()` with automatic workspace management.

Tested SpMV and SpMM on RTX 3060 Ti (CUDA 13.0).