### PR TITLE
Add CUDA 13.3 support

### DIFF
--- a/.github/workflows/cargo-check.yaml
+++ b/.github/workflows/cargo-check.yaml
@@ -26,6 +26,7 @@ jobs:
           - cuda-13000
           - cuda-13010
           - cuda-13020
+          - cuda-13030
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/cargo-clippy.yaml
+++ b/.github/workflows/cargo-clippy.yaml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-default-features --features cuda-13020,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl,dynamic-loading,cufile,cupti,nvtx,cufft --all-targets -- -D warnings
+          args: --no-default-features --features cuda-13030,no-std,cudnn,cublas,cublaslt,nvrtc,driver,curand,nccl,dynamic-loading,cufile,cupti,nvtx,cufft --all-targets -- -D warnings

--- a/.github/workflows/cargo-publish-dry-run.yaml
+++ b/.github/workflows/cargo-publish-dry-run.yaml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: publish
-          args: --dry-run -F cuda-13020
+          args: --dry-run -F cuda-13030

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ categories = [
 
 [package.metadata.docs.rs]
 features = [
-    "cuda-13020",
+    "cuda-13030",
     "f16",
     "cudnn",
     "nccl",
@@ -71,6 +71,7 @@ cuda-12090 = []
 cuda-13000 = []
 cuda-13010 = []
 cuda-13020 = []
+cuda-13030 = []
 
 fallback-dynamic-loading = []
 dynamic-loading = []

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Safe CUDA wrappers for:
 CUDA Versions supported (choose with `-F cuda-<version>`, like `cuda-13010`):
 - 11.4-11.8
 - 12.0-12.9
-- 13.0
+- 13.0-13.3
 
 CUDNN versions supported (choose with `-F cudnn-<version>`, like `cudnn-09021`):
 - 8.9.7

--- a/bindings_generator/src/main.rs
+++ b/bindings_generator/src/main.rs
@@ -550,9 +550,11 @@ fn create_bindings(modules: &[ModuleConfig], cuda_versions: &[Version]) -> Resul
             // cuda_cudart provides cuda.h / cuda_runtime.h, which virtually every module
             // transitively includes. It must be a primary archive so all parallel module
             // tasks have those headers on their include path.
-            let names = match cuda_version.major {
-                13 => vec!["cuda_nvcc", "cuda_cccl", "cuda_crt", "cuda_cudart"],
-                12 => vec!["cuda_nvcc", "cuda_cccl", "cuda_cudart"],
+            let names = match (cuda_version.major, cuda_version.minor) {
+                // CCCL was renamed from `cuda_cccl` to `cccl` in the 13.3 redistrib manifest.
+                (13, 3..) => vec!["cuda_nvcc", "cccl", "cuda_crt", "cuda_cudart"],
+                (13, _) => vec!["cuda_nvcc", "cuda_cccl", "cuda_crt", "cuda_cudart"],
+                (12, _) => vec!["cuda_nvcc", "cuda_cccl", "cuda_cudart"],
                 _ => vec!["cuda_nvcc", "cuda_cudart"],
             };
             let mut archives = vec![];
@@ -808,6 +810,7 @@ const CUDA_VERSIONS: &[Version] = &[
     Version::new(13, 0, 0),
     Version::new(13, 1, 0),
     Version::new(13, 2, 0),
+    Version::new(13, 3, 0),
 ];
 
 fn main() -> Result<()> {

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ const TYPICAL_CUDA_PATH_ENV_VARS: [&str; 5] = [
 ];
 
 const SUPPORTED_CUDA_VERSIONS: &[((usize, usize), bool)] = &[
+    ((13, 3), cfg!(feature = "cuda-13030")),
     ((13, 2), cfg!(feature = "cuda-13020")),
     ((13, 1), cfg!(feature = "cuda-13010")),
     ((13, 0), cfg!(feature = "cuda-13000")),
@@ -114,7 +115,7 @@ fn main() {
         (major, minor)
     } else {
         #[cfg(not(feature = "cuda-version-from-build-system"))]
-        panic!("Must specify one of the following features: [cuda-version-from-build-system, cuda-13020, cuda-13010, cuda-13000, cuda-12090, cuda-12080, cuda-12060, cuda-12050, cuda-12040, cuda-12030, cuda-12020, cuda-12010, cuda-12000, cuda-11080, cuda-11070, cuda-11060, cuda-11050, cuda-11040]");
+        panic!("Must specify one of the following features: [cuda-version-from-build-system, cuda-13030, cuda-13020, cuda-13010, cuda-13000, cuda-12090, cuda-12080, cuda-12060, cuda-12050, cuda-12040, cuda-12030, cuda-12020, cuda-12010, cuda-12000, cuda-11080, cuda-11070, cuda-11060, cuda-11050, cuda-11040]");
 
         #[cfg(feature = "cuda-version-from-build-system")]
         {

--- a/src/cublas/sys/mod.rs
+++ b/src/cublas/sys/mod.rs
@@ -13,9 +13,9 @@ fn load<F: Copy>(name: &str) -> F {
 }
 pub use self::cudaDataType as cublasDataType_t;
 pub use self::cudaDataType_t as cudaDataType;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::cudaEmulationMantissaControl_t as cudaEmulationMantissaControl;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::cudaEmulationSpecialValuesSupport_t as cudaEmulationSpecialValuesSupport;
 pub use self::libraryPropertyType_t as libraryPropertyType;
 pub type cuComplex = cuFloatComplex;
@@ -63,7 +63,7 @@ pub enum cublasComputeType_t {
     CUBLAS_COMPUTE_32I = 72,
     CUBLAS_COMPUTE_32I_PEDANTIC = 73,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasComputeType_t {
@@ -87,7 +87,7 @@ pub enum cublasDiagType_t {
     CUBLAS_DIAG_NON_UNIT = 0,
     CUBLAS_DIAG_UNIT = 1,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasEmulationStrategy_t {
@@ -149,7 +149,7 @@ pub enum cublasGemmAlgo_t {
     CUBLAS_GEMM_ALGO14_TENSOR_OP = 114,
     CUBLAS_GEMM_ALGO15_TENSOR_OP = 115,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasGemmAlgo_t {
@@ -218,7 +218,7 @@ pub enum cublasMath_t {
     CUBLAS_FP32_EMULATED_BF16X9_MATH = 4,
     CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION = 16,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasMath_t {
@@ -332,7 +332,7 @@ pub enum cudaDataType_t {
     CUDA_R_8F_E4M3 = 28,
     CUDA_R_8F_E5M2 = 29,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDataType_t {
@@ -371,14 +371,14 @@ pub enum cudaDataType_t {
     CUDA_R_6F_E3M2 = 32,
     CUDA_R_4F_E2M1 = 33,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaEmulationMantissaControl_t {
     CUDA_EMULATION_MANTISSA_CONTROL_DYNAMIC = 0,
     CUDA_EMULATION_MANTISSA_CONTROL_FIXED = 1,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaEmulationSpecialValuesSupport_t {
@@ -427,7 +427,7 @@ impl cublasGemmAlgo_t {
 impl cublasOperation_t {
     pub const CUBLAS_OP_HERMITAN: cublasOperation_t = cublasOperation_t::CUBLAS_OP_C;
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl cudaDataType_t {
     pub const CUDA_R_8F_UE4M3: cudaDataType_t = cudaDataType_t::CUDA_R_8F_E4M3;
 }
@@ -447,7 +447,7 @@ pub unsafe fn cublasAsumEx(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *co
         cublasAsumEx(handle, n, x, xType, incx, result, resultType, executiontype)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasAsumEx_64(handle: cublasHandle_t, n: i64, x: *const ::core::ffi::c_void, xType: cudaDataType, incx: i64, result: *mut ::core::ffi::c_void, resultType: cudaDataType, executiontype: cudaDataType) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -480,7 +480,7 @@ pub unsafe fn cublasAxpyEx(handle: cublasHandle_t, n: ::core::ffi::c_int, alpha:
         cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executiontype)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasAxpyEx_64(handle: cublasHandle_t, n: i64, alpha: *const ::core::ffi::c_void, alphaType: cudaDataType, x: *const ::core::ffi::c_void, xType: cudaDataType, incx: i64, y: *mut ::core::ffi::c_void, yType: cudaDataType, incy: i64, executiontype: cudaDataType) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -513,7 +513,7 @@ pub unsafe fn cublasCaxpy_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alph
         cublasCaxpy_v2(handle, n, alpha, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCaxpy_v2_64(handle: cublasHandle_t, n: i64, alpha: *const cuComplex, x: *const cuComplex, incx: i64, y: *mut cuComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -546,7 +546,7 @@ pub unsafe fn cublasCcopy_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasCcopy_v2(handle, n, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCcopy_v2_64(handle: cublasHandle_t, n: i64, x: *const cuComplex, incx: i64, y: *mut cuComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -579,7 +579,7 @@ pub unsafe fn cublasCdgmm(handle: cublasHandle_t, mode: cublasSideMode_t, m: ::c
         cublasCdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCdgmm_64(handle: cublasHandle_t, mode: cublasSideMode_t, m: i64, n: i64, A: *const cuComplex, lda: i64, x: *const cuComplex, incx: i64, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -612,7 +612,7 @@ pub unsafe fn cublasCdotc_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasCdotc_v2(handle, n, x, incx, y, incy, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCdotc_v2_64(handle: cublasHandle_t, n: i64, x: *const cuComplex, incx: i64, y: *const cuComplex, incy: i64, result: *mut cuComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -645,7 +645,7 @@ pub unsafe fn cublasCdotu_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasCdotu_v2(handle, n, x, incx, y, incy, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCdotu_v2_64(handle: cublasHandle_t, n: i64, x: *const cuComplex, incx: i64, y: *const cuComplex, incy: i64, result: *mut cuComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -678,7 +678,7 @@ pub unsafe fn cublasCgbmv_v2(handle: cublasHandle_t, trans: cublasOperation_t, m
         cublasCgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgbmv_v2_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, kl: i64, ku: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, x: *const cuComplex, incx: i64, beta: *const cuComplex, y: *mut cuComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -711,7 +711,7 @@ pub unsafe fn cublasCgeam(handle: cublasHandle_t, transa: cublasOperation_t, tra
         cublasCgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgeam_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, beta: *const cuComplex, B: *const cuComplex, ldb: i64, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -776,7 +776,7 @@ pub unsafe fn cublasCgemm3mBatched(handle: cublasHandle_t, transa: cublasOperati
         cublasCgemm3mBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemm3mBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuComplex, Aarray: *const *const cuComplex, lda: i64, Barray: *const *const cuComplex, ldb: i64, beta: *const cuComplex, Carray: *const *mut cuComplex, ldc: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -809,7 +809,7 @@ pub unsafe fn cublasCgemm3mEx(handle: cublasHandle_t, transa: cublasOperation_t,
         cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemm3mEx_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuComplex, A: *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, B: *const ::core::ffi::c_void, Btype: cudaDataType, ldb: i64, beta: *const cuComplex, C: *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -842,7 +842,7 @@ pub unsafe fn cublasCgemm3mStridedBatched(handle: cublasHandle_t, transa: cublas
         cublasCgemm3mStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemm3mStridedBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, strideA: ::core::ffi::c_longlong, B: *const cuComplex, ldb: i64, strideB: ::core::ffi::c_longlong, beta: *const cuComplex, C: *mut cuComplex, ldc: i64, strideC: ::core::ffi::c_longlong, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -859,7 +859,7 @@ pub unsafe fn cublasCgemm3mStridedBatched_64(handle: cublasHandle_t, transa: cub
         cublasCgemm3mStridedBatched_64(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemm3m_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *const cuComplex, ldb: i64, beta: *const cuComplex, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -892,7 +892,7 @@ pub unsafe fn cublasCgemmBatched(handle: cublasHandle_t, transa: cublasOperation
         cublasCgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemmBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuComplex, Aarray: *const *const cuComplex, lda: i64, Barray: *const *const cuComplex, ldb: i64, beta: *const cuComplex, Carray: *const *mut cuComplex, ldc: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -925,7 +925,7 @@ pub unsafe fn cublasCgemmEx(handle: cublasHandle_t, transa: cublasOperation_t, t
         cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemmEx_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuComplex, A: *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, B: *const ::core::ffi::c_void, Btype: cudaDataType, ldb: i64, beta: *const cuComplex, C: *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -958,7 +958,7 @@ pub unsafe fn cublasCgemmStridedBatched(handle: cublasHandle_t, transa: cublasOp
         cublasCgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemmStridedBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, strideA: ::core::ffi::c_longlong, B: *const cuComplex, ldb: i64, strideB: ::core::ffi::c_longlong, beta: *const cuComplex, C: *mut cuComplex, ldc: i64, strideC: ::core::ffi::c_longlong, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -991,7 +991,7 @@ pub unsafe fn cublasCgemm_v2(handle: cublasHandle_t, transa: cublasOperation_t, 
         cublasCgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemm_v2_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *const cuComplex, ldb: i64, beta: *const cuComplex, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1008,7 +1008,7 @@ pub unsafe fn cublasCgemm_v2_64(handle: cublasHandle_t, transa: cublasOperation_
         cublasCgemm_v2_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemvBatched(handle: cublasHandle_t, trans: cublasOperation_t, m: ::core::ffi::c_int, n: ::core::ffi::c_int, alpha: *const cuComplex, Aarray: *const *const cuComplex, lda: ::core::ffi::c_int, xarray: *const *const cuComplex, incx: ::core::ffi::c_int, beta: *const cuComplex, yarray: *const *mut cuComplex, incy: ::core::ffi::c_int, batchCount: ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1025,7 +1025,7 @@ pub unsafe fn cublasCgemvBatched(handle: cublasHandle_t, trans: cublasOperation_
         cublasCgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray, incx, beta, yarray, incy, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemvBatched_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const cuComplex, Aarray: *const *const cuComplex, lda: i64, xarray: *const *const cuComplex, incx: i64, beta: *const cuComplex, yarray: *const *mut cuComplex, incy: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1042,7 +1042,7 @@ pub unsafe fn cublasCgemvBatched_64(handle: cublasHandle_t, trans: cublasOperati
         cublasCgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray, incx, beta, yarray, incy, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemvStridedBatched(handle: cublasHandle_t, trans: cublasOperation_t, m: ::core::ffi::c_int, n: ::core::ffi::c_int, alpha: *const cuComplex, A: *const cuComplex, lda: ::core::ffi::c_int, strideA: ::core::ffi::c_longlong, x: *const cuComplex, incx: ::core::ffi::c_int, stridex: ::core::ffi::c_longlong, beta: *const cuComplex, y: *mut cuComplex, incy: ::core::ffi::c_int, stridey: ::core::ffi::c_longlong, batchCount: ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1059,7 +1059,7 @@ pub unsafe fn cublasCgemvStridedBatched(handle: cublasHandle_t, trans: cublasOpe
         cublasCgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA, x, incx, stridex, beta, y, incy, stridey, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemvStridedBatched_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, strideA: ::core::ffi::c_longlong, x: *const cuComplex, incx: i64, stridex: ::core::ffi::c_longlong, beta: *const cuComplex, y: *mut cuComplex, incy: i64, stridey: ::core::ffi::c_longlong, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1092,7 +1092,7 @@ pub unsafe fn cublasCgemv_v2(handle: cublasHandle_t, trans: cublasOperation_t, m
         cublasCgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgemv_v2_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, x: *const cuComplex, incx: i64, beta: *const cuComplex, y: *mut cuComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1141,7 +1141,7 @@ pub unsafe fn cublasCgerc_v2(handle: cublasHandle_t, m: ::core::ffi::c_int, n: :
         cublasCgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgerc_v2_64(handle: cublasHandle_t, m: i64, n: i64, alpha: *const cuComplex, x: *const cuComplex, incx: i64, y: *const cuComplex, incy: i64, A: *mut cuComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1174,7 +1174,7 @@ pub unsafe fn cublasCgeru_v2(handle: cublasHandle_t, m: ::core::ffi::c_int, n: :
         cublasCgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCgeru_v2_64(handle: cublasHandle_t, m: i64, n: i64, alpha: *const cuComplex, x: *const cuComplex, incx: i64, y: *const cuComplex, incy: i64, A: *mut cuComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1255,7 +1255,7 @@ pub unsafe fn cublasChbmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasChbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasChbmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, x: *const cuComplex, incx: i64, beta: *const cuComplex, y: *mut cuComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1288,7 +1288,7 @@ pub unsafe fn cublasChemm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasChemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasChemm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, m: i64, n: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *const cuComplex, ldb: i64, beta: *const cuComplex, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1321,7 +1321,7 @@ pub unsafe fn cublasChemv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasChemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasChemv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, x: *const cuComplex, incx: i64, beta: *const cuComplex, y: *mut cuComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1354,7 +1354,7 @@ pub unsafe fn cublasCher2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasCher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCher2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuComplex, x: *const cuComplex, incx: i64, y: *const cuComplex, incy: i64, A: *mut cuComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1387,7 +1387,7 @@ pub unsafe fn cublasCher2k_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tr
         cublasCher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCher2k_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *const cuComplex, ldb: i64, beta: *const f32, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1420,7 +1420,7 @@ pub unsafe fn cublasCher_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasCher_v2(handle, uplo, n, alpha, x, incx, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCher_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f32, x: *const cuComplex, incx: i64, A: *mut cuComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1453,7 +1453,7 @@ pub unsafe fn cublasCherk3mEx(handle: cublasHandle_t, uplo: cublasFillMode_t, tr
         cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCherk3mEx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f32, A: *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, beta: *const f32, C: *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1486,7 +1486,7 @@ pub unsafe fn cublasCherkEx(handle: cublasHandle_t, uplo: cublasFillMode_t, tran
         cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCherkEx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f32, A: *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, beta: *const f32, C: *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1519,7 +1519,7 @@ pub unsafe fn cublasCherk_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasCherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCherk_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f32, A: *const cuComplex, lda: i64, beta: *const f32, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1552,7 +1552,7 @@ pub unsafe fn cublasCherkx(handle: cublasHandle_t, uplo: cublasFillMode_t, trans
         cublasCherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCherkx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *const cuComplex, ldb: i64, beta: *const f32, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1585,7 +1585,7 @@ pub unsafe fn cublasChpmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasChpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasChpmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuComplex, AP: *const cuComplex, x: *const cuComplex, incx: i64, beta: *const cuComplex, y: *mut cuComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1618,7 +1618,7 @@ pub unsafe fn cublasChpr2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasChpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasChpr2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuComplex, x: *const cuComplex, incx: i64, y: *const cuComplex, incy: i64, AP: *mut cuComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1651,7 +1651,7 @@ pub unsafe fn cublasChpr_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasChpr_v2(handle, uplo, n, alpha, x, incx, AP)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasChpr_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f32, x: *const cuComplex, incx: i64, AP: *mut cuComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1700,7 +1700,7 @@ pub unsafe fn cublasCopyEx(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *co
         cublasCopyEx(handle, n, x, xType, incx, y, yType, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCopyEx_64(handle: cublasHandle_t, n: i64, x: *const ::core::ffi::c_void, xType: cudaDataType, incx: i64, y: *mut ::core::ffi::c_void, yType: cudaDataType, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1749,7 +1749,7 @@ pub unsafe fn cublasCrot_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *m
         cublasCrot_v2(handle, n, x, incx, y, incy, c, s)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCrot_v2_64(handle: cublasHandle_t, n: i64, x: *mut cuComplex, incx: i64, y: *mut cuComplex, incy: i64, c: *const f32, s: *const cuComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1798,7 +1798,7 @@ pub unsafe fn cublasCscal_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alph
         cublasCscal_v2(handle, n, alpha, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCscal_v2_64(handle: cublasHandle_t, n: i64, alpha: *const cuComplex, x: *mut cuComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1831,7 +1831,7 @@ pub unsafe fn cublasCsrot_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasCsrot_v2(handle, n, x, incx, y, incy, c, s)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsrot_v2_64(handle: cublasHandle_t, n: i64, x: *mut cuComplex, incx: i64, y: *mut cuComplex, incy: i64, c: *const f32, s: *const f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1864,7 +1864,7 @@ pub unsafe fn cublasCsscal_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alp
         cublasCsscal_v2(handle, n, alpha, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsscal_v2_64(handle: cublasHandle_t, n: i64, alpha: *const f32, x: *mut cuComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1897,7 +1897,7 @@ pub unsafe fn cublasCswap_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasCswap_v2(handle, n, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCswap_v2_64(handle: cublasHandle_t, n: i64, x: *mut cuComplex, incx: i64, y: *mut cuComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1930,7 +1930,7 @@ pub unsafe fn cublasCsymm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasCsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsymm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, m: i64, n: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *const cuComplex, ldb: i64, beta: *const cuComplex, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1963,7 +1963,7 @@ pub unsafe fn cublasCsymv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasCsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsymv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, x: *const cuComplex, incx: i64, beta: *const cuComplex, y: *mut cuComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1996,7 +1996,7 @@ pub unsafe fn cublasCsyr2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasCsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsyr2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuComplex, x: *const cuComplex, incx: i64, y: *const cuComplex, incy: i64, A: *mut cuComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2029,7 +2029,7 @@ pub unsafe fn cublasCsyr2k_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tr
         cublasCsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsyr2k_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *const cuComplex, ldb: i64, beta: *const cuComplex, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2062,7 +2062,7 @@ pub unsafe fn cublasCsyr_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasCsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsyr_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuComplex, x: *const cuComplex, incx: i64, A: *mut cuComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2095,7 +2095,7 @@ pub unsafe fn cublasCsyrk3mEx(handle: cublasHandle_t, uplo: cublasFillMode_t, tr
         cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsyrk3mEx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuComplex, A: *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, beta: *const cuComplex, C: *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2128,7 +2128,7 @@ pub unsafe fn cublasCsyrkEx(handle: cublasHandle_t, uplo: cublasFillMode_t, tran
         cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsyrkEx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuComplex, A: *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, beta: *const cuComplex, C: *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2161,7 +2161,7 @@ pub unsafe fn cublasCsyrk_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasCsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsyrk_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, beta: *const cuComplex, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2194,7 +2194,7 @@ pub unsafe fn cublasCsyrkx(handle: cublasHandle_t, uplo: cublasFillMode_t, trans
         cublasCsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCsyrkx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *const cuComplex, ldb: i64, beta: *const cuComplex, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2227,7 +2227,7 @@ pub unsafe fn cublasCtbmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasCtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCtbmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, k: i64, A: *const cuComplex, lda: i64, x: *mut cuComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2260,7 +2260,7 @@ pub unsafe fn cublasCtbsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasCtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCtbsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, k: i64, A: *const cuComplex, lda: i64, x: *mut cuComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2293,7 +2293,7 @@ pub unsafe fn cublasCtpmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasCtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCtpmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, AP: *const cuComplex, x: *mut cuComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2326,7 +2326,7 @@ pub unsafe fn cublasCtpsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasCtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCtpsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, AP: *const cuComplex, x: *mut cuComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2375,7 +2375,7 @@ pub unsafe fn cublasCtrmm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasCtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCtrmm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *const cuComplex, ldb: i64, C: *mut cuComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2408,7 +2408,7 @@ pub unsafe fn cublasCtrmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasCtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCtrmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, A: *const cuComplex, lda: i64, x: *mut cuComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2441,7 +2441,7 @@ pub unsafe fn cublasCtrsmBatched(handle: cublasHandle_t, side: cublasSideMode_t,
         cublasCtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCtrsmBatched_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const cuComplex, A: *const *const cuComplex, lda: i64, B: *const *mut cuComplex, ldb: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2474,7 +2474,7 @@ pub unsafe fn cublasCtrsm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasCtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCtrsm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const cuComplex, A: *const cuComplex, lda: i64, B: *mut cuComplex, ldb: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2507,7 +2507,7 @@ pub unsafe fn cublasCtrsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasCtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasCtrsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, A: *const cuComplex, lda: i64, x: *mut cuComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2556,7 +2556,7 @@ pub unsafe fn cublasDasum_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasDasum_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDasum_v2_64(handle: cublasHandle_t, n: i64, x: *const f64, incx: i64, result: *mut f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2589,7 +2589,7 @@ pub unsafe fn cublasDaxpy_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alph
         cublasDaxpy_v2(handle, n, alpha, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDaxpy_v2_64(handle: cublasHandle_t, n: i64, alpha: *const f64, x: *const f64, incx: i64, y: *mut f64, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2622,7 +2622,7 @@ pub unsafe fn cublasDcopy_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasDcopy_v2(handle, n, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDcopy_v2_64(handle: cublasHandle_t, n: i64, x: *const f64, incx: i64, y: *mut f64, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2655,7 +2655,7 @@ pub unsafe fn cublasDdgmm(handle: cublasHandle_t, mode: cublasSideMode_t, m: ::c
         cublasDdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDdgmm_64(handle: cublasHandle_t, mode: cublasSideMode_t, m: i64, n: i64, A: *const f64, lda: i64, x: *const f64, incx: i64, C: *mut f64, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2688,7 +2688,7 @@ pub unsafe fn cublasDdot_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *c
         cublasDdot_v2(handle, n, x, incx, y, incy, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDdot_v2_64(handle: cublasHandle_t, n: i64, x: *const f64, incx: i64, y: *const f64, incy: i64, result: *mut f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2737,7 +2737,7 @@ pub unsafe fn cublasDgbmv_v2(handle: cublasHandle_t, trans: cublasOperation_t, m
         cublasDgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgbmv_v2_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, kl: i64, ku: i64, alpha: *const f64, A: *const f64, lda: i64, x: *const f64, incx: i64, beta: *const f64, y: *mut f64, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2770,7 +2770,7 @@ pub unsafe fn cublasDgeam(handle: cublasHandle_t, transa: cublasOperation_t, tra
         cublasDgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgeam_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, alpha: *const f64, A: *const f64, lda: i64, beta: *const f64, B: *const f64, ldb: i64, C: *mut f64, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2819,7 +2819,7 @@ pub unsafe fn cublasDgemmBatched(handle: cublasHandle_t, transa: cublasOperation
         cublasDgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemmBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const f64, Aarray: *const *const f64, lda: i64, Barray: *const *const f64, ldb: i64, beta: *const f64, Carray: *const *mut f64, ldc: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2836,7 +2836,7 @@ pub unsafe fn cublasDgemmBatched_64(handle: cublasHandle_t, transa: cublasOperat
         cublasDgemmBatched_64(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemmGroupedBatched(handle: cublasHandle_t, transa_array: *const cublasOperation_t, transb_array: *const cublasOperation_t, m_array: *const ::core::ffi::c_int, n_array: *const ::core::ffi::c_int, k_array: *const ::core::ffi::c_int, alpha_array: *const f64, Aarray: *const *const f64, lda_array: *const ::core::ffi::c_int, Barray: *const *const f64, ldb_array: *const ::core::ffi::c_int, beta_array: *const f64, Carray: *const *mut f64, ldc_array: *const ::core::ffi::c_int, group_count: ::core::ffi::c_int, group_size: *const ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2853,7 +2853,7 @@ pub unsafe fn cublasDgemmGroupedBatched(handle: cublasHandle_t, transa_array: *c
         cublasDgemmGroupedBatched(handle, transa_array, transb_array, m_array, n_array, k_array, alpha_array, Aarray, lda_array, Barray, ldb_array, beta_array, Carray, ldc_array, group_count, group_size)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemmGroupedBatched_64(handle: cublasHandle_t, transa_array: *const cublasOperation_t, transb_array: *const cublasOperation_t, m_array: *const i64, n_array: *const i64, k_array: *const i64, alpha_array: *const f64, Aarray: *const *const f64, lda_array: *const i64, Barray: *const *const f64, ldb_array: *const i64, beta_array: *const f64, Carray: *const *mut f64, ldc_array: *const i64, group_count: i64, group_size: *const i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2886,7 +2886,7 @@ pub unsafe fn cublasDgemmStridedBatched(handle: cublasHandle_t, transa: cublasOp
         cublasDgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemmStridedBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const f64, A: *const f64, lda: i64, strideA: ::core::ffi::c_longlong, B: *const f64, ldb: i64, strideB: ::core::ffi::c_longlong, beta: *const f64, C: *mut f64, ldc: i64, strideC: ::core::ffi::c_longlong, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2919,7 +2919,7 @@ pub unsafe fn cublasDgemm_v2(handle: cublasHandle_t, transa: cublasOperation_t, 
         cublasDgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemm_v2_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const f64, A: *const f64, lda: i64, B: *const f64, ldb: i64, beta: *const f64, C: *mut f64, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2936,7 +2936,7 @@ pub unsafe fn cublasDgemm_v2_64(handle: cublasHandle_t, transa: cublasOperation_
         cublasDgemm_v2_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemvBatched(handle: cublasHandle_t, trans: cublasOperation_t, m: ::core::ffi::c_int, n: ::core::ffi::c_int, alpha: *const f64, Aarray: *const *const f64, lda: ::core::ffi::c_int, xarray: *const *const f64, incx: ::core::ffi::c_int, beta: *const f64, yarray: *const *mut f64, incy: ::core::ffi::c_int, batchCount: ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2953,7 +2953,7 @@ pub unsafe fn cublasDgemvBatched(handle: cublasHandle_t, trans: cublasOperation_
         cublasDgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray, incx, beta, yarray, incy, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemvBatched_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const f64, Aarray: *const *const f64, lda: i64, xarray: *const *const f64, incx: i64, beta: *const f64, yarray: *const *mut f64, incy: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2970,7 +2970,7 @@ pub unsafe fn cublasDgemvBatched_64(handle: cublasHandle_t, trans: cublasOperati
         cublasDgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray, incx, beta, yarray, incy, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemvStridedBatched(handle: cublasHandle_t, trans: cublasOperation_t, m: ::core::ffi::c_int, n: ::core::ffi::c_int, alpha: *const f64, A: *const f64, lda: ::core::ffi::c_int, strideA: ::core::ffi::c_longlong, x: *const f64, incx: ::core::ffi::c_int, stridex: ::core::ffi::c_longlong, beta: *const f64, y: *mut f64, incy: ::core::ffi::c_int, stridey: ::core::ffi::c_longlong, batchCount: ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2987,7 +2987,7 @@ pub unsafe fn cublasDgemvStridedBatched(handle: cublasHandle_t, trans: cublasOpe
         cublasDgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA, x, incx, stridex, beta, y, incy, stridey, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemvStridedBatched_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const f64, A: *const f64, lda: i64, strideA: ::core::ffi::c_longlong, x: *const f64, incx: i64, stridex: ::core::ffi::c_longlong, beta: *const f64, y: *mut f64, incy: i64, stridey: ::core::ffi::c_longlong, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3020,7 +3020,7 @@ pub unsafe fn cublasDgemv_v2(handle: cublasHandle_t, trans: cublasOperation_t, m
         cublasDgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDgemv_v2_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const f64, A: *const f64, lda: i64, x: *const f64, incx: i64, beta: *const f64, y: *mut f64, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3069,7 +3069,7 @@ pub unsafe fn cublasDger_v2(handle: cublasHandle_t, m: ::core::ffi::c_int, n: ::
         cublasDger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDger_v2_64(handle: cublasHandle_t, m: i64, n: i64, alpha: *const f64, x: *const f64, incx: i64, y: *const f64, incy: i64, A: *mut f64, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3166,7 +3166,7 @@ pub unsafe fn cublasDnrm2_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasDnrm2_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDnrm2_v2_64(handle: cublasHandle_t, n: i64, x: *const f64, incx: i64, result: *mut f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3199,7 +3199,7 @@ pub unsafe fn cublasDotEx(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *con
         cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDotEx_64(handle: cublasHandle_t, n: i64, x: *const ::core::ffi::c_void, xType: cudaDataType, incx: i64, y: *const ::core::ffi::c_void, yType: cudaDataType, incy: i64, result: *mut ::core::ffi::c_void, resultType: cudaDataType, executionType: cudaDataType) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3232,7 +3232,7 @@ pub unsafe fn cublasDotcEx(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *co
         cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDotcEx_64(handle: cublasHandle_t, n: i64, x: *const ::core::ffi::c_void, xType: cudaDataType, incx: i64, y: *const ::core::ffi::c_void, yType: cudaDataType, incy: i64, result: *mut ::core::ffi::c_void, resultType: cudaDataType, executionType: cudaDataType) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3265,7 +3265,7 @@ pub unsafe fn cublasDrot_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *m
         cublasDrot_v2(handle, n, x, incx, y, incy, c, s)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDrot_v2_64(handle: cublasHandle_t, n: i64, x: *mut f64, incx: i64, y: *mut f64, incy: i64, c: *const f64, s: *const f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3314,7 +3314,7 @@ pub unsafe fn cublasDrotm_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasDrotm_v2(handle, n, x, incx, y, incy, param)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDrotm_v2_64(handle: cublasHandle_t, n: i64, x: *mut f64, incx: i64, y: *mut f64, incy: i64, param: *const f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3363,7 +3363,7 @@ pub unsafe fn cublasDsbmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasDsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDsbmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, k: i64, alpha: *const f64, A: *const f64, lda: i64, x: *const f64, incx: i64, beta: *const f64, y: *mut f64, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3396,7 +3396,7 @@ pub unsafe fn cublasDscal_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alph
         cublasDscal_v2(handle, n, alpha, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDscal_v2_64(handle: cublasHandle_t, n: i64, alpha: *const f64, x: *mut f64, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3429,7 +3429,7 @@ pub unsafe fn cublasDspmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasDspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDspmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f64, AP: *const f64, x: *const f64, incx: i64, beta: *const f64, y: *mut f64, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3462,7 +3462,7 @@ pub unsafe fn cublasDspr2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasDspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDspr2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f64, x: *const f64, incx: i64, y: *const f64, incy: i64, AP: *mut f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3495,7 +3495,7 @@ pub unsafe fn cublasDspr_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasDspr_v2(handle, uplo, n, alpha, x, incx, AP)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDspr_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f64, x: *const f64, incx: i64, AP: *mut f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3528,7 +3528,7 @@ pub unsafe fn cublasDswap_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasDswap_v2(handle, n, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDswap_v2_64(handle: cublasHandle_t, n: i64, x: *mut f64, incx: i64, y: *mut f64, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3561,7 +3561,7 @@ pub unsafe fn cublasDsymm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasDsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDsymm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, m: i64, n: i64, alpha: *const f64, A: *const f64, lda: i64, B: *const f64, ldb: i64, beta: *const f64, C: *mut f64, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3594,7 +3594,7 @@ pub unsafe fn cublasDsymv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasDsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDsymv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f64, A: *const f64, lda: i64, x: *const f64, incx: i64, beta: *const f64, y: *mut f64, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3627,7 +3627,7 @@ pub unsafe fn cublasDsyr2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasDsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDsyr2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f64, x: *const f64, incx: i64, y: *const f64, incy: i64, A: *mut f64, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3660,7 +3660,7 @@ pub unsafe fn cublasDsyr2k_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tr
         cublasDsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDsyr2k_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f64, A: *const f64, lda: i64, B: *const f64, ldb: i64, beta: *const f64, C: *mut f64, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3693,7 +3693,7 @@ pub unsafe fn cublasDsyr_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasDsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDsyr_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f64, x: *const f64, incx: i64, A: *mut f64, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3726,7 +3726,7 @@ pub unsafe fn cublasDsyrk_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasDsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDsyrk_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f64, A: *const f64, lda: i64, beta: *const f64, C: *mut f64, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3759,7 +3759,7 @@ pub unsafe fn cublasDsyrkx(handle: cublasHandle_t, uplo: cublasFillMode_t, trans
         cublasDsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDsyrkx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f64, A: *const f64, lda: i64, B: *const f64, ldb: i64, beta: *const f64, C: *mut f64, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3792,7 +3792,7 @@ pub unsafe fn cublasDtbmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasDtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDtbmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, k: i64, A: *const f64, lda: i64, x: *mut f64, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3825,7 +3825,7 @@ pub unsafe fn cublasDtbsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasDtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDtbsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, k: i64, A: *const f64, lda: i64, x: *mut f64, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3858,7 +3858,7 @@ pub unsafe fn cublasDtpmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasDtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDtpmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, AP: *const f64, x: *mut f64, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3891,7 +3891,7 @@ pub unsafe fn cublasDtpsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasDtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDtpsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, AP: *const f64, x: *mut f64, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3940,7 +3940,7 @@ pub unsafe fn cublasDtrmm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasDtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDtrmm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const f64, A: *const f64, lda: i64, B: *const f64, ldb: i64, C: *mut f64, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3973,7 +3973,7 @@ pub unsafe fn cublasDtrmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasDtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDtrmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, A: *const f64, lda: i64, x: *mut f64, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4006,7 +4006,7 @@ pub unsafe fn cublasDtrsmBatched(handle: cublasHandle_t, side: cublasSideMode_t,
         cublasDtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDtrsmBatched_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const f64, A: *const *const f64, lda: i64, B: *const *mut f64, ldb: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4039,7 +4039,7 @@ pub unsafe fn cublasDtrsm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasDtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDtrsm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const f64, A: *const f64, lda: i64, B: *mut f64, ldb: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4072,7 +4072,7 @@ pub unsafe fn cublasDtrsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasDtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDtrsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, A: *const f64, lda: i64, x: *mut f64, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4121,7 +4121,7 @@ pub unsafe fn cublasDzasum_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasDzasum_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDzasum_v2_64(handle: cublasHandle_t, n: i64, x: *const cuDoubleComplex, incx: i64, result: *mut f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4154,7 +4154,7 @@ pub unsafe fn cublasDznrm2_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasDznrm2_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasDznrm2_v2_64(handle: cublasHandle_t, n: i64, x: *const cuDoubleComplex, incx: i64, result: *mut f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4187,7 +4187,7 @@ pub unsafe fn cublasGemmBatchedEx(handle: cublasHandle_t, transa: cublasOperatio
         cublasGemmBatchedEx(handle, transa, transb, m, n, k, alpha, Aarray, Atype, lda, Barray, Btype, ldb, beta, Carray, Ctype, ldc, batchCount, computeType, algo)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGemmBatchedEx_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const ::core::ffi::c_void, Aarray: *const *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, Barray: *const *const ::core::ffi::c_void, Btype: cudaDataType, ldb: i64, beta: *const ::core::ffi::c_void, Carray: *const *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64, batchCount: i64, computeType: cublasComputeType_t, algo: cublasGemmAlgo_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4220,7 +4220,7 @@ pub unsafe fn cublasGemmEx(handle: cublasHandle_t, transa: cublasOperation_t, tr
         cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGemmEx_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const ::core::ffi::c_void, A: *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, B: *const ::core::ffi::c_void, Btype: cudaDataType, ldb: i64, beta: *const ::core::ffi::c_void, C: *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64, computeType: cublasComputeType_t, algo: cublasGemmAlgo_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4237,7 +4237,7 @@ pub unsafe fn cublasGemmEx_64(handle: cublasHandle_t, transa: cublasOperation_t,
         cublasGemmEx_64(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGemmGroupedBatchedEx(handle: cublasHandle_t, transa_array: *const cublasOperation_t, transb_array: *const cublasOperation_t, m_array: *const ::core::ffi::c_int, n_array: *const ::core::ffi::c_int, k_array: *const ::core::ffi::c_int, alpha_array: *const ::core::ffi::c_void, Aarray: *const *const ::core::ffi::c_void, Atype: cudaDataType_t, lda_array: *const ::core::ffi::c_int, Barray: *const *const ::core::ffi::c_void, Btype: cudaDataType_t, ldb_array: *const ::core::ffi::c_int, beta_array: *const ::core::ffi::c_void, Carray: *const *mut ::core::ffi::c_void, Ctype: cudaDataType_t, ldc_array: *const ::core::ffi::c_int, group_count: ::core::ffi::c_int, group_size: *const ::core::ffi::c_int, computeType: cublasComputeType_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4254,7 +4254,7 @@ pub unsafe fn cublasGemmGroupedBatchedEx(handle: cublasHandle_t, transa_array: *
         cublasGemmGroupedBatchedEx(handle, transa_array, transb_array, m_array, n_array, k_array, alpha_array, Aarray, Atype, lda_array, Barray, Btype, ldb_array, beta_array, Carray, Ctype, ldc_array, group_count, group_size, computeType)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGemmGroupedBatchedEx_64(handle: cublasHandle_t, transa_array: *const cublasOperation_t, transb_array: *const cublasOperation_t, m_array: *const i64, n_array: *const i64, k_array: *const i64, alpha_array: *const ::core::ffi::c_void, Aarray: *const *const ::core::ffi::c_void, Atype: cudaDataType_t, lda_array: *const i64, Barray: *const *const ::core::ffi::c_void, Btype: cudaDataType_t, ldb_array: *const i64, beta_array: *const ::core::ffi::c_void, Carray: *const *mut ::core::ffi::c_void, Ctype: cudaDataType_t, ldc_array: *const i64, group_count: i64, group_size: *const i64, computeType: cublasComputeType_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4287,7 +4287,7 @@ pub unsafe fn cublasGemmStridedBatchedEx(handle: cublasHandle_t, transa: cublasO
         cublasGemmStridedBatchedEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, strideA, B, Btype, ldb, strideB, beta, C, Ctype, ldc, strideC, batchCount, computeType, algo)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGemmStridedBatchedEx_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const ::core::ffi::c_void, A: *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, strideA: ::core::ffi::c_longlong, B: *const ::core::ffi::c_void, Btype: cudaDataType, ldb: i64, strideB: ::core::ffi::c_longlong, beta: *const ::core::ffi::c_void, C: *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64, strideC: ::core::ffi::c_longlong, batchCount: i64, computeType: cublasComputeType_t, algo: cublasGemmAlgo_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4336,7 +4336,7 @@ pub unsafe fn cublasGetCudartVersion() -> usize {
         cublasGetCudartVersion()
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGetEmulationStrategy(handle: cublasHandle_t, emulationStrategy: *mut cublasEmulationStrategy_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4417,7 +4417,7 @@ pub unsafe fn cublasGetMatrixAsync(rows: ::core::ffi::c_int, cols: ::core::ffi::
         cublasGetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGetMatrixAsync_64(rows: i64, cols: i64, elemSize: i64, A: *const ::core::ffi::c_void, lda: i64, B: *mut ::core::ffi::c_void, ldb: i64, stream: cudaStream_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4434,7 +4434,7 @@ pub unsafe fn cublasGetMatrixAsync_64(rows: i64, cols: i64, elemSize: i64, A: *c
         cublasGetMatrixAsync_64(rows, cols, elemSize, A, lda, B, ldb, stream)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGetMatrix_64(rows: i64, cols: i64, elemSize: i64, A: *const ::core::ffi::c_void, lda: i64, B: *mut ::core::ffi::c_void, ldb: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4579,7 +4579,7 @@ pub unsafe fn cublasGetVectorAsync(n: ::core::ffi::c_int, elemSize: ::core::ffi:
         cublasGetVectorAsync(n, elemSize, devicePtr, incx, hostPtr, incy, stream)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGetVectorAsync_64(n: i64, elemSize: i64, devicePtr: *const ::core::ffi::c_void, incx: i64, hostPtr: *mut ::core::ffi::c_void, incy: i64, stream: cudaStream_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4596,7 +4596,7 @@ pub unsafe fn cublasGetVectorAsync_64(n: i64, elemSize: i64, devicePtr: *const :
         cublasGetVectorAsync_64(n, elemSize, devicePtr, incx, hostPtr, incy, stream)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasGetVector_64(n: i64, elemSize: i64, x: *const ::core::ffi::c_void, incx: i64, y: *mut ::core::ffi::c_void, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4645,7 +4645,7 @@ pub unsafe fn cublasIamaxEx(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *c
         cublasIamaxEx(handle, n, x, xType, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIamaxEx_64(handle: cublasHandle_t, n: i64, x: *const ::core::ffi::c_void, xType: cudaDataType, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4678,7 +4678,7 @@ pub unsafe fn cublasIaminEx(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *c
         cublasIaminEx(handle, n, x, xType, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIaminEx_64(handle: cublasHandle_t, n: i64, x: *const ::core::ffi::c_void, xType: cudaDataType, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4711,7 +4711,7 @@ pub unsafe fn cublasIcamax_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasIcamax_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIcamax_v2_64(handle: cublasHandle_t, n: i64, x: *const cuComplex, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4744,7 +4744,7 @@ pub unsafe fn cublasIcamin_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasIcamin_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIcamin_v2_64(handle: cublasHandle_t, n: i64, x: *const cuComplex, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4777,7 +4777,7 @@ pub unsafe fn cublasIdamax_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasIdamax_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIdamax_v2_64(handle: cublasHandle_t, n: i64, x: *const f64, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4810,7 +4810,7 @@ pub unsafe fn cublasIdamin_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasIdamin_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIdamin_v2_64(handle: cublasHandle_t, n: i64, x: *const f64, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4843,7 +4843,7 @@ pub unsafe fn cublasIsamax_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasIsamax_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIsamax_v2_64(handle: cublasHandle_t, n: i64, x: *const f32, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4876,7 +4876,7 @@ pub unsafe fn cublasIsamin_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasIsamin_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIsamin_v2_64(handle: cublasHandle_t, n: i64, x: *const f32, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4909,7 +4909,7 @@ pub unsafe fn cublasIzamax_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasIzamax_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIzamax_v2_64(handle: cublasHandle_t, n: i64, x: *const cuDoubleComplex, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4942,7 +4942,7 @@ pub unsafe fn cublasIzamin_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasIzamin_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasIzamin_v2_64(handle: cublasHandle_t, n: i64, x: *const cuDoubleComplex, incx: i64, result: *mut i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4991,7 +4991,7 @@ pub unsafe fn cublasNrm2Ex(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *co
         cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasNrm2Ex_64(handle: cublasHandle_t, n: i64, x: *const ::core::ffi::c_void, xType: cudaDataType, incx: i64, result: *mut ::core::ffi::c_void, resultType: cudaDataType, executionType: cudaDataType) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5024,7 +5024,7 @@ pub unsafe fn cublasRotEx(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *mut
         cublasRotEx(handle, n, x, xType, incx, y, yType, incy, c, s, csType, executiontype)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasRotEx_64(handle: cublasHandle_t, n: i64, x: *mut ::core::ffi::c_void, xType: cudaDataType, incx: i64, y: *mut ::core::ffi::c_void, yType: cudaDataType, incy: i64, c: *const ::core::ffi::c_void, s: *const ::core::ffi::c_void, csType: cudaDataType, executiontype: cudaDataType) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5073,7 +5073,7 @@ pub unsafe fn cublasRotmEx(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *mu
         cublasRotmEx(handle, n, x, xType, incx, y, yType, incy, param, paramType, executiontype)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasRotmEx_64(handle: cublasHandle_t, n: i64, x: *mut ::core::ffi::c_void, xType: cudaDataType, incx: i64, y: *mut ::core::ffi::c_void, yType: cudaDataType, incy: i64, param: *const ::core::ffi::c_void, paramType: cudaDataType, executiontype: cudaDataType) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5122,7 +5122,7 @@ pub unsafe fn cublasSasum_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasSasum_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSasum_v2_64(handle: cublasHandle_t, n: i64, x: *const f32, incx: i64, result: *mut f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5155,7 +5155,7 @@ pub unsafe fn cublasSaxpy_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alph
         cublasSaxpy_v2(handle, n, alpha, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSaxpy_v2_64(handle: cublasHandle_t, n: i64, alpha: *const f32, x: *const f32, incx: i64, y: *mut f32, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5188,7 +5188,7 @@ pub unsafe fn cublasScalEx(handle: cublasHandle_t, n: ::core::ffi::c_int, alpha:
         cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasScalEx_64(handle: cublasHandle_t, n: i64, alpha: *const ::core::ffi::c_void, alphaType: cudaDataType, x: *mut ::core::ffi::c_void, xType: cudaDataType, incx: i64, executionType: cudaDataType) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5221,7 +5221,7 @@ pub unsafe fn cublasScasum_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasScasum_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasScasum_v2_64(handle: cublasHandle_t, n: i64, x: *const cuComplex, incx: i64, result: *mut f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5254,7 +5254,7 @@ pub unsafe fn cublasScnrm2_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: 
         cublasScnrm2_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasScnrm2_v2_64(handle: cublasHandle_t, n: i64, x: *const cuComplex, incx: i64, result: *mut f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5287,7 +5287,7 @@ pub unsafe fn cublasScopy_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasScopy_v2(handle, n, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasScopy_v2_64(handle: cublasHandle_t, n: i64, x: *const f32, incx: i64, y: *mut f32, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5320,7 +5320,7 @@ pub unsafe fn cublasSdgmm(handle: cublasHandle_t, mode: cublasSideMode_t, m: ::c
         cublasSdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSdgmm_64(handle: cublasHandle_t, mode: cublasSideMode_t, m: i64, n: i64, A: *const f32, lda: i64, x: *const f32, incx: i64, C: *mut f32, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5353,7 +5353,7 @@ pub unsafe fn cublasSdot_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *c
         cublasSdot_v2(handle, n, x, incx, y, incy, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSdot_v2_64(handle: cublasHandle_t, n: i64, x: *const f32, incx: i64, y: *const f32, incy: i64, result: *mut f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5386,7 +5386,7 @@ pub unsafe fn cublasSetAtomicsMode(handle: cublasHandle_t, mode: cublasAtomicsMo
         cublasSetAtomicsMode(handle, mode)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSetEmulationStrategy(handle: cublasHandle_t, emulationStrategy: cublasEmulationStrategy_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5467,7 +5467,7 @@ pub unsafe fn cublasSetMatrixAsync(rows: ::core::ffi::c_int, cols: ::core::ffi::
         cublasSetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSetMatrixAsync_64(rows: i64, cols: i64, elemSize: i64, A: *const ::core::ffi::c_void, lda: i64, B: *mut ::core::ffi::c_void, ldb: i64, stream: cudaStream_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5484,7 +5484,7 @@ pub unsafe fn cublasSetMatrixAsync_64(rows: i64, cols: i64, elemSize: i64, A: *c
         cublasSetMatrixAsync_64(rows, cols, elemSize, A, lda, B, ldb, stream)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSetMatrix_64(rows: i64, cols: i64, elemSize: i64, A: *const ::core::ffi::c_void, lda: i64, B: *mut ::core::ffi::c_void, ldb: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5581,7 +5581,7 @@ pub unsafe fn cublasSetVectorAsync(n: ::core::ffi::c_int, elemSize: ::core::ffi:
         cublasSetVectorAsync(n, elemSize, hostPtr, incx, devicePtr, incy, stream)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSetVectorAsync_64(n: i64, elemSize: i64, hostPtr: *const ::core::ffi::c_void, incx: i64, devicePtr: *mut ::core::ffi::c_void, incy: i64, stream: cudaStream_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5598,7 +5598,7 @@ pub unsafe fn cublasSetVectorAsync_64(n: i64, elemSize: i64, hostPtr: *const ::c
         cublasSetVectorAsync_64(n, elemSize, hostPtr, incx, devicePtr, incy, stream)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSetVector_64(n: i64, elemSize: i64, x: *const ::core::ffi::c_void, incx: i64, devicePtr: *mut ::core::ffi::c_void, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5647,7 +5647,7 @@ pub unsafe fn cublasSgbmv_v2(handle: cublasHandle_t, trans: cublasOperation_t, m
         cublasSgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgbmv_v2_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, kl: i64, ku: i64, alpha: *const f32, A: *const f32, lda: i64, x: *const f32, incx: i64, beta: *const f32, y: *mut f32, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5680,7 +5680,7 @@ pub unsafe fn cublasSgeam(handle: cublasHandle_t, transa: cublasOperation_t, tra
         cublasSgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgeam_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, alpha: *const f32, A: *const f32, lda: i64, beta: *const f32, B: *const f32, ldb: i64, C: *mut f32, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5729,7 +5729,7 @@ pub unsafe fn cublasSgemmBatched(handle: cublasHandle_t, transa: cublasOperation
         cublasSgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemmBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const f32, Aarray: *const *const f32, lda: i64, Barray: *const *const f32, ldb: i64, beta: *const f32, Carray: *const *mut f32, ldc: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5762,7 +5762,7 @@ pub unsafe fn cublasSgemmEx(handle: cublasHandle_t, transa: cublasOperation_t, t
         cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemmEx_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const f32, A: *const ::core::ffi::c_void, Atype: cudaDataType, lda: i64, B: *const ::core::ffi::c_void, Btype: cudaDataType, ldb: i64, beta: *const f32, C: *mut ::core::ffi::c_void, Ctype: cudaDataType, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5779,7 +5779,7 @@ pub unsafe fn cublasSgemmEx_64(handle: cublasHandle_t, transa: cublasOperation_t
         cublasSgemmEx_64(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemmGroupedBatched(handle: cublasHandle_t, transa_array: *const cublasOperation_t, transb_array: *const cublasOperation_t, m_array: *const ::core::ffi::c_int, n_array: *const ::core::ffi::c_int, k_array: *const ::core::ffi::c_int, alpha_array: *const f32, Aarray: *const *const f32, lda_array: *const ::core::ffi::c_int, Barray: *const *const f32, ldb_array: *const ::core::ffi::c_int, beta_array: *const f32, Carray: *const *mut f32, ldc_array: *const ::core::ffi::c_int, group_count: ::core::ffi::c_int, group_size: *const ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5796,7 +5796,7 @@ pub unsafe fn cublasSgemmGroupedBatched(handle: cublasHandle_t, transa_array: *c
         cublasSgemmGroupedBatched(handle, transa_array, transb_array, m_array, n_array, k_array, alpha_array, Aarray, lda_array, Barray, ldb_array, beta_array, Carray, ldc_array, group_count, group_size)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemmGroupedBatched_64(handle: cublasHandle_t, transa_array: *const cublasOperation_t, transb_array: *const cublasOperation_t, m_array: *const i64, n_array: *const i64, k_array: *const i64, alpha_array: *const f32, Aarray: *const *const f32, lda_array: *const i64, Barray: *const *const f32, ldb_array: *const i64, beta_array: *const f32, Carray: *const *mut f32, ldc_array: *const i64, group_count: i64, group_size: *const i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5829,7 +5829,7 @@ pub unsafe fn cublasSgemmStridedBatched(handle: cublasHandle_t, transa: cublasOp
         cublasSgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemmStridedBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const f32, A: *const f32, lda: i64, strideA: ::core::ffi::c_longlong, B: *const f32, ldb: i64, strideB: ::core::ffi::c_longlong, beta: *const f32, C: *mut f32, ldc: i64, strideC: ::core::ffi::c_longlong, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5862,7 +5862,7 @@ pub unsafe fn cublasSgemm_v2(handle: cublasHandle_t, transa: cublasOperation_t, 
         cublasSgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemm_v2_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const f32, A: *const f32, lda: i64, B: *const f32, ldb: i64, beta: *const f32, C: *mut f32, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5879,7 +5879,7 @@ pub unsafe fn cublasSgemm_v2_64(handle: cublasHandle_t, transa: cublasOperation_
         cublasSgemm_v2_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemvBatched(handle: cublasHandle_t, trans: cublasOperation_t, m: ::core::ffi::c_int, n: ::core::ffi::c_int, alpha: *const f32, Aarray: *const *const f32, lda: ::core::ffi::c_int, xarray: *const *const f32, incx: ::core::ffi::c_int, beta: *const f32, yarray: *const *mut f32, incy: ::core::ffi::c_int, batchCount: ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5896,7 +5896,7 @@ pub unsafe fn cublasSgemvBatched(handle: cublasHandle_t, trans: cublasOperation_
         cublasSgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray, incx, beta, yarray, incy, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemvBatched_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const f32, Aarray: *const *const f32, lda: i64, xarray: *const *const f32, incx: i64, beta: *const f32, yarray: *const *mut f32, incy: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5913,7 +5913,7 @@ pub unsafe fn cublasSgemvBatched_64(handle: cublasHandle_t, trans: cublasOperati
         cublasSgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray, incx, beta, yarray, incy, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemvStridedBatched(handle: cublasHandle_t, trans: cublasOperation_t, m: ::core::ffi::c_int, n: ::core::ffi::c_int, alpha: *const f32, A: *const f32, lda: ::core::ffi::c_int, strideA: ::core::ffi::c_longlong, x: *const f32, incx: ::core::ffi::c_int, stridex: ::core::ffi::c_longlong, beta: *const f32, y: *mut f32, incy: ::core::ffi::c_int, stridey: ::core::ffi::c_longlong, batchCount: ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5930,7 +5930,7 @@ pub unsafe fn cublasSgemvStridedBatched(handle: cublasHandle_t, trans: cublasOpe
         cublasSgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA, x, incx, stridex, beta, y, incy, stridey, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemvStridedBatched_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const f32, A: *const f32, lda: i64, strideA: ::core::ffi::c_longlong, x: *const f32, incx: i64, stridex: ::core::ffi::c_longlong, beta: *const f32, y: *mut f32, incy: i64, stridey: ::core::ffi::c_longlong, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5963,7 +5963,7 @@ pub unsafe fn cublasSgemv_v2(handle: cublasHandle_t, trans: cublasOperation_t, m
         cublasSgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSgemv_v2_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const f32, A: *const f32, lda: i64, x: *const f32, incx: i64, beta: *const f32, y: *mut f32, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6012,7 +6012,7 @@ pub unsafe fn cublasSger_v2(handle: cublasHandle_t, m: ::core::ffi::c_int, n: ::
         cublasSger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSger_v2_64(handle: cublasHandle_t, m: i64, n: i64, alpha: *const f32, x: *const f32, incx: i64, y: *const f32, incy: i64, A: *mut f32, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6109,7 +6109,7 @@ pub unsafe fn cublasSnrm2_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasSnrm2_v2(handle, n, x, incx, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSnrm2_v2_64(handle: cublasHandle_t, n: i64, x: *const f32, incx: i64, result: *mut f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6142,7 +6142,7 @@ pub unsafe fn cublasSrot_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *m
         cublasSrot_v2(handle, n, x, incx, y, incy, c, s)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSrot_v2_64(handle: cublasHandle_t, n: i64, x: *mut f32, incx: i64, y: *mut f32, incy: i64, c: *const f32, s: *const f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6191,7 +6191,7 @@ pub unsafe fn cublasSrotm_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasSrotm_v2(handle, n, x, incx, y, incy, param)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSrotm_v2_64(handle: cublasHandle_t, n: i64, x: *mut f32, incx: i64, y: *mut f32, incy: i64, param: *const f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6240,7 +6240,7 @@ pub unsafe fn cublasSsbmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasSsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSsbmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, k: i64, alpha: *const f32, A: *const f32, lda: i64, x: *const f32, incx: i64, beta: *const f32, y: *mut f32, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6273,7 +6273,7 @@ pub unsafe fn cublasSscal_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alph
         cublasSscal_v2(handle, n, alpha, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSscal_v2_64(handle: cublasHandle_t, n: i64, alpha: *const f32, x: *mut f32, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6306,7 +6306,7 @@ pub unsafe fn cublasSspmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasSspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSspmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f32, AP: *const f32, x: *const f32, incx: i64, beta: *const f32, y: *mut f32, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6339,7 +6339,7 @@ pub unsafe fn cublasSspr2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasSspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSspr2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f32, x: *const f32, incx: i64, y: *const f32, incy: i64, AP: *mut f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6372,7 +6372,7 @@ pub unsafe fn cublasSspr_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasSspr_v2(handle, uplo, n, alpha, x, incx, AP)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSspr_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f32, x: *const f32, incx: i64, AP: *mut f32) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6405,7 +6405,7 @@ pub unsafe fn cublasSswap_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasSswap_v2(handle, n, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSswap_v2_64(handle: cublasHandle_t, n: i64, x: *mut f32, incx: i64, y: *mut f32, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6438,7 +6438,7 @@ pub unsafe fn cublasSsymm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasSsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSsymm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, m: i64, n: i64, alpha: *const f32, A: *const f32, lda: i64, B: *const f32, ldb: i64, beta: *const f32, C: *mut f32, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6471,7 +6471,7 @@ pub unsafe fn cublasSsymv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasSsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSsymv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f32, A: *const f32, lda: i64, x: *const f32, incx: i64, beta: *const f32, y: *mut f32, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6504,7 +6504,7 @@ pub unsafe fn cublasSsyr2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasSsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSsyr2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f32, x: *const f32, incx: i64, y: *const f32, incy: i64, A: *mut f32, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6537,7 +6537,7 @@ pub unsafe fn cublasSsyr2k_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tr
         cublasSsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSsyr2k_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f32, A: *const f32, lda: i64, B: *const f32, ldb: i64, beta: *const f32, C: *mut f32, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6570,7 +6570,7 @@ pub unsafe fn cublasSsyr_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasSsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSsyr_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f32, x: *const f32, incx: i64, A: *mut f32, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6603,7 +6603,7 @@ pub unsafe fn cublasSsyrk_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasSsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSsyrk_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f32, A: *const f32, lda: i64, beta: *const f32, C: *mut f32, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6636,7 +6636,7 @@ pub unsafe fn cublasSsyrkx(handle: cublasHandle_t, uplo: cublasFillMode_t, trans
         cublasSsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSsyrkx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f32, A: *const f32, lda: i64, B: *const f32, ldb: i64, beta: *const f32, C: *mut f32, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6669,7 +6669,7 @@ pub unsafe fn cublasStbmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasStbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasStbmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, k: i64, A: *const f32, lda: i64, x: *mut f32, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6702,7 +6702,7 @@ pub unsafe fn cublasStbsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasStbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasStbsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, k: i64, A: *const f32, lda: i64, x: *mut f32, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6735,7 +6735,7 @@ pub unsafe fn cublasStpmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasStpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasStpmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, AP: *const f32, x: *mut f32, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6768,7 +6768,7 @@ pub unsafe fn cublasStpsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasStpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasStpsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, AP: *const f32, x: *mut f32, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6817,7 +6817,7 @@ pub unsafe fn cublasStrmm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasStrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasStrmm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const f32, A: *const f32, lda: i64, B: *const f32, ldb: i64, C: *mut f32, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6850,7 +6850,7 @@ pub unsafe fn cublasStrmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasStrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasStrmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, A: *const f32, lda: i64, x: *mut f32, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6883,7 +6883,7 @@ pub unsafe fn cublasStrsmBatched(handle: cublasHandle_t, side: cublasSideMode_t,
         cublasStrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasStrsmBatched_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const f32, A: *const *const f32, lda: i64, B: *const *mut f32, ldb: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6916,7 +6916,7 @@ pub unsafe fn cublasStrsm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasStrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasStrsm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const f32, A: *const f32, lda: i64, B: *mut f32, ldb: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6949,7 +6949,7 @@ pub unsafe fn cublasStrsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasStrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasStrsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, A: *const f32, lda: i64, x: *mut f32, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6998,7 +6998,7 @@ pub unsafe fn cublasSwapEx(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *mu
         cublasSwapEx(handle, n, x, xType, incx, y, yType, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasSwapEx_64(handle: cublasHandle_t, n: i64, x: *mut ::core::ffi::c_void, xType: cudaDataType, incx: i64, y: *mut ::core::ffi::c_void, yType: cudaDataType, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7063,7 +7063,7 @@ pub unsafe fn cublasZaxpy_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alph
         cublasZaxpy_v2(handle, n, alpha, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZaxpy_v2_64(handle: cublasHandle_t, n: i64, alpha: *const cuDoubleComplex, x: *const cuDoubleComplex, incx: i64, y: *mut cuDoubleComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7096,7 +7096,7 @@ pub unsafe fn cublasZcopy_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasZcopy_v2(handle, n, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZcopy_v2_64(handle: cublasHandle_t, n: i64, x: *const cuDoubleComplex, incx: i64, y: *mut cuDoubleComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7129,7 +7129,7 @@ pub unsafe fn cublasZdgmm(handle: cublasHandle_t, mode: cublasSideMode_t, m: ::c
         cublasZdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZdgmm_64(handle: cublasHandle_t, mode: cublasSideMode_t, m: i64, n: i64, A: *const cuDoubleComplex, lda: i64, x: *const cuDoubleComplex, incx: i64, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7162,7 +7162,7 @@ pub unsafe fn cublasZdotc_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasZdotc_v2(handle, n, x, incx, y, incy, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZdotc_v2_64(handle: cublasHandle_t, n: i64, x: *const cuDoubleComplex, incx: i64, y: *const cuDoubleComplex, incy: i64, result: *mut cuDoubleComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7195,7 +7195,7 @@ pub unsafe fn cublasZdotu_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasZdotu_v2(handle, n, x, incx, y, incy, result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZdotu_v2_64(handle: cublasHandle_t, n: i64, x: *const cuDoubleComplex, incx: i64, y: *const cuDoubleComplex, incy: i64, result: *mut cuDoubleComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7228,7 +7228,7 @@ pub unsafe fn cublasZdrot_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasZdrot_v2(handle, n, x, incx, y, incy, c, s)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZdrot_v2_64(handle: cublasHandle_t, n: i64, x: *mut cuDoubleComplex, incx: i64, y: *mut cuDoubleComplex, incy: i64, c: *const f64, s: *const f64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7261,7 +7261,7 @@ pub unsafe fn cublasZdscal_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alp
         cublasZdscal_v2(handle, n, alpha, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZdscal_v2_64(handle: cublasHandle_t, n: i64, alpha: *const f64, x: *mut cuDoubleComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7294,7 +7294,7 @@ pub unsafe fn cublasZgbmv_v2(handle: cublasHandle_t, trans: cublasOperation_t, m
         cublasZgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgbmv_v2_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, kl: i64, ku: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, x: *const cuDoubleComplex, incx: i64, beta: *const cuDoubleComplex, y: *mut cuDoubleComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7327,7 +7327,7 @@ pub unsafe fn cublasZgeam(handle: cublasHandle_t, transa: cublasOperation_t, tra
         cublasZgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgeam_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, beta: *const cuDoubleComplex, B: *const cuDoubleComplex, ldb: i64, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7376,7 +7376,7 @@ pub unsafe fn cublasZgemm3m(handle: cublasHandle_t, transa: cublasOperation_t, t
         cublasZgemm3m(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgemm3m_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *const cuDoubleComplex, ldb: i64, beta: *const cuDoubleComplex, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7409,7 +7409,7 @@ pub unsafe fn cublasZgemmBatched(handle: cublasHandle_t, transa: cublasOperation
         cublasZgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgemmBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuDoubleComplex, Aarray: *const *const cuDoubleComplex, lda: i64, Barray: *const *const cuDoubleComplex, ldb: i64, beta: *const cuDoubleComplex, Carray: *const *mut cuDoubleComplex, ldc: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7442,7 +7442,7 @@ pub unsafe fn cublasZgemmStridedBatched(handle: cublasHandle_t, transa: cublasOp
         cublasZgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgemmStridedBatched_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, strideA: ::core::ffi::c_longlong, B: *const cuDoubleComplex, ldb: i64, strideB: ::core::ffi::c_longlong, beta: *const cuDoubleComplex, C: *mut cuDoubleComplex, ldc: i64, strideC: ::core::ffi::c_longlong, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7475,7 +7475,7 @@ pub unsafe fn cublasZgemm_v2(handle: cublasHandle_t, transa: cublasOperation_t, 
         cublasZgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgemm_v2_64(handle: cublasHandle_t, transa: cublasOperation_t, transb: cublasOperation_t, m: i64, n: i64, k: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *const cuDoubleComplex, ldb: i64, beta: *const cuDoubleComplex, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7492,7 +7492,7 @@ pub unsafe fn cublasZgemm_v2_64(handle: cublasHandle_t, transa: cublasOperation_
         cublasZgemm_v2_64(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgemvBatched(handle: cublasHandle_t, trans: cublasOperation_t, m: ::core::ffi::c_int, n: ::core::ffi::c_int, alpha: *const cuDoubleComplex, Aarray: *const *const cuDoubleComplex, lda: ::core::ffi::c_int, xarray: *const *const cuDoubleComplex, incx: ::core::ffi::c_int, beta: *const cuDoubleComplex, yarray: *const *mut cuDoubleComplex, incy: ::core::ffi::c_int, batchCount: ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7509,7 +7509,7 @@ pub unsafe fn cublasZgemvBatched(handle: cublasHandle_t, trans: cublasOperation_
         cublasZgemvBatched(handle, trans, m, n, alpha, Aarray, lda, xarray, incx, beta, yarray, incy, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgemvBatched_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const cuDoubleComplex, Aarray: *const *const cuDoubleComplex, lda: i64, xarray: *const *const cuDoubleComplex, incx: i64, beta: *const cuDoubleComplex, yarray: *const *mut cuDoubleComplex, incy: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7526,7 +7526,7 @@ pub unsafe fn cublasZgemvBatched_64(handle: cublasHandle_t, trans: cublasOperati
         cublasZgemvBatched_64(handle, trans, m, n, alpha, Aarray, lda, xarray, incx, beta, yarray, incy, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgemvStridedBatched(handle: cublasHandle_t, trans: cublasOperation_t, m: ::core::ffi::c_int, n: ::core::ffi::c_int, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: ::core::ffi::c_int, strideA: ::core::ffi::c_longlong, x: *const cuDoubleComplex, incx: ::core::ffi::c_int, stridex: ::core::ffi::c_longlong, beta: *const cuDoubleComplex, y: *mut cuDoubleComplex, incy: ::core::ffi::c_int, stridey: ::core::ffi::c_longlong, batchCount: ::core::ffi::c_int) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7543,7 +7543,7 @@ pub unsafe fn cublasZgemvStridedBatched(handle: cublasHandle_t, trans: cublasOpe
         cublasZgemvStridedBatched(handle, trans, m, n, alpha, A, lda, strideA, x, incx, stridex, beta, y, incy, stridey, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgemvStridedBatched_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, strideA: ::core::ffi::c_longlong, x: *const cuDoubleComplex, incx: i64, stridex: ::core::ffi::c_longlong, beta: *const cuDoubleComplex, y: *mut cuDoubleComplex, incy: i64, stridey: ::core::ffi::c_longlong, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7576,7 +7576,7 @@ pub unsafe fn cublasZgemv_v2(handle: cublasHandle_t, trans: cublasOperation_t, m
         cublasZgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgemv_v2_64(handle: cublasHandle_t, trans: cublasOperation_t, m: i64, n: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, x: *const cuDoubleComplex, incx: i64, beta: *const cuDoubleComplex, y: *mut cuDoubleComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7625,7 +7625,7 @@ pub unsafe fn cublasZgerc_v2(handle: cublasHandle_t, m: ::core::ffi::c_int, n: :
         cublasZgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgerc_v2_64(handle: cublasHandle_t, m: i64, n: i64, alpha: *const cuDoubleComplex, x: *const cuDoubleComplex, incx: i64, y: *const cuDoubleComplex, incy: i64, A: *mut cuDoubleComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7658,7 +7658,7 @@ pub unsafe fn cublasZgeru_v2(handle: cublasHandle_t, m: ::core::ffi::c_int, n: :
         cublasZgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZgeru_v2_64(handle: cublasHandle_t, m: i64, n: i64, alpha: *const cuDoubleComplex, x: *const cuDoubleComplex, incx: i64, y: *const cuDoubleComplex, incy: i64, A: *mut cuDoubleComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7739,7 +7739,7 @@ pub unsafe fn cublasZhbmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasZhbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZhbmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, k: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, x: *const cuDoubleComplex, incx: i64, beta: *const cuDoubleComplex, y: *mut cuDoubleComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7772,7 +7772,7 @@ pub unsafe fn cublasZhemm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasZhemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZhemm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, m: i64, n: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *const cuDoubleComplex, ldb: i64, beta: *const cuDoubleComplex, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7805,7 +7805,7 @@ pub unsafe fn cublasZhemv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasZhemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZhemv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, x: *const cuDoubleComplex, incx: i64, beta: *const cuDoubleComplex, y: *mut cuDoubleComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7838,7 +7838,7 @@ pub unsafe fn cublasZher2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasZher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZher2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuDoubleComplex, x: *const cuDoubleComplex, incx: i64, y: *const cuDoubleComplex, incy: i64, A: *mut cuDoubleComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7871,7 +7871,7 @@ pub unsafe fn cublasZher2k_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tr
         cublasZher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZher2k_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *const cuDoubleComplex, ldb: i64, beta: *const f64, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7904,7 +7904,7 @@ pub unsafe fn cublasZher_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasZher_v2(handle, uplo, n, alpha, x, incx, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZher_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f64, x: *const cuDoubleComplex, incx: i64, A: *mut cuDoubleComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7937,7 +7937,7 @@ pub unsafe fn cublasZherk_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasZherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZherk_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const f64, A: *const cuDoubleComplex, lda: i64, beta: *const f64, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7970,7 +7970,7 @@ pub unsafe fn cublasZherkx(handle: cublasHandle_t, uplo: cublasFillMode_t, trans
         cublasZherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZherkx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *const cuDoubleComplex, ldb: i64, beta: *const f64, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8003,7 +8003,7 @@ pub unsafe fn cublasZhpmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasZhpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZhpmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuDoubleComplex, AP: *const cuDoubleComplex, x: *const cuDoubleComplex, incx: i64, beta: *const cuDoubleComplex, y: *mut cuDoubleComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8036,7 +8036,7 @@ pub unsafe fn cublasZhpr2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasZhpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZhpr2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuDoubleComplex, x: *const cuDoubleComplex, incx: i64, y: *const cuDoubleComplex, incy: i64, AP: *mut cuDoubleComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8069,7 +8069,7 @@ pub unsafe fn cublasZhpr_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasZhpr_v2(handle, uplo, n, alpha, x, incx, AP)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZhpr_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const f64, x: *const cuDoubleComplex, incx: i64, AP: *mut cuDoubleComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8118,7 +8118,7 @@ pub unsafe fn cublasZrot_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *m
         cublasZrot_v2(handle, n, x, incx, y, incy, c, s)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZrot_v2_64(handle: cublasHandle_t, n: i64, x: *mut cuDoubleComplex, incx: i64, y: *mut cuDoubleComplex, incy: i64, c: *const f64, s: *const cuDoubleComplex) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8167,7 +8167,7 @@ pub unsafe fn cublasZscal_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, alph
         cublasZscal_v2(handle, n, alpha, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZscal_v2_64(handle: cublasHandle_t, n: i64, alpha: *const cuDoubleComplex, x: *mut cuDoubleComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8200,7 +8200,7 @@ pub unsafe fn cublasZswap_v2(handle: cublasHandle_t, n: ::core::ffi::c_int, x: *
         cublasZswap_v2(handle, n, x, incx, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZswap_v2_64(handle: cublasHandle_t, n: i64, x: *mut cuDoubleComplex, incx: i64, y: *mut cuDoubleComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8233,7 +8233,7 @@ pub unsafe fn cublasZsymm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasZsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZsymm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, m: i64, n: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *const cuDoubleComplex, ldb: i64, beta: *const cuDoubleComplex, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8266,7 +8266,7 @@ pub unsafe fn cublasZsymv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasZsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZsymv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, x: *const cuDoubleComplex, incx: i64, beta: *const cuDoubleComplex, y: *mut cuDoubleComplex, incy: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8299,7 +8299,7 @@ pub unsafe fn cublasZsyr2_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: 
         cublasZsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZsyr2_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuDoubleComplex, x: *const cuDoubleComplex, incx: i64, y: *const cuDoubleComplex, incy: i64, A: *mut cuDoubleComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8332,7 +8332,7 @@ pub unsafe fn cublasZsyr2k_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tr
         cublasZsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZsyr2k_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *const cuDoubleComplex, ldb: i64, beta: *const cuDoubleComplex, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8365,7 +8365,7 @@ pub unsafe fn cublasZsyr_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, n: :
         cublasZsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZsyr_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, n: i64, alpha: *const cuDoubleComplex, x: *const cuDoubleComplex, incx: i64, A: *mut cuDoubleComplex, lda: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8398,7 +8398,7 @@ pub unsafe fn cublasZsyrk_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasZsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZsyrk_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, beta: *const cuDoubleComplex, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8431,7 +8431,7 @@ pub unsafe fn cublasZsyrkx(handle: cublasHandle_t, uplo: cublasFillMode_t, trans
         cublasZsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZsyrkx_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, n: i64, k: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *const cuDoubleComplex, ldb: i64, beta: *const cuDoubleComplex, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8464,7 +8464,7 @@ pub unsafe fn cublasZtbmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasZtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZtbmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, k: i64, A: *const cuDoubleComplex, lda: i64, x: *mut cuDoubleComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8497,7 +8497,7 @@ pub unsafe fn cublasZtbsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasZtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZtbsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, k: i64, A: *const cuDoubleComplex, lda: i64, x: *mut cuDoubleComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8530,7 +8530,7 @@ pub unsafe fn cublasZtpmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasZtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZtpmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, AP: *const cuDoubleComplex, x: *mut cuDoubleComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8563,7 +8563,7 @@ pub unsafe fn cublasZtpsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasZtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZtpsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, AP: *const cuDoubleComplex, x: *mut cuDoubleComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8612,7 +8612,7 @@ pub unsafe fn cublasZtrmm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasZtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZtrmm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *const cuDoubleComplex, ldb: i64, C: *mut cuDoubleComplex, ldc: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8645,7 +8645,7 @@ pub unsafe fn cublasZtrmv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasZtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZtrmv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, A: *const cuDoubleComplex, lda: i64, x: *mut cuDoubleComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8678,7 +8678,7 @@ pub unsafe fn cublasZtrsmBatched(handle: cublasHandle_t, side: cublasSideMode_t,
         cublasZtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZtrsmBatched_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const cuDoubleComplex, A: *const *const cuDoubleComplex, lda: i64, B: *const *mut cuDoubleComplex, ldb: i64, batchCount: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8711,7 +8711,7 @@ pub unsafe fn cublasZtrsm_v2(handle: cublasHandle_t, side: cublasSideMode_t, upl
         cublasZtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZtrsm_v2_64(handle: cublasHandle_t, side: cublasSideMode_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, m: i64, n: i64, alpha: *const cuDoubleComplex, A: *const cuDoubleComplex, lda: i64, B: *mut cuDoubleComplex, ldb: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8744,7 +8744,7 @@ pub unsafe fn cublasZtrsv_v2(handle: cublasHandle_t, uplo: cublasFillMode_t, tra
         cublasZtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasZtrsv_v2_64(handle: cublasHandle_t, uplo: cublasFillMode_t, trans: cublasOperation_t, diag: cublasDiagType_t, n: i64, A: *const cuDoubleComplex, lda: i64, x: *mut cuDoubleComplex, incx: i64) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {

--- a/src/cublaslt/sys/mod.rs
+++ b/src/cublaslt/sys/mod.rs
@@ -14,10 +14,7 @@ fn load<F: Copy>(name: &str) -> F {
 pub use self::cudaDataType_t as cudaDataType;
 pub use self::libraryPropertyType_t as libraryPropertyType;
 pub type FILE = _IO_FILE;
-pub type _IO_lock_t = ::core::ffi::c_void;
-pub type __off64_t = ::core::ffi::c_long;
-pub type __off_t = ::core::ffi::c_long;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cublasLtEmulationDesc_t = *mut cublasLtEmulationDescOpaque_t;
 pub type cublasLtHandle_t = *mut cublasLtContext;
 pub type cublasLtLoggerCallback_t = ::core::option::Option<unsafe extern "C" fn(logLevel: ::core::ffi::c_int, functionName: *const ::core::ffi::c_char, message: *const ::core::ffi::c_char)>;
@@ -60,7 +57,7 @@ pub enum cublasComputeType_t {
     CUBLAS_COMPUTE_32I = 72,
     CUBLAS_COMPUTE_32I_PEDANTIC = 73,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasComputeType_t {
@@ -92,7 +89,7 @@ pub enum cublasLtBatchMode_t {
     CUBLASLT_BATCH_MODE_STRIDED = 0,
     CUBLASLT_BATCH_MODE_POINTER_ARRAY = 1,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtBatchMode_t {
@@ -100,7 +97,7 @@ pub enum cublasLtBatchMode_t {
     CUBLASLT_BATCH_MODE_POINTER_ARRAY = 1,
     CUBLASLT_BATCH_MODE_GROUPED = 2,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtClusterShape_t {
@@ -157,7 +154,7 @@ pub enum cublasLtClusterShape_t {
     CUBLASLT_CLUSTER_SHAPE_1x15x1 = 51,
     CUBLASLT_CLUSTER_SHAPE_END = 52,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtEmulationDescAttributes_t {
@@ -187,7 +184,7 @@ pub enum cublasLtEpilogue_t {
     CUBLASLT_EPILOGUE_BGRADA = 256,
     CUBLASLT_EPILOGUE_BGRADB = 512,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtEpilogue_t {
@@ -208,7 +205,7 @@ pub enum cublasLtEpilogue_t {
     CUBLASLT_EPILOGUE_BGRADA = 256,
     CUBLASLT_EPILOGUE_BGRADB = 512,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtIntegerWidth_t {
@@ -338,7 +335,7 @@ pub enum cublasLtMatmulAlgoCapAttributes_t {
     CUBLASLT_ALGO_CAP_POINTER_ARRAY_BATCH_SUPPORT = 21,
     CUBLASLT_ALGO_CAP_FLOATING_POINT_EMULATION_SUPPORT = 22,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatmulAlgoCapAttributes_t {
@@ -376,7 +373,7 @@ pub enum cublasLtMatmulAlgoConfigAttributes_t {
     CUBLASLT_ALGO_CONFIG_CUSTOM_OPTION = 5,
     CUBLASLT_ALGO_CONFIG_STAGES_ID = 6,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatmulAlgoConfigAttributes_t {
@@ -572,7 +569,7 @@ pub enum cublasLtMatmulDescAttributes_t {
     CUBLASLT_MATMUL_DESC_D_OUT_SCALE_MODE = 37,
     CUBLASLT_MATMUL_DESC_EMULATION_DESCRIPTOR = 38,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatmulDescAttributes_t {
@@ -612,7 +609,7 @@ pub enum cublasLtMatmulDescAttributes_t {
     CUBLASLT_MATMUL_DESC_ALPHA_BATCH_STRIDE = 39,
     CUBLASLT_MATMUL_DESC_BETA_BATCH_STRIDE = 40,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatmulInnerShape_t {
@@ -644,7 +641,7 @@ pub enum cublasLtMatmulMatrixScale_t {
     CUBLASLT_MATMUL_MATRIX_SCALE_BLK128x128_32F = 5,
     CUBLASLT_MATMUL_MATRIX_SCALE_END = 6,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatmulMatrixScale_t {
@@ -690,7 +687,7 @@ pub enum cublasLtMatmulPreferenceAttributes_t {
     CUBLASLT_MATMUL_PREF_MAX_WAVES_COUNT = 9,
     CUBLASLT_MATMUL_PREF_IMPL_MASK = 12,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatmulPreferenceAttributes_t {
@@ -718,7 +715,7 @@ pub enum cublasLtMatmulSearch_t {
     CUBLASLT_SEARCH_RESERVED_04 = 4,
     CUBLASLT_SEARCH_RESERVED_05 = 5,
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatmulSearch_t {
@@ -896,7 +893,7 @@ pub enum cublasLtMatmulStages_t {
     CUBLASLT_MATMUL_STAGES_256xAUTO = 37,
     CUBLASLT_MATMUL_STAGES_END = 38,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatmulStages_t {
@@ -1696,7 +1693,7 @@ pub enum cublasLtMatmulTile_t {
     CUBLASLT_MATMUL_TILE_768x80 = 630,
     CUBLASLT_MATMUL_TILE_END = 631,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatmulTile_t {
@@ -2364,7 +2361,7 @@ pub enum cublasLtMatrixLayoutAttribute_t {
     CUBLASLT_MATRIX_LAYOUT_PLANE_OFFSET = 7,
     CUBLASLT_MATRIX_LAYOUT_BATCH_MODE = 8,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtMatrixLayoutAttribute_t {
@@ -2411,7 +2408,7 @@ pub enum cublasLtPointerModeMask_t {
     CUBLASLT_POINTER_MODE_MASK_ALPHA_DEVICE_VECTOR_BETA_ZERO = 8,
     CUBLASLT_POINTER_MODE_MASK_ALPHA_DEVICE_VECTOR_BETA_HOST = 16,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cublasLtPointerModeMask_t {
@@ -2521,7 +2518,7 @@ pub enum cudaDataType_t {
     CUDA_R_8F_E4M3 = 28,
     CUDA_R_8F_E5M2 = 29,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDataType_t {
@@ -2575,57 +2572,14 @@ pub struct CUstream_st {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct _IO_FILE {
-    pub _flags: ::core::ffi::c_int,
-    pub _IO_read_ptr: *mut ::core::ffi::c_char,
-    pub _IO_read_end: *mut ::core::ffi::c_char,
-    pub _IO_read_base: *mut ::core::ffi::c_char,
-    pub _IO_write_base: *mut ::core::ffi::c_char,
-    pub _IO_write_ptr: *mut ::core::ffi::c_char,
-    pub _IO_write_end: *mut ::core::ffi::c_char,
-    pub _IO_buf_base: *mut ::core::ffi::c_char,
-    pub _IO_buf_end: *mut ::core::ffi::c_char,
-    pub _IO_save_base: *mut ::core::ffi::c_char,
-    pub _IO_backup_base: *mut ::core::ffi::c_char,
-    pub _IO_save_end: *mut ::core::ffi::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::core::ffi::c_int,
-    pub _flags2: ::core::ffi::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::core::ffi::c_ushort,
-    pub _vtable_offset: ::core::ffi::c_schar,
-    pub _shortbuf: [::core::ffi::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::core::ffi::c_void,
-    pub __pad5: usize,
-    pub _mode: ::core::ffi::c_int,
-    pub _unused2: [::core::ffi::c_char; 20usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
-    _unused: [u8; 0],
+    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cublasLtContext {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cublasLtEmulationDescOpaque_t {
@@ -2654,7 +2608,7 @@ pub struct cublasLtMatmulDescOpaque_t {
 pub struct cublasLtMatmulDescOpaque_t {
     pub data: [u64; 23usize],
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cublasLtMatmulDescOpaque_t {
@@ -2681,7 +2635,7 @@ pub struct cublasLtMatmulPreferenceOpaque_t {
 pub struct cublasLtMatmulPreferenceOpaque_t {
     pub data: [u64; 8usize],
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cublasLtMatmulPreferenceOpaque_t {
@@ -2693,7 +2647,7 @@ pub struct cublasLtMatmulPreferenceOpaque_t {
 pub struct cublasLtMatrixLayoutOpaque_t {
     pub data: [u64; 8usize],
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cublasLtMatrixLayoutOpaque_t {
@@ -2704,7 +2658,7 @@ pub struct cublasLtMatrixLayoutOpaque_t {
 pub struct cublasLtMatrixTransformDescOpaque_t {
     pub data: [u64; 8usize],
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl cudaDataType_t {
     pub const CUDA_R_8F_UE4M3: cudaDataType_t = cudaDataType_t::CUDA_R_8F_E4M3;
 }
@@ -2740,7 +2694,7 @@ pub unsafe fn cublasLtDestroy(lightHandle: cublasLtHandle_t) -> cublasStatus_t {
         cublasLtDestroy(lightHandle)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasLtEmulationDescCreate(emulationDesc: *mut cublasLtEmulationDesc_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2757,7 +2711,7 @@ pub unsafe fn cublasLtEmulationDescCreate(emulationDesc: *mut cublasLtEmulationD
         cublasLtEmulationDescCreate(emulationDesc)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasLtEmulationDescDestroy(emulationDesc: cublasLtEmulationDesc_t) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2774,7 +2728,7 @@ pub unsafe fn cublasLtEmulationDescDestroy(emulationDesc: cublasLtEmulationDesc_
         cublasLtEmulationDescDestroy(emulationDesc)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasLtEmulationDescGetAttribute(emulationDesc: cublasLtEmulationDesc_t, attr: cublasLtEmulationDescAttributes_t, buf: *mut ::core::ffi::c_void, sizeInBytes: usize, sizeWritten: *mut usize) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2791,7 +2745,7 @@ pub unsafe fn cublasLtEmulationDescGetAttribute(emulationDesc: cublasLtEmulation
         cublasLtEmulationDescGetAttribute(emulationDesc, attr, buf, sizeInBytes, sizeWritten)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasLtEmulationDescInit_internal(emulationDesc: cublasLtEmulationDesc_t, size: usize) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2808,7 +2762,7 @@ pub unsafe fn cublasLtEmulationDescInit_internal(emulationDesc: cublasLtEmulatio
         cublasLtEmulationDescInit_internal(emulationDesc, size)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasLtEmulationDescSetAttribute(emulationDesc: cublasLtEmulationDesc_t, attr: cublasLtEmulationDescAttributes_t, buf: *const ::core::ffi::c_void, sizeInBytes: usize) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2905,7 +2859,7 @@ pub unsafe fn cublasLtGetVersion() -> usize {
         cublasLtGetVersion()
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasLtGroupedMatrixLayoutCreate(matLayout: *mut cublasLtMatrixLayout_t, type_: cudaDataType, groupCount: ::core::ffi::c_int, rows_array: *const ::core::ffi::c_void, cols_array: *const ::core::ffi::c_void, ld_array: *const ::core::ffi::c_void) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2922,7 +2876,7 @@ pub unsafe fn cublasLtGroupedMatrixLayoutCreate(matLayout: *mut cublasLtMatrixLa
         cublasLtGroupedMatrixLayoutCreate(matLayout, type_, groupCount, rows_array, cols_array, ld_array)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasLtGroupedMatrixLayoutInit_internal(matLayout: cublasLtMatrixLayout_t, size: usize, type_: cudaDataType, groupCount: ::core::ffi::c_int, rows_array: *const ::core::ffi::c_void, cols_array: *const ::core::ffi::c_void, ld_array: *const ::core::ffi::c_void) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2939,7 +2893,7 @@ pub unsafe fn cublasLtGroupedMatrixLayoutInit_internal(matLayout: cublasLtMatrix
         cublasLtGroupedMatrixLayoutInit_internal(matLayout, size, type_, groupCount, rows_array, cols_array, ld_array)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasLtHeuristicsCacheGetCapacity(capacity: *mut usize) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2956,7 +2910,7 @@ pub unsafe fn cublasLtHeuristicsCacheGetCapacity(capacity: *mut usize) -> cublas
         cublasLtHeuristicsCacheGetCapacity(capacity)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cublasLtHeuristicsCacheSetCapacity(capacity: usize) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3117,6 +3071,23 @@ pub unsafe fn cublasLtMatmulAlgoCheck(lightHandle: cublasLtHandle_t, operationDe
         cublasLtMatmulAlgoCheck(lightHandle, operationDesc, Adesc, Bdesc, Cdesc, Ddesc, algo, result)
     }
 }
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cublasLtMatmulAlgoCheckForStream(lightHandle: cublasLtHandle_t, operationDesc: cublasLtMatmulDesc_t, Adesc: cublasLtMatrixLayout_t, Bdesc: cublasLtMatrixLayout_t, Cdesc: cublasLtMatrixLayout_t, Ddesc: cublasLtMatrixLayout_t, algo: *const cublasLtMatmulAlgo_t, result: *mut cublasLtMatmulHeuristicResult_t, stream: cudaStream_t) -> cublasStatus_t {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(cublasLtHandle_t, cublasLtMatmulDesc_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, *const cublasLtMatmulAlgo_t, *mut cublasLtMatmulHeuristicResult_t, cudaStream_t) -> cublasStatus_t;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cublasLtMatmulAlgoCheckForStream") });
+        _f(lightHandle, operationDesc, Adesc, Bdesc, Cdesc, Ddesc, algo, result, stream)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cublasLtMatmulAlgoCheckForStream(lightHandle: cublasLtHandle_t, operationDesc: cublasLtMatmulDesc_t, Adesc: cublasLtMatrixLayout_t, Bdesc: cublasLtMatrixLayout_t, Cdesc: cublasLtMatrixLayout_t, Ddesc: cublasLtMatrixLayout_t, algo: *const cublasLtMatmulAlgo_t, result: *mut cublasLtMatmulHeuristicResult_t, stream: cudaStream_t) -> cublasStatus_t;
+        }
+        cublasLtMatmulAlgoCheckForStream(lightHandle, operationDesc, Adesc, Bdesc, Cdesc, Ddesc, algo, result, stream)
+    }
+}
 pub unsafe fn cublasLtMatmulAlgoConfigGetAttribute(algo: *const cublasLtMatmulAlgo_t, attr: cublasLtMatmulAlgoConfigAttributes_t, buf: *mut ::core::ffi::c_void, sizeInBytes: usize, sizeWritten: *mut usize) -> cublasStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3163,6 +3134,23 @@ pub unsafe fn cublasLtMatmulAlgoGetHeuristic(lightHandle: cublasLtHandle_t, oper
             fn cublasLtMatmulAlgoGetHeuristic(lightHandle: cublasLtHandle_t, operationDesc: cublasLtMatmulDesc_t, Adesc: cublasLtMatrixLayout_t, Bdesc: cublasLtMatrixLayout_t, Cdesc: cublasLtMatrixLayout_t, Ddesc: cublasLtMatrixLayout_t, preference: cublasLtMatmulPreference_t, requestedAlgoCount: ::core::ffi::c_int, heuristicResultsArray: *mut cublasLtMatmulHeuristicResult_t, returnAlgoCount: *mut ::core::ffi::c_int) -> cublasStatus_t;
         }
         cublasLtMatmulAlgoGetHeuristic(lightHandle, operationDesc, Adesc, Bdesc, Cdesc, Ddesc, preference, requestedAlgoCount, heuristicResultsArray, returnAlgoCount)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cublasLtMatmulAlgoGetHeuristicForStream(lightHandle: cublasLtHandle_t, operationDesc: cublasLtMatmulDesc_t, Adesc: cublasLtMatrixLayout_t, Bdesc: cublasLtMatrixLayout_t, Cdesc: cublasLtMatrixLayout_t, Ddesc: cublasLtMatrixLayout_t, preference: cublasLtMatmulPreference_t, requestedAlgoCount: ::core::ffi::c_int, heuristicResultsArray: *mut cublasLtMatmulHeuristicResult_t, returnAlgoCount: *mut ::core::ffi::c_int, stream: cudaStream_t) -> cublasStatus_t {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(cublasLtHandle_t, cublasLtMatmulDesc_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatmulPreference_t, ::core::ffi::c_int, *mut cublasLtMatmulHeuristicResult_t, *mut ::core::ffi::c_int, cudaStream_t) -> cublasStatus_t;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cublasLtMatmulAlgoGetHeuristicForStream") });
+        _f(lightHandle, operationDesc, Adesc, Bdesc, Cdesc, Ddesc, preference, requestedAlgoCount, heuristicResultsArray, returnAlgoCount, stream)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cublasLtMatmulAlgoGetHeuristicForStream(lightHandle: cublasLtHandle_t, operationDesc: cublasLtMatmulDesc_t, Adesc: cublasLtMatrixLayout_t, Bdesc: cublasLtMatrixLayout_t, Cdesc: cublasLtMatrixLayout_t, Ddesc: cublasLtMatrixLayout_t, preference: cublasLtMatmulPreference_t, requestedAlgoCount: ::core::ffi::c_int, heuristicResultsArray: *mut cublasLtMatmulHeuristicResult_t, returnAlgoCount: *mut ::core::ffi::c_int, stream: cudaStream_t) -> cublasStatus_t;
+        }
+        cublasLtMatmulAlgoGetHeuristicForStream(lightHandle, operationDesc, Adesc, Bdesc, Cdesc, Ddesc, preference, requestedAlgoCount, heuristicResultsArray, returnAlgoCount, stream)
     }
 }
 pub unsafe fn cublasLtMatmulAlgoGetIds(lightHandle: cublasLtHandle_t, computeType: cublasComputeType_t, scaleType: cudaDataType_t, Atype: cudaDataType_t, Btype: cudaDataType_t, Ctype: cudaDataType_t, Dtype: cudaDataType_t, requestedAlgoCount: ::core::ffi::c_int, algoIdsArray: *mut ::core::ffi::c_int, returnAlgoCount: *mut ::core::ffi::c_int) -> cublasStatus_t {

--- a/src/cufft/sys/mod.rs
+++ b/src/cufft/sys/mod.rs
@@ -12,7 +12,7 @@ fn load<F: Copy>(name: &str) -> F {
     unsafe { *culib().get::<F>(name.as_bytes()).unwrap_or_else(|e| panic!("Missing symbol {name}: {e}")) }
 }
 pub use self::cufftCompatibility_t as cufftCompatibility;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::cufftProperty_t as cufftProperty;
 pub use self::cufftResult_t as cufftResult;
 pub use self::cufftType_t as cufftType;
@@ -37,7 +37,7 @@ pub enum cufftCompatibility_t {
 pub enum cufftProperty_t {
     NVFFT_PLAN_PROPERTY_INT64_PATIENT_JIT = 1,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cufftProperty_t {
@@ -66,7 +66,7 @@ pub enum cufftResult_t {
     CUFFT_LICENSE_ERROR = 15,
     CUFFT_NOT_SUPPORTED = 16,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cufftResult_t {
@@ -317,7 +317,7 @@ pub unsafe fn cufftExecZ2Z(plan: cufftHandle, idata: *mut cufftDoubleComplex, od
         cufftExecZ2Z(plan, idata, odata, direction)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cufftGetPlanPropertyInt64(plan: cufftHandle, property: cufftProperty, returnPtrValue: *mut ::core::ffi::c_longlong) -> cufftResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -606,7 +606,7 @@ pub unsafe fn cufftPlanMany(plan: *mut cufftHandle, rank: ::core::ffi::c_int, n:
         cufftPlanMany(plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type_, batch)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cufftResetPlanProperty(plan: cufftHandle, property: cufftProperty) -> cufftResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -639,7 +639,7 @@ pub unsafe fn cufftSetAutoAllocation(plan: cufftHandle, autoAllocate: ::core::ff
         cufftSetAutoAllocation(plan, autoAllocate)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cufftSetPlanPropertyInt64(plan: cufftHandle, property: cufftProperty, inputValueInt: ::core::ffi::c_longlong) -> cufftResult {
     #[cfg(feature = "dynamic-loading")]
     {

--- a/src/cufile/sys/mod.rs
+++ b/src/cufile/sys/mod.rs
@@ -12,52 +12,52 @@ fn load<F: Copy>(name: &str) -> F {
     unsafe { *culib().get::<F>(name.as_bytes()).unwrap_or_else(|e| panic!("Missing symbol {name}: {e}")) }
 }
 pub use self::cudaError_enum as CUresult;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::cufileBatchMode as CUfileBatchMode_t;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUFILEStatus_enum as CUfileStatus_t;
 pub use self::CUfileDriverControlFlags as CUfileDriverControlFlags_t;
 pub use self::CUfileDriverStatusFlags as CUfileDriverStatusFlags_t;
 pub use self::CUfileFeatureFlags as CUfileFeatureFlags_t;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUfileOpcode as CUfileOpcode_t;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUfileP2PFlags as CUfileP2PFlags_t;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUfileBatchHandle_t = *mut ::core::ffi::c_void;
 pub type CUfileDrvProps_t = CUfileDrvProps;
 pub type CUfileError_t = CUfileError;
 pub type CUfileFSOps_t = CUfileFSOps;
 pub type CUfileHandle_t = *mut ::core::ffi::c_void;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUfileIOEvents_t = CUfileIOEvents;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUfileIOParams_t = CUfileIOParams;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUfileOpCounter_t = CUfileOpCounter;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUfilePerGpuStats_t = CUfilePerGpuStats;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUfileStatsLevel1_t = CUfileStatsLevel1;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUfileStatsLevel2_t = CUfileStatsLevel2;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUfileStatsLevel3_t = CUfileStatsLevel3;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUstream = *mut CUstream_st;
 pub type __loff_t = __off64_t;
 pub type __off64_t = ::core::ffi::c_long;
 pub type __off_t = ::core::ffi::c_long;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type __syscall_slong_t = ::core::ffi::c_long;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type __time_t = ::core::ffi::c_long;
 pub type cufileRDMAInfo_t = cufileRDMAInfo;
 pub type loff_t = __loff_t;
 pub type off_t = __off_t;
 pub type sa_family_t = ::core::ffi::c_ushort;
 pub type sockaddr_t = sockaddr;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUFILEStatus_enum {
@@ -76,7 +76,7 @@ pub enum CUFileArrayConfigParameter_t {
     CUFILE_PARAM_POSIX_POOL_SLAB_SIZE_KB = 0,
     CUFILE_PARAM_POSIX_POOL_SLAB_COUNT = 1,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUFileArrayConfigParameter_t {
@@ -85,7 +85,7 @@ pub enum CUFileArrayConfigParameter_t {
     CUFILE_PARAM_GPU_BOUNCE_BUFFER_SLAB_SIZE_KB = 2,
     CUFILE_PARAM_GPU_BOUNCE_BUFFER_SLAB_COUNT = 3,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUFileBoolConfigParameter_t {
@@ -102,7 +102,7 @@ pub enum CUFileBoolConfigParameter_t {
     CUFILE_PARAM_SKIP_TOPOLOGY_DETECTION = 10,
     CUFILE_PARAM_STREAM_MEMOPS_BYPASS = 11,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUFileSizeTConfigParameter_t {
@@ -119,7 +119,7 @@ pub enum CUFileSizeTConfigParameter_t {
     CUFILE_PARAM_POLLTHRESHOLD_SIZE_KB = 10,
     CUFILE_PARAM_PROPERTIES_BATCH_IO_TIMEOUT_MS = 11,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUFileStringConfigParameter_t {
@@ -134,7 +134,7 @@ pub enum CUfileDriverControlFlags {
     CU_FILE_USE_POLL_MODE = 0,
     CU_FILE_ALLOW_COMPAT_MODE = 1,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUfileDriverControlFlags {
@@ -205,7 +205,7 @@ pub enum CUfileDriverStatusFlags {
     CU_FILE_NVME_P2P_SUPPORTED = 11,
     CU_FILE_SCATEFS_SUPPORTED = 12,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUfileDriverStatusFlags {
@@ -241,7 +241,7 @@ pub enum CUfileFeatureFlags {
     CU_FILE_STREAMS_SUPPORTED = 2,
     CU_FILE_PARALLEL_IO_SUPPORTED = 3,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUfileFeatureFlags {
@@ -461,7 +461,7 @@ pub enum CUfileOpError {
     CU_FILE_ASYNC_NOT_SUPPORTED = 5038,
     CU_FILE_IO_MAX_ERROR = 5039,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUfileOpError {
@@ -515,14 +515,14 @@ pub enum CUfileOpError {
     CU_FILE_BATCH_NOCOMPAT_ERROR = 5049,
     CU_FILE_IO_MAX_ERROR = 5050,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUfileOpcode {
     CUFILE_READ = 0,
     CUFILE_WRITE = 1,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUfileP2PFlags {
@@ -1526,7 +1526,115 @@ pub enum cudaError_enum {
     CUDA_ERROR_STREAM_DETACHED = 917,
     CUDA_ERROR_UNKNOWN = 999,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cudaError_enum {
+    CUDA_SUCCESS = 0,
+    CUDA_ERROR_INVALID_VALUE = 1,
+    CUDA_ERROR_OUT_OF_MEMORY = 2,
+    CUDA_ERROR_NOT_INITIALIZED = 3,
+    CUDA_ERROR_DEINITIALIZED = 4,
+    CUDA_ERROR_PROFILER_DISABLED = 5,
+    CUDA_ERROR_PROFILER_NOT_INITIALIZED = 6,
+    CUDA_ERROR_PROFILER_ALREADY_STARTED = 7,
+    CUDA_ERROR_PROFILER_ALREADY_STOPPED = 8,
+    CUDA_ERROR_STUB_LIBRARY = 34,
+    CUDA_ERROR_CALL_REQUIRES_NEWER_DRIVER = 36,
+    CUDA_ERROR_DEVICE_UNAVAILABLE = 46,
+    CUDA_ERROR_NO_DEVICE = 100,
+    CUDA_ERROR_INVALID_DEVICE = 101,
+    CUDA_ERROR_DEVICE_NOT_LICENSED = 102,
+    CUDA_ERROR_INVALID_IMAGE = 200,
+    CUDA_ERROR_INVALID_CONTEXT = 201,
+    CUDA_ERROR_CONTEXT_ALREADY_CURRENT = 202,
+    CUDA_ERROR_MAP_FAILED = 205,
+    CUDA_ERROR_UNMAP_FAILED = 206,
+    CUDA_ERROR_ARRAY_IS_MAPPED = 207,
+    CUDA_ERROR_ALREADY_MAPPED = 208,
+    CUDA_ERROR_NO_BINARY_FOR_GPU = 209,
+    CUDA_ERROR_ALREADY_ACQUIRED = 210,
+    CUDA_ERROR_NOT_MAPPED = 211,
+    CUDA_ERROR_NOT_MAPPED_AS_ARRAY = 212,
+    CUDA_ERROR_NOT_MAPPED_AS_POINTER = 213,
+    CUDA_ERROR_ECC_UNCORRECTABLE = 214,
+    CUDA_ERROR_UNSUPPORTED_LIMIT = 215,
+    CUDA_ERROR_CONTEXT_ALREADY_IN_USE = 216,
+    CUDA_ERROR_PEER_ACCESS_UNSUPPORTED = 217,
+    CUDA_ERROR_INVALID_PTX = 218,
+    CUDA_ERROR_INVALID_GRAPHICS_CONTEXT = 219,
+    CUDA_ERROR_NVLINK_UNCORRECTABLE = 220,
+    CUDA_ERROR_JIT_COMPILER_NOT_FOUND = 221,
+    CUDA_ERROR_UNSUPPORTED_PTX_VERSION = 222,
+    CUDA_ERROR_JIT_COMPILATION_DISABLED = 223,
+    CUDA_ERROR_UNSUPPORTED_EXEC_AFFINITY = 224,
+    CUDA_ERROR_UNSUPPORTED_DEVSIDE_SYNC = 225,
+    CUDA_ERROR_CONTAINED = 226,
+    CUDA_ERROR_INVALID_SOURCE = 300,
+    CUDA_ERROR_FILE_NOT_FOUND = 301,
+    CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND = 302,
+    CUDA_ERROR_SHARED_OBJECT_INIT_FAILED = 303,
+    CUDA_ERROR_OPERATING_SYSTEM = 304,
+    CUDA_ERROR_INVALID_HANDLE = 400,
+    CUDA_ERROR_ILLEGAL_STATE = 401,
+    CUDA_ERROR_LOSSY_QUERY = 402,
+    CUDA_ERROR_NOT_FOUND = 500,
+    CUDA_ERROR_NOT_READY = 600,
+    CUDA_ERROR_ILLEGAL_ADDRESS = 700,
+    CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES = 701,
+    CUDA_ERROR_LAUNCH_TIMEOUT = 702,
+    CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING = 703,
+    CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED = 704,
+    CUDA_ERROR_PEER_ACCESS_NOT_ENABLED = 705,
+    CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE = 708,
+    CUDA_ERROR_CONTEXT_IS_DESTROYED = 709,
+    CUDA_ERROR_ASSERT = 710,
+    CUDA_ERROR_TOO_MANY_PEERS = 711,
+    CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED = 712,
+    CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED = 713,
+    CUDA_ERROR_HARDWARE_STACK_ERROR = 714,
+    CUDA_ERROR_ILLEGAL_INSTRUCTION = 715,
+    CUDA_ERROR_MISALIGNED_ADDRESS = 716,
+    CUDA_ERROR_INVALID_ADDRESS_SPACE = 717,
+    CUDA_ERROR_INVALID_PC = 718,
+    CUDA_ERROR_LAUNCH_FAILED = 719,
+    CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE = 720,
+    CUDA_ERROR_TENSOR_MEMORY_LEAK = 721,
+    CUDA_ERROR_NOT_PERMITTED = 800,
+    CUDA_ERROR_NOT_SUPPORTED = 801,
+    CUDA_ERROR_SYSTEM_NOT_READY = 802,
+    CUDA_ERROR_SYSTEM_DRIVER_MISMATCH = 803,
+    CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE = 804,
+    CUDA_ERROR_MPS_CONNECTION_FAILED = 805,
+    CUDA_ERROR_MPS_RPC_FAILURE = 806,
+    CUDA_ERROR_MPS_SERVER_NOT_READY = 807,
+    CUDA_ERROR_MPS_MAX_CLIENTS_REACHED = 808,
+    CUDA_ERROR_MPS_MAX_CONNECTIONS_REACHED = 809,
+    CUDA_ERROR_MPS_CLIENT_TERMINATED = 810,
+    CUDA_ERROR_CDP_NOT_SUPPORTED = 811,
+    CUDA_ERROR_CDP_VERSION_MISMATCH = 812,
+    CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED = 900,
+    CUDA_ERROR_STREAM_CAPTURE_INVALIDATED = 901,
+    CUDA_ERROR_STREAM_CAPTURE_MERGE = 902,
+    CUDA_ERROR_STREAM_CAPTURE_UNMATCHED = 903,
+    CUDA_ERROR_STREAM_CAPTURE_UNJOINED = 904,
+    CUDA_ERROR_STREAM_CAPTURE_ISOLATION = 905,
+    CUDA_ERROR_STREAM_CAPTURE_IMPLICIT = 906,
+    CUDA_ERROR_CAPTURED_EVENT = 907,
+    CUDA_ERROR_STREAM_CAPTURE_WRONG_THREAD = 908,
+    CUDA_ERROR_TIMEOUT = 909,
+    CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE = 910,
+    CUDA_ERROR_EXTERNAL_DEVICE = 911,
+    CUDA_ERROR_INVALID_CLUSTER_SIZE = 912,
+    CUDA_ERROR_FUNCTION_NOT_LOADED = 913,
+    CUDA_ERROR_INVALID_RESOURCE_TYPE = 914,
+    CUDA_ERROR_INVALID_RESOURCE_CONFIGURATION = 915,
+    CUDA_ERROR_KEY_ROTATION = 916,
+    CUDA_ERROR_STREAM_DETACHED = 917,
+    CUDA_ERROR_GRAPH_RECAPTURE_FAILURE = 918,
+    CUDA_ERROR_UNKNOWN = 999,
+}
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cufileBatchMode {
@@ -1550,7 +1658,7 @@ pub struct CUfileDrvProps {
     pub max_device_pinned_mem_size: ::core::ffi::c_uint,
     pub max_batch_io_timeout_msecs: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUfileDrvProps {
@@ -1588,7 +1696,7 @@ pub struct CUfileFSOps {
     pub read: ::core::option::Option<unsafe extern "C" fn(handle: *mut ::core::ffi::c_void, arg1: *mut ::core::ffi::c_char, arg2: usize, arg3: loff_t, arg4: *mut cufileRDMAInfo_t) -> isize>,
     pub write: ::core::option::Option<unsafe extern "C" fn(handle: *mut ::core::ffi::c_void, arg1: *const ::core::ffi::c_char, arg2: usize, arg3: loff_t, arg4: *mut cufileRDMAInfo_t) -> isize>,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUfileFSOps {
@@ -1598,7 +1706,7 @@ pub struct CUfileFSOps {
     pub read: ::core::option::Option<unsafe extern "C" fn(handle: *const ::core::ffi::c_void, arg1: *mut ::core::ffi::c_char, arg2: usize, arg3: loff_t, arg4: *const cufileRDMAInfo_t) -> isize>,
     pub write: ::core::option::Option<unsafe extern "C" fn(handle: *const ::core::ffi::c_void, arg1: *const ::core::ffi::c_char, arg2: usize, arg3: loff_t, arg4: *const cufileRDMAInfo_t) -> isize>,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUfileIOEvents {
@@ -1606,7 +1714,7 @@ pub struct CUfileIOEvents {
     pub status: CUfileStatus_t,
     pub ret: usize,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUfileIOParams {
@@ -1616,7 +1724,7 @@ pub struct CUfileIOParams {
     pub opcode: CUfileOpcode_t,
     pub cookie: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUfileIOParams__bindgen_ty_1__bindgen_ty_1 {
@@ -1625,14 +1733,14 @@ pub struct CUfileIOParams__bindgen_ty_1__bindgen_ty_1 {
     pub devPtr_offset: off_t,
     pub size: usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUfileOpCounter {
     pub ok: u64,
     pub err: u64,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUfilePerGpuStats {
@@ -1667,7 +1775,7 @@ pub struct CUfilePerGpuStats {
     pub n_mmap_free: u64,
     pub reg_bytes: u64,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUfileStatsLevel1 {
@@ -1715,7 +1823,7 @@ pub struct CUfileStatsLevel1 {
     pub last_batch_read_bytes: u64,
     pub last_batch_write_bytes: u64,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUfileStatsLevel2 {
@@ -1723,7 +1831,7 @@ pub struct CUfileStatsLevel2 {
     pub read_size_kb_hist: [u64; 32usize],
     pub write_size_kb_hist: [u64; 32usize],
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUfileStatsLevel3 {
@@ -1731,7 +1839,7 @@ pub struct CUfileStatsLevel3 {
     pub num_gpus: u32,
     pub per_gpu_stats: [CUfilePerGpuStats_t; 16usize],
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUstream_st {
@@ -1750,7 +1858,7 @@ pub struct sockaddr {
     pub sa_family: sa_family_t,
     pub sa_data: [::core::ffi::c_char; 14usize],
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct timespec {
@@ -1763,13 +1871,13 @@ pub union CUfileDescr_t__bindgen_ty_1 {
     pub fd: ::core::ffi::c_int,
     pub handle: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUfileIOParams__bindgen_ty_1 {
     pub batch: CUfileIOParams__bindgen_ty_1__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileBatchIOCancel(batch_idp: CUfileBatchHandle_t) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1786,7 +1894,7 @@ pub unsafe fn cuFileBatchIOCancel(batch_idp: CUfileBatchHandle_t) -> CUfileError
         cuFileBatchIOCancel(batch_idp)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileBatchIODestroy(batch_idp: CUfileBatchHandle_t) {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1803,7 +1911,7 @@ pub unsafe fn cuFileBatchIODestroy(batch_idp: CUfileBatchHandle_t) {
         cuFileBatchIODestroy(batch_idp)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileBatchIOGetStatus(batch_idp: CUfileBatchHandle_t, min_nr: ::core::ffi::c_uint, nr: *mut ::core::ffi::c_uint, iocbp: *mut CUfileIOEvents_t, timeout: *mut timespec) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1820,7 +1928,7 @@ pub unsafe fn cuFileBatchIOGetStatus(batch_idp: CUfileBatchHandle_t, min_nr: ::c
         cuFileBatchIOGetStatus(batch_idp, min_nr, nr, iocbp, timeout)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileBatchIOSetUp(batch_idp: *mut CUfileBatchHandle_t, nr: ::core::ffi::c_uint) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1837,7 +1945,7 @@ pub unsafe fn cuFileBatchIOSetUp(batch_idp: *mut CUfileBatchHandle_t, nr: ::core
         cuFileBatchIOSetUp(batch_idp, nr)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileBatchIOSubmit(batch_idp: CUfileBatchHandle_t, nr: ::core::ffi::c_uint, iocbp: *mut CUfileIOParams_t, flags: ::core::ffi::c_uint) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1871,7 +1979,7 @@ pub unsafe fn cuFileBufDeregister(devPtr_base: *const ::core::ffi::c_void) -> CU
         cuFileBufDeregister(devPtr_base)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileBufDeregister(bufPtr_base: *const ::core::ffi::c_void) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1905,7 +2013,7 @@ pub unsafe fn cuFileBufRegister(devPtr_base: *const ::core::ffi::c_void, length:
         cuFileBufRegister(devPtr_base, length, flags)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileBufRegister(bufPtr_base: *const ::core::ffi::c_void, length: usize, flags: ::core::ffi::c_int) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1938,7 +2046,7 @@ pub unsafe fn cuFileDriverClose() -> CUfileError_t {
         cuFileDriverClose()
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileDriverClose_v2() -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1955,7 +2063,7 @@ pub unsafe fn cuFileDriverClose_v2() -> CUfileError_t {
         cuFileDriverClose_v2()
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileDriverGetP2PFlags(status_flag: CUfileDriverStatusFlags_t, p2p_flags: *mut CUfileP2PFlags_t) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2052,7 +2160,7 @@ pub unsafe fn cuFileDriverSetMaxPinnedMemSize(max_pinned_size: usize) -> CUfileE
         cuFileDriverSetMaxPinnedMemSize(max_pinned_size)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileDriverSetP2PFlags(status_flag: CUfileDriverStatusFlags_t, p2p_flags: CUfileP2PFlags_t) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2085,7 +2193,7 @@ pub unsafe fn cuFileDriverSetPollMode(poll: bool, poll_threshold_size: usize) ->
         cuFileDriverSetPollMode(poll, poll_threshold_size)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileExportPCIeTopology(filename: *const ::core::ffi::c_char) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2102,7 +2210,7 @@ pub unsafe fn cuFileExportPCIeTopology(filename: *const ::core::ffi::c_char) -> 
         cuFileExportPCIeTopology(filename)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetBARSizeInKB(gpuIndex: ::core::ffi::c_int, barSize: *mut usize) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2119,7 +2227,7 @@ pub unsafe fn cuFileGetBARSizeInKB(gpuIndex: ::core::ffi::c_int, barSize: *mut u
         cuFileGetBARSizeInKB(gpuIndex, barSize)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetParameterBool(param: CUFileBoolConfigParameter_t, value: *mut bool) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2136,7 +2244,7 @@ pub unsafe fn cuFileGetParameterBool(param: CUFileBoolConfigParameter_t, value: 
         cuFileGetParameterBool(param, value)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetParameterGpuBounceBufferSlabArray(size_values: *mut usize, count_values: *mut usize, len: ::core::ffi::c_int) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2153,7 +2261,7 @@ pub unsafe fn cuFileGetParameterGpuBounceBufferSlabArray(size_values: *mut usize
         cuFileGetParameterGpuBounceBufferSlabArray(size_values, count_values, len)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetParameterMinMaxValue(param: CUFileSizeTConfigParameter_t, min_value: *mut usize, max_value: *mut usize) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2170,7 +2278,7 @@ pub unsafe fn cuFileGetParameterMinMaxValue(param: CUFileSizeTConfigParameter_t,
         cuFileGetParameterMinMaxValue(param, min_value, max_value)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetParameterPosixPoolSlabArray(size_values: *mut usize, count_values: *mut usize, len: ::core::ffi::c_int) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2187,7 +2295,7 @@ pub unsafe fn cuFileGetParameterPosixPoolSlabArray(size_values: *mut usize, coun
         cuFileGetParameterPosixPoolSlabArray(size_values, count_values, len)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetParameterSizeT(param: CUFileSizeTConfigParameter_t, value: *mut usize) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2204,7 +2312,7 @@ pub unsafe fn cuFileGetParameterSizeT(param: CUFileSizeTConfigParameter_t, value
         cuFileGetParameterSizeT(param, value)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetParameterString(param: CUFileStringConfigParameter_t, desc_str: *mut ::core::ffi::c_char, len: ::core::ffi::c_int) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2221,7 +2329,7 @@ pub unsafe fn cuFileGetParameterString(param: CUFileStringConfigParameter_t, des
         cuFileGetParameterString(param, desc_str, len)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetStatsL1(stats: *mut CUfileStatsLevel1_t) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2238,7 +2346,7 @@ pub unsafe fn cuFileGetStatsL1(stats: *mut CUfileStatsLevel1_t) -> CUfileError_t
         cuFileGetStatsL1(stats)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetStatsL2(stats: *mut CUfileStatsLevel2_t) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2255,7 +2363,7 @@ pub unsafe fn cuFileGetStatsL2(stats: *mut CUfileStatsLevel2_t) -> CUfileError_t
         cuFileGetStatsL2(stats)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetStatsL3(stats: *mut CUfileStatsLevel3_t) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2272,7 +2380,7 @@ pub unsafe fn cuFileGetStatsL3(stats: *mut CUfileStatsLevel3_t) -> CUfileError_t
         cuFileGetStatsL3(stats)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetStatsLevel(level: *mut ::core::ffi::c_int) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2289,7 +2397,7 @@ pub unsafe fn cuFileGetStatsLevel(level: *mut ::core::ffi::c_int) -> CUfileError
         cuFileGetStatsLevel(level)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileGetVersion(version: *mut ::core::ffi::c_int) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2355,7 +2463,7 @@ pub unsafe fn cuFileRead(fh: CUfileHandle_t, devPtr_base: *mut ::core::ffi::c_vo
         cuFileRead(fh, devPtr_base, size, file_offset, devPtr_offset)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileRead(fh: CUfileHandle_t, bufPtr_base: *mut ::core::ffi::c_void, size: usize, file_offset: off_t, bufPtr_offset: off_t) -> isize {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2372,7 +2480,7 @@ pub unsafe fn cuFileRead(fh: CUfileHandle_t, bufPtr_base: *mut ::core::ffi::c_vo
         cuFileRead(fh, bufPtr_base, size, file_offset, bufPtr_offset)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileReadAsync(fh: CUfileHandle_t, bufPtr_base: *mut ::core::ffi::c_void, size_p: *mut usize, file_offset_p: *mut off_t, bufPtr_offset_p: *mut off_t, bytes_read_p: *mut isize, stream: CUstream) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2389,7 +2497,7 @@ pub unsafe fn cuFileReadAsync(fh: CUfileHandle_t, bufPtr_base: *mut ::core::ffi:
         cuFileReadAsync(fh, bufPtr_base, size_p, file_offset_p, bufPtr_offset_p, bytes_read_p, stream)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileSetParameterBool(param: CUFileBoolConfigParameter_t, value: bool) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2406,7 +2514,7 @@ pub unsafe fn cuFileSetParameterBool(param: CUFileBoolConfigParameter_t, value: 
         cuFileSetParameterBool(param, value)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileSetParameterGpuBounceBufferSlabArray(size_values: *const usize, count_values: *const usize, len: ::core::ffi::c_int) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2423,7 +2531,7 @@ pub unsafe fn cuFileSetParameterGpuBounceBufferSlabArray(size_values: *const usi
         cuFileSetParameterGpuBounceBufferSlabArray(size_values, count_values, len)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileSetParameterPosixPoolSlabArray(size_values: *const usize, count_values: *const usize, len: ::core::ffi::c_int) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2440,7 +2548,7 @@ pub unsafe fn cuFileSetParameterPosixPoolSlabArray(size_values: *const usize, co
         cuFileSetParameterPosixPoolSlabArray(size_values, count_values, len)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileSetParameterSizeT(param: CUFileSizeTConfigParameter_t, value: usize) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2457,7 +2565,7 @@ pub unsafe fn cuFileSetParameterSizeT(param: CUFileSizeTConfigParameter_t, value
         cuFileSetParameterSizeT(param, value)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileSetParameterString(param: CUFileStringConfigParameter_t, desc_str: *const ::core::ffi::c_char) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2474,7 +2582,7 @@ pub unsafe fn cuFileSetParameterString(param: CUFileStringConfigParameter_t, des
         cuFileSetParameterString(param, desc_str)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileSetStatsLevel(level: ::core::ffi::c_int) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2491,7 +2599,7 @@ pub unsafe fn cuFileSetStatsLevel(level: ::core::ffi::c_int) -> CUfileError_t {
         cuFileSetStatsLevel(level)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileStatsReset() -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2508,7 +2616,7 @@ pub unsafe fn cuFileStatsReset() -> CUfileError_t {
         cuFileStatsReset()
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileStatsStart() -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2525,7 +2633,7 @@ pub unsafe fn cuFileStatsStart() -> CUfileError_t {
         cuFileStatsStart()
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileStatsStop() -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2542,7 +2650,7 @@ pub unsafe fn cuFileStatsStop() -> CUfileError_t {
         cuFileStatsStop()
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileStreamDeregister(stream: CUstream) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2559,7 +2667,7 @@ pub unsafe fn cuFileStreamDeregister(stream: CUstream) -> CUfileError_t {
         cuFileStreamDeregister(stream)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileStreamRegister(stream: CUstream, flags: ::core::ffi::c_uint) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2576,7 +2684,7 @@ pub unsafe fn cuFileStreamRegister(stream: CUstream, flags: ::core::ffi::c_uint)
         cuFileStreamRegister(stream, flags)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileUseCount() -> ::core::ffi::c_long {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2610,7 +2718,7 @@ pub unsafe fn cuFileWrite(fh: CUfileHandle_t, devPtr_base: *const ::core::ffi::c
         cuFileWrite(fh, devPtr_base, size, file_offset, devPtr_offset)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileWrite(fh: CUfileHandle_t, bufPtr_base: *const ::core::ffi::c_void, size: usize, file_offset: off_t, bufPtr_offset: off_t) -> isize {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2627,7 +2735,7 @@ pub unsafe fn cuFileWrite(fh: CUfileHandle_t, bufPtr_base: *const ::core::ffi::c
         cuFileWrite(fh, bufPtr_base, size, file_offset, bufPtr_offset)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFileWriteAsync(fh: CUfileHandle_t, bufPtr_base: *mut ::core::ffi::c_void, size_p: *mut usize, file_offset_p: *mut off_t, bufPtr_offset_p: *mut off_t, bytes_written_p: *mut isize, stream: CUstream) -> CUfileError_t {
     #[cfg(feature = "dynamic-loading")]
     {

--- a/src/cupti/sys/mod.rs
+++ b/src/cupti/sys/mod.rs
@@ -44,31 +44,33 @@ pub const CUPTI_API_VERSION: u32 = 130001;
 pub const CUPTI_API_VERSION: u32 = 130101;
 #[cfg(any(feature = "cuda-13020"))]
 pub const CUPTI_API_VERSION: u32 = 130201;
+#[cfg(any(feature = "cuda-13030"))]
+pub const CUPTI_API_VERSION: u32 = 130300;
 pub const CUPTI_AUTO_BOOST_INVALID_CLIENT_PID: u32 = 0;
 pub const CUPTI_CORRELATION_ID_UNKNOWN: u32 = 0;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CUPTI_DECOMPRESSED_BYTES_UNKNOWN: u32 = 0;
 pub const CUPTI_FUNCTION_INDEX_ID_INVALID: u32 = 0;
 pub const CUPTI_GRID_ID_UNKNOWN: u32 = 0;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CUPTI_INVALID_CONTEXT_ID: u32 = 0;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CUPTI_INVALID_STREAM_ID: u32 = 0;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CUPTI_MAX_DEVICES: u32 = 256;
 pub const CUPTI_MAX_GPUS: u32 = 32;
 #[cfg(any(feature = "cuda-11040"))]
 pub const CUPTI_MAX_NVLINK_PORTS: u32 = 16;
 #[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010"))]
 pub const CUPTI_MAX_NVLINK_PORTS: u32 = 32;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CUPTI_MAX_NVLINK_PORTS: u32 = 256;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010"))]
 pub const CUPTI_NVLINK_INVALID_PORT: i32 = -1;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CUPTI_OLD_SUBSCRIBER_NAME_MIN_LEN: u32 = 64;
 pub const CUPTI_SOURCE_LOCATOR_ID_UNKNOWN: u32 = 0;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CUPTI_SUBSCRIBER_NAME_MAX_LEN: u32 = 53;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060"))]
 pub const CUPTI_SYNCHRONIZATION_INVALID_VALUE: i32 = -1;
@@ -80,10 +82,10 @@ pub type CUDA_MEMCPY3D_v1 = CUDA_MEMCPY3D_v1_st;
 pub type CUdeviceptr_v1 = ::core::ffi::c_uint;
 pub type CUpti_ActivityMemcpy2 = CUpti_ActivityMemcpyPtoP;
 pub type CUpti_BuffersCallbackCompleteFunc = ::core::option::Option<unsafe extern "C" fn(context: CUcontext, streamId: u32, buffer: *mut u8, size: usize, validSize: usize)>;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUpti_BuffersCallbackCompleteFunc_v2 = ::core::option::Option<unsafe extern "C" fn(buffer: *mut u8, size: usize, validSize: usize, pBufferCompleteInfo: *mut CUpti_BufferCallbackCompleteInfo)>;
 pub type CUpti_BuffersCallbackRequestFunc = ::core::option::Option<unsafe extern "C" fn(buffer: *mut *mut u8, size: *mut usize, maxNumRecords: *mut usize)>;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUpti_BuffersCallbackRequestFunc_v2 = ::core::option::Option<unsafe extern "C" fn(buffer: *mut *mut u8, size: *mut usize, maxNumRecords: *mut usize, pBufferRequestInfo: *mut CUpti_BufferCallbackRequestInfo)>;
 pub type CUpti_CallbackFunc = ::core::option::Option<unsafe extern "C" fn(userdata: *mut ::core::ffi::c_void, domain: CUpti_CallbackDomain, cbid: CUpti_CallbackId, cbdata: *const ::core::ffi::c_void)>;
 pub type CUpti_CallbackId = u32;
@@ -94,7 +96,7 @@ pub type CUpti_EventID = u32;
 pub type CUpti_KernelReplayUpdateFunc = ::core::option::Option<unsafe extern "C" fn(kernelName: *const ::core::ffi::c_char, numReplaysDone: ::core::ffi::c_int, customData: *mut ::core::ffi::c_void)>;
 pub type CUpti_MetricID = u32;
 pub type CUpti_SubscriberHandle = *mut CUpti_Subscriber_st;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUpti_TimestampCallbackFunc = ::core::option::Option<unsafe extern "C" fn() -> u64>;
 pub type cuArray3DCreate_params = cuArray3DCreate_params_st;
 pub type cuArray3DCreate_v2_params = cuArray3DCreate_v2_params_st;
@@ -105,62 +107,62 @@ pub type cuArrayCreate_v2_params = cuArrayCreate_v2_params_st;
 pub type cuArrayDestroy_params = cuArrayDestroy_params_st;
 pub type cuArrayGetDescriptor_params = cuArrayGetDescriptor_params_st;
 pub type cuArrayGetDescriptor_v2_params = cuArrayGetDescriptor_v2_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuArrayGetMemoryRequirements_params = cuArrayGetMemoryRequirements_params_st;
 pub type cuArrayGetPlane_params = cuArrayGetPlane_params_st;
 pub type cuArrayGetSparseProperties_params = cuArrayGetSparseProperties_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCheckpointProcessCheckpoint_params = cuCheckpointProcessCheckpoint_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCheckpointProcessGetRestoreThreadId_params = cuCheckpointProcessGetRestoreThreadId_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCheckpointProcessGetState_params = cuCheckpointProcessGetState_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCheckpointProcessLock_params = cuCheckpointProcessLock_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCheckpointProcessRestore_params = cuCheckpointProcessRestore_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCheckpointProcessUnlock_params = cuCheckpointProcessUnlock_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCoredumpDeregisterCompleteCallback_params = cuCoredumpDeregisterCompleteCallback_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCoredumpDeregisterStartCallback_params = cuCoredumpDeregisterStartCallback_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCoredumpGetAttributeGlobal_params = cuCoredumpGetAttributeGlobal_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCoredumpGetAttribute_params = cuCoredumpGetAttribute_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCoredumpRegisterCompleteCallback_params = cuCoredumpRegisterCompleteCallback_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCoredumpRegisterStartCallback_params = cuCoredumpRegisterStartCallback_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCoredumpSetAttributeGlobal_params = cuCoredumpSetAttributeGlobal_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCoredumpSetAttribute_params = cuCoredumpSetAttribute_params_st;
 pub type cuCtxAttach_params = cuCtxAttach_params_st;
 pub type cuCtxCreate_params = cuCtxCreate_params_st;
 pub type cuCtxCreate_v2_params = cuCtxCreate_v2_params_st;
 pub type cuCtxCreate_v3_params = cuCtxCreate_v3_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCtxCreate_v4_params = cuCtxCreate_v4_params_st;
 pub type cuCtxDestroy_params = cuCtxDestroy_params_st;
 pub type cuCtxDestroy_v2_params = cuCtxDestroy_v2_params_st;
 pub type cuCtxDetach_params = cuCtxDetach_params_st;
 pub type cuCtxDisablePeerAccess_params = cuCtxDisablePeerAccess_params_st;
 pub type cuCtxEnablePeerAccess_params = cuCtxEnablePeerAccess_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCtxFromGreenCtx_params = cuCtxFromGreenCtx_params_st;
 pub type cuCtxGetApiVersion_params = cuCtxGetApiVersion_params_st;
 pub type cuCtxGetCacheConfig_params = cuCtxGetCacheConfig_params_st;
 pub type cuCtxGetCurrent_params = cuCtxGetCurrent_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCtxGetDevResource_params = cuCtxGetDevResource_params_st;
 pub type cuCtxGetDevice_params = cuCtxGetDevice_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCtxGetDevice_v2_params = cuCtxGetDevice_v2_params_st;
 pub type cuCtxGetExecAffinity_params = cuCtxGetExecAffinity_params_st;
 pub type cuCtxGetFlags_params = cuCtxGetFlags_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCtxGetId_params = cuCtxGetId_params_st;
 pub type cuCtxGetLimit_params = cuCtxGetLimit_params_st;
 pub type cuCtxGetSharedMemConfig_params = cuCtxGetSharedMemConfig_params_st;
@@ -169,25 +171,25 @@ pub type cuCtxPopCurrent_params = cuCtxPopCurrent_params_st;
 pub type cuCtxPopCurrent_v2_params = cuCtxPopCurrent_v2_params_st;
 pub type cuCtxPushCurrent_params = cuCtxPushCurrent_params_st;
 pub type cuCtxPushCurrent_v2_params = cuCtxPushCurrent_v2_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCtxRecordEvent_params = cuCtxRecordEvent_params_st;
 pub type cuCtxSetCacheConfig_params = cuCtxSetCacheConfig_params_st;
 pub type cuCtxSetCurrent_params = cuCtxSetCurrent_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCtxSetFlags_params = cuCtxSetFlags_params_st;
 pub type cuCtxSetLimit_params = cuCtxSetLimit_params_st;
 pub type cuCtxSetSharedMemConfig_params = cuCtxSetSharedMemConfig_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCtxSynchronize_v2_params = cuCtxSynchronize_v2_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuCtxWaitEvent_params = cuCtxWaitEvent_params_st;
 pub type cuDestroyExternalMemory_params = cuDestroyExternalMemory_params_st;
 pub type cuDestroyExternalSemaphore_params = cuDestroyExternalSemaphore_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuDevResourceGenerateDesc_params = cuDevResourceGenerateDesc_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuDevSmResourceSplitByCount_params = cuDevSmResourceSplitByCount_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuDevSmResourceSplit_params = cuDevSmResourceSplit_params_st;
 pub type cuDeviceCanAccessPeer_params = cuDeviceCanAccessPeer_params_st;
 pub type cuDeviceComputeCapability_params = cuDeviceComputeCapability_params_st;
@@ -195,17 +197,17 @@ pub type cuDeviceGetAttribute_params = cuDeviceGetAttribute_params_st;
 pub type cuDeviceGetByPCIBusId_params = cuDeviceGetByPCIBusId_params_st;
 pub type cuDeviceGetCount_params = cuDeviceGetCount_params_st;
 pub type cuDeviceGetDefaultMemPool_params = cuDeviceGetDefaultMemPool_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuDeviceGetDevResource_params = cuDeviceGetDevResource_params_st;
 pub type cuDeviceGetExecAffinitySupport_params = cuDeviceGetExecAffinitySupport_params_st;
 pub type cuDeviceGetGraphMemAttribute_params = cuDeviceGetGraphMemAttribute_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuDeviceGetHostAtomicCapabilities_params = cuDeviceGetHostAtomicCapabilities_params_st;
 pub type cuDeviceGetLuid_params = cuDeviceGetLuid_params_st;
 pub type cuDeviceGetMemPool_params = cuDeviceGetMemPool_params_st;
 pub type cuDeviceGetName_params = cuDeviceGetName_params_st;
 pub type cuDeviceGetNvSciSyncAttributes_params = cuDeviceGetNvSciSyncAttributes_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuDeviceGetP2PAtomicCapabilities_params = cuDeviceGetP2PAtomicCapabilities_params_st;
 pub type cuDeviceGetP2PAttribute_params = cuDeviceGetP2PAttribute_params_st;
 pub type cuDeviceGetPCIBusId_params = cuDeviceGetPCIBusId_params_st;
@@ -223,20 +225,20 @@ pub type cuDevicePrimaryCtxReset_v2_params = cuDevicePrimaryCtxReset_v2_params_s
 pub type cuDevicePrimaryCtxRetain_params = cuDevicePrimaryCtxRetain_params_st;
 pub type cuDevicePrimaryCtxSetFlags_params = cuDevicePrimaryCtxSetFlags_params_st;
 pub type cuDevicePrimaryCtxSetFlags_v2_params = cuDevicePrimaryCtxSetFlags_v2_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuDeviceRegisterAsyncNotification_params = cuDeviceRegisterAsyncNotification_params_st;
 pub type cuDeviceSetGraphMemAttribute_params = cuDeviceSetGraphMemAttribute_params_st;
 pub type cuDeviceSetMemPool_params = cuDeviceSetMemPool_params_st;
 pub type cuDeviceTotalMem_params = cuDeviceTotalMem_params_st;
 pub type cuDeviceTotalMem_v2_params = cuDeviceTotalMem_v2_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuDeviceUnregisterAsyncNotification_params = cuDeviceUnregisterAsyncNotification_params_st;
 pub type cuDriverGetVersion_params = cuDriverGetVersion_params_st;
 pub type cuEventCreate_params = cuEventCreate_params_st;
 pub type cuEventDestroy_params = cuEventDestroy_params_st;
 pub type cuEventDestroy_v2_params = cuEventDestroy_v2_params_st;
 pub type cuEventElapsedTime_params = cuEventElapsedTime_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuEventElapsedTime_v2_params = cuEventElapsedTime_v2_params_st;
 pub type cuEventQuery_params = cuEventQuery_params_st;
 pub type cuEventRecordWithFlags_params = cuEventRecordWithFlags_params_st;
@@ -246,19 +248,19 @@ pub type cuEventRecord_ptsz_params = cuEventRecord_ptsz_params_st;
 pub type cuEventSynchronize_params = cuEventSynchronize_params_st;
 pub type cuExternalMemoryGetMappedBuffer_params = cuExternalMemoryGetMappedBuffer_params_st;
 pub type cuExternalMemoryGetMappedMipmappedArray_params = cuExternalMemoryGetMappedMipmappedArray_params_st;
-#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuFlushGPUDirectRDMAWrites_params = cuFlushGPUDirectRDMAWrites_params_st;
 pub type cuFuncGetAttribute_params = cuFuncGetAttribute_params_st;
 pub type cuFuncGetModule_params = cuFuncGetModule_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuFuncGetName_params = cuFuncGetName_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuFuncGetParamCount_params = cuFuncGetParamCount_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuFuncGetParamInfo_params = cuFuncGetParamInfo_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuFuncIsLoaded_params = cuFuncIsLoaded_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuFuncLoad_params = cuFuncLoad_params_st;
 pub type cuFuncSetAttribute_params = cuFuncSetAttribute_params_st;
 pub type cuFuncSetBlockShape_params = cuFuncSetBlockShape_params_st;
@@ -268,15 +270,15 @@ pub type cuFuncSetSharedSize_params = cuFuncSetSharedSize_params_st;
 pub type cuGetErrorName_params = cuGetErrorName_params_st;
 pub type cuGetErrorString_params = cuGetErrorString_params_st;
 pub type cuGetExportTable_params = cuGetExportTable_params_st;
-#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGetProcAddress_params = cuGetProcAddress_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGetProcAddress_v2_params = cuGetProcAddress_v2_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphAddBatchMemOpNode_params = cuGraphAddBatchMemOpNode_params_st;
 pub type cuGraphAddChildGraphNode_params = cuGraphAddChildGraphNode_params_st;
 pub type cuGraphAddDependencies_params = cuGraphAddDependencies_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphAddDependencies_v2_params = cuGraphAddDependencies_v2_params_st;
 pub type cuGraphAddEmptyNode_params = cuGraphAddEmptyNode_params_st;
 pub type cuGraphAddEventRecordNode_params = cuGraphAddEventRecordNode_params_st;
@@ -285,23 +287,23 @@ pub type cuGraphAddExternalSemaphoresSignalNode_params = cuGraphAddExternalSemap
 pub type cuGraphAddExternalSemaphoresWaitNode_params = cuGraphAddExternalSemaphoresWaitNode_params_st;
 pub type cuGraphAddHostNode_params = cuGraphAddHostNode_params_st;
 pub type cuGraphAddKernelNode_params = cuGraphAddKernelNode_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphAddKernelNode_v2_params = cuGraphAddKernelNode_v2_params_st;
 pub type cuGraphAddMemAllocNode_params = cuGraphAddMemAllocNode_params_st;
 pub type cuGraphAddMemFreeNode_params = cuGraphAddMemFreeNode_params_st;
 pub type cuGraphAddMemcpyNode_params = cuGraphAddMemcpyNode_params_st;
 pub type cuGraphAddMemsetNode_params = cuGraphAddMemsetNode_params_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphAddNode_params = cuGraphAddNode_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphAddNode_v2_params = cuGraphAddNode_v2_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphBatchMemOpNodeGetParams_params = cuGraphBatchMemOpNodeGetParams_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphBatchMemOpNodeSetParams_params = cuGraphBatchMemOpNodeSetParams_params_st;
 pub type cuGraphChildGraphNodeGetGraph_params = cuGraphChildGraphNodeGetGraph_params_st;
 pub type cuGraphClone_params = cuGraphClone_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphConditionalHandleCreate_params = cuGraphConditionalHandleCreate_params_st;
 pub type cuGraphCreate_params = cuGraphCreate_params_st;
 pub type cuGraphDebugDotPrint_params = cuGraphDebugDotPrint_params_st;
@@ -311,7 +313,7 @@ pub type cuGraphEventRecordNodeGetEvent_params = cuGraphEventRecordNodeGetEvent_
 pub type cuGraphEventRecordNodeSetEvent_params = cuGraphEventRecordNodeSetEvent_params_st;
 pub type cuGraphEventWaitNodeGetEvent_params = cuGraphEventWaitNodeGetEvent_params_st;
 pub type cuGraphEventWaitNodeSetEvent_params = cuGraphEventWaitNodeSetEvent_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphExecBatchMemOpNodeSetParams_params = cuGraphExecBatchMemOpNodeSetParams_params_st;
 pub type cuGraphExecChildGraphNodeSetParams_params = cuGraphExecChildGraphNodeSetParams_params_st;
 pub type cuGraphExecDestroy_params = cuGraphExecDestroy_params_st;
@@ -319,49 +321,49 @@ pub type cuGraphExecEventRecordNodeSetEvent_params = cuGraphExecEventRecordNodeS
 pub type cuGraphExecEventWaitNodeSetEvent_params = cuGraphExecEventWaitNodeSetEvent_params_st;
 pub type cuGraphExecExternalSemaphoresSignalNodeSetParams_params = cuGraphExecExternalSemaphoresSignalNodeSetParams_params_st;
 pub type cuGraphExecExternalSemaphoresWaitNodeSetParams_params = cuGraphExecExternalSemaphoresWaitNodeSetParams_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphExecGetFlags_params = cuGraphExecGetFlags_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphExecGetId_params = cuGraphExecGetId_params_st;
 pub type cuGraphExecHostNodeSetParams_params = cuGraphExecHostNodeSetParams_params_st;
 pub type cuGraphExecKernelNodeSetParams_params = cuGraphExecKernelNodeSetParams_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphExecKernelNodeSetParams_v2_params = cuGraphExecKernelNodeSetParams_v2_params_st;
 pub type cuGraphExecMemcpyNodeSetParams_params = cuGraphExecMemcpyNodeSetParams_params_st;
 pub type cuGraphExecMemsetNodeSetParams_params = cuGraphExecMemsetNodeSetParams_params_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphExecNodeSetParams_params = cuGraphExecNodeSetParams_params_st;
 pub type cuGraphExecUpdate_params = cuGraphExecUpdate_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphExecUpdate_v2_params = cuGraphExecUpdate_v2_params_st;
 pub type cuGraphExternalSemaphoresSignalNodeGetParams_params = cuGraphExternalSemaphoresSignalNodeGetParams_params_st;
 pub type cuGraphExternalSemaphoresSignalNodeSetParams_params = cuGraphExternalSemaphoresSignalNodeSetParams_params_st;
 pub type cuGraphExternalSemaphoresWaitNodeGetParams_params = cuGraphExternalSemaphoresWaitNodeGetParams_params_st;
 pub type cuGraphExternalSemaphoresWaitNodeSetParams_params = cuGraphExternalSemaphoresWaitNodeSetParams_params_st;
 pub type cuGraphGetEdges_params = cuGraphGetEdges_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphGetEdges_v2_params = cuGraphGetEdges_v2_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphGetId_params = cuGraphGetId_params_st;
 pub type cuGraphGetNodes_params = cuGraphGetNodes_params_st;
 pub type cuGraphGetRootNodes_params = cuGraphGetRootNodes_params_st;
 pub type cuGraphHostNodeGetParams_params = cuGraphHostNodeGetParams_params_st;
 pub type cuGraphHostNodeSetParams_params = cuGraphHostNodeSetParams_params_st;
 pub type cuGraphInstantiateWithFlags_params = cuGraphInstantiateWithFlags_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphInstantiateWithParams_params = cuGraphInstantiateWithParams_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphInstantiateWithParams_ptsz_params = cuGraphInstantiateWithParams_ptsz_params_st;
 pub type cuGraphInstantiate_params = cuGraphInstantiate_params_st;
 pub type cuGraphInstantiate_v2_params = cuGraphInstantiate_v2_params_st;
 pub type cuGraphKernelNodeCopyAttributes_params = cuGraphKernelNodeCopyAttributes_params_st;
 pub type cuGraphKernelNodeGetAttribute_params = cuGraphKernelNodeGetAttribute_params_st;
 pub type cuGraphKernelNodeGetParams_params = cuGraphKernelNodeGetParams_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphKernelNodeGetParams_v2_params = cuGraphKernelNodeGetParams_v2_params_st;
 pub type cuGraphKernelNodeSetAttribute_params = cuGraphKernelNodeSetAttribute_params_st;
 pub type cuGraphKernelNodeSetParams_params = cuGraphKernelNodeSetParams_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphKernelNodeSetParams_v2_params = cuGraphKernelNodeSetParams_v2_params_st;
 pub type cuGraphLaunch_params = cuGraphLaunch_params_st;
 pub type cuGraphLaunch_ptsz_params = cuGraphLaunch_ptsz_params_st;
@@ -372,30 +374,30 @@ pub type cuGraphMemcpyNodeSetParams_params = cuGraphMemcpyNodeSetParams_params_s
 pub type cuGraphMemsetNodeGetParams_params = cuGraphMemsetNodeGetParams_params_st;
 pub type cuGraphMemsetNodeSetParams_params = cuGraphMemsetNodeSetParams_params_st;
 pub type cuGraphNodeFindInClone_params = cuGraphNodeFindInClone_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphNodeGetContainingGraph_params = cuGraphNodeGetContainingGraph_params_st;
 pub type cuGraphNodeGetDependencies_params = cuGraphNodeGetDependencies_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphNodeGetDependencies_v2_params = cuGraphNodeGetDependencies_v2_params_st;
 pub type cuGraphNodeGetDependentNodes_params = cuGraphNodeGetDependentNodes_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphNodeGetDependentNodes_v2_params = cuGraphNodeGetDependentNodes_v2_params_st;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphNodeGetEnabled_params = cuGraphNodeGetEnabled_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphNodeGetLocalId_params = cuGraphNodeGetLocalId_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphNodeGetParams_params = cuGraphNodeGetParams_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphNodeGetToolsId_params = cuGraphNodeGetToolsId_params_st;
 pub type cuGraphNodeGetType_params = cuGraphNodeGetType_params_st;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphNodeSetEnabled_params = cuGraphNodeSetEnabled_params_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphNodeSetParams_params = cuGraphNodeSetParams_params_st;
 pub type cuGraphReleaseUserObject_params = cuGraphReleaseUserObject_params_st;
 pub type cuGraphRemoveDependencies_params = cuGraphRemoveDependencies_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGraphRemoveDependencies_v2_params = cuGraphRemoveDependencies_v2_params_st;
 pub type cuGraphRetainUserObject_params = cuGraphRetainUserObject_params_st;
 pub type cuGraphUpload_params = cuGraphUpload_params_st;
@@ -411,19 +413,19 @@ pub type cuGraphicsSubResourceGetMappedArray_params = cuGraphicsSubResourceGetMa
 pub type cuGraphicsUnmapResources_params = cuGraphicsUnmapResources_params_st;
 pub type cuGraphicsUnmapResources_ptsz_params = cuGraphicsUnmapResources_ptsz_params_st;
 pub type cuGraphicsUnregisterResource_params = cuGraphicsUnregisterResource_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGreenCtxCreate_params = cuGreenCtxCreate_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGreenCtxDestroy_params = cuGreenCtxDestroy_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGreenCtxGetDevResource_params = cuGreenCtxGetDevResource_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGreenCtxGetId_params = cuGreenCtxGetId_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGreenCtxRecordEvent_params = cuGreenCtxRecordEvent_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGreenCtxStreamCreate_params = cuGreenCtxStreamCreate_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuGreenCtxWaitEvent_params = cuGreenCtxWaitEvent_params_st;
 pub type cuImportExternalMemory_params = cuImportExternalMemory_params_st;
 pub type cuImportExternalSemaphore_params = cuImportExternalSemaphore_params_st;
@@ -434,21 +436,21 @@ pub type cuIpcGetMemHandle_params = cuIpcGetMemHandle_params_st;
 pub type cuIpcOpenEventHandle_params = cuIpcOpenEventHandle_params_st;
 pub type cuIpcOpenMemHandle_params = cuIpcOpenMemHandle_params_st;
 pub type cuIpcOpenMemHandle_v2_params = cuIpcOpenMemHandle_v2_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuKernelGetAttribute_params = cuKernelGetAttribute_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuKernelGetFunction_params = cuKernelGetFunction_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuKernelGetLibrary_params = cuKernelGetLibrary_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuKernelGetName_params = cuKernelGetName_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuKernelGetParamCount_params = cuKernelGetParamCount_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuKernelGetParamInfo_params = cuKernelGetParamInfo_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuKernelSetAttribute_params = cuKernelSetAttribute_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuKernelSetCacheConfig_params = cuKernelSetCacheConfig_params_st;
 pub type cuLaunchCooperativeKernelMultiDevice_params = cuLaunchCooperativeKernelMultiDevice_params_st;
 pub type cuLaunchCooperativeKernel_params = cuLaunchCooperativeKernel_params_st;
@@ -457,36 +459,36 @@ pub type cuLaunchGridAsync_params = cuLaunchGridAsync_params_st;
 pub type cuLaunchGrid_params = cuLaunchGrid_params_st;
 pub type cuLaunchHostFunc_params = cuLaunchHostFunc_params_st;
 pub type cuLaunchHostFunc_ptsz_params = cuLaunchHostFunc_ptsz_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLaunchHostFunc_v2_params = cuLaunchHostFunc_v2_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLaunchHostFunc_v2_ptsz_params = cuLaunchHostFunc_v2_ptsz_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLaunchKernelEx_params = cuLaunchKernelEx_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLaunchKernelEx_ptsz_params = cuLaunchKernelEx_ptsz_params_st;
 pub type cuLaunchKernel_params = cuLaunchKernel_params_st;
 pub type cuLaunchKernel_ptsz_params = cuLaunchKernel_ptsz_params_st;
 pub type cuLaunch_params = cuLaunch_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryEnumerateKernels_params = cuLibraryEnumerateKernels_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryGetGlobal_params = cuLibraryGetGlobal_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryGetKernelCount_params = cuLibraryGetKernelCount_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryGetKernel_params = cuLibraryGetKernel_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryGetManaged_params = cuLibraryGetManaged_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryGetModule_params = cuLibraryGetModule_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryGetUnifiedFunction_params = cuLibraryGetUnifiedFunction_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryLoadData_params = cuLibraryLoadData_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryLoadFromFile_params = cuLibraryLoadFromFile_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLibraryUnload_params = cuLibraryUnload_params_st;
 pub type cuLinkAddData_params = cuLinkAddData_params_st;
 pub type cuLinkAddData_v2_params = cuLinkAddData_v2_params_st;
@@ -496,20 +498,20 @@ pub type cuLinkComplete_params = cuLinkComplete_params_st;
 pub type cuLinkCreate_params = cuLinkCreate_params_st;
 pub type cuLinkCreate_v2_params = cuLinkCreate_v2_params_st;
 pub type cuLinkDestroy_params = cuLinkDestroy_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLogsCurrent_params = cuLogsCurrent_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLogsDumpToFile_params = cuLogsDumpToFile_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLogsDumpToMemory_params = cuLogsDumpToMemory_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLogsRegisterCallback_params = cuLogsRegisterCallback_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuLogsUnregisterCallback_params = cuLogsUnregisterCallback_params_st;
 pub type cuMemAddressFree_params = cuMemAddressFree_params_st;
 pub type cuMemAddressReserve_params = cuMemAddressReserve_params_st;
 pub type cuMemAdvise_params = cuMemAdvise_params_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemAdvise_v2_params = cuMemAdvise_v2_params_st;
 pub type cuMemAllocAsync_params = cuMemAllocAsync_params_st;
 pub type cuMemAllocAsync_ptsz_params = cuMemAllocAsync_ptsz_params_st;
@@ -522,18 +524,18 @@ pub type cuMemAllocPitch_params = cuMemAllocPitch_params_st;
 pub type cuMemAllocPitch_v2_params = cuMemAllocPitch_v2_params_st;
 pub type cuMemAlloc_params = cuMemAlloc_params_st;
 pub type cuMemAlloc_v2_params = cuMemAlloc_v2_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemBatchDecompressAsync_params = cuMemBatchDecompressAsync_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemBatchDecompressAsync_ptsz_params = cuMemBatchDecompressAsync_ptsz_params_st;
 pub type cuMemCreate_params = cuMemCreate_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemDiscardAndPrefetchBatchAsync_params = cuMemDiscardAndPrefetchBatchAsync_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemDiscardAndPrefetchBatchAsync_ptsz_params = cuMemDiscardAndPrefetchBatchAsync_ptsz_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemDiscardBatchAsync_params = cuMemDiscardBatchAsync_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemDiscardBatchAsync_ptsz_params = cuMemDiscardBatchAsync_ptsz_params_st;
 pub type cuMemExportToShareableHandle_params = cuMemExportToShareableHandle_params_st;
 pub type cuMemFreeAsync_params = cuMemFreeAsync_params_st;
@@ -546,13 +548,13 @@ pub type cuMemGetAddressRange_params = cuMemGetAddressRange_params_st;
 pub type cuMemGetAddressRange_v2_params = cuMemGetAddressRange_v2_params_st;
 pub type cuMemGetAllocationGranularity_params = cuMemGetAllocationGranularity_params_st;
 pub type cuMemGetAllocationPropertiesFromHandle_params = cuMemGetAllocationPropertiesFromHandle_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemGetDefaultMemPool_params = cuMemGetDefaultMemPool_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemGetHandleForAddressRange_params = cuMemGetHandleForAddressRange_params_st;
 pub type cuMemGetInfo_params = cuMemGetInfo_params_st;
 pub type cuMemGetInfo_v2_params = cuMemGetInfo_v2_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemGetMemPool_params = cuMemGetMemPool_params_st;
 pub type cuMemHostAlloc_params = cuMemHostAlloc_params_st;
 pub type cuMemHostGetDevicePointer_params = cuMemHostGetDevicePointer_params_st;
@@ -578,20 +580,20 @@ pub type cuMemPoolSetAttribute_params = cuMemPoolSetAttribute_params_st;
 pub type cuMemPoolTrimTo_params = cuMemPoolTrimTo_params_st;
 pub type cuMemPrefetchAsync_params = cuMemPrefetchAsync_params_st;
 pub type cuMemPrefetchAsync_ptsz_params = cuMemPrefetchAsync_ptsz_params_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemPrefetchAsync_v2_params = cuMemPrefetchAsync_v2_params_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemPrefetchAsync_v2_ptsz_params = cuMemPrefetchAsync_v2_ptsz_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemPrefetchBatchAsync_params = cuMemPrefetchBatchAsync_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemPrefetchBatchAsync_ptsz_params = cuMemPrefetchBatchAsync_ptsz_params_st;
 pub type cuMemRangeGetAttribute_params = cuMemRangeGetAttribute_params_st;
 pub type cuMemRangeGetAttributes_params = cuMemRangeGetAttributes_params_st;
 pub type cuMemRelease_params = cuMemRelease_params_st;
 pub type cuMemRetainAllocationHandle_params = cuMemRetainAllocationHandle_params_st;
 pub type cuMemSetAccess_params = cuMemSetAccess_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemSetMemPool_params = cuMemSetMemPool_params_st;
 pub type cuMemUnmap_params = cuMemUnmap_params_st;
 pub type cuMemcpy2DAsync_params = cuMemcpy2DAsync_params_st;
@@ -606,21 +608,21 @@ pub type cuMemcpy2D_v2_ptds_params = cuMemcpy2D_v2_ptds_params_st;
 pub type cuMemcpy3DAsync_params = cuMemcpy3DAsync_params_st;
 pub type cuMemcpy3DAsync_v2_params = cuMemcpy3DAsync_v2_params_st;
 pub type cuMemcpy3DAsync_v2_ptsz_params = cuMemcpy3DAsync_v2_ptsz_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpy3DBatchAsync_params = cuMemcpy3DBatchAsync_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpy3DBatchAsync_ptsz_params = cuMemcpy3DBatchAsync_ptsz_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpy3DBatchAsync_v2_params = cuMemcpy3DBatchAsync_v2_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpy3DBatchAsync_v2_ptsz_params = cuMemcpy3DBatchAsync_v2_ptsz_params_st;
 pub type cuMemcpy3DPeerAsync_params = cuMemcpy3DPeerAsync_params_st;
 pub type cuMemcpy3DPeerAsync_ptsz_params = cuMemcpy3DPeerAsync_ptsz_params_st;
 pub type cuMemcpy3DPeer_params = cuMemcpy3DPeer_params_st;
 pub type cuMemcpy3DPeer_ptds_params = cuMemcpy3DPeer_ptds_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpy3DWithAttributesAsync_params = cuMemcpy3DWithAttributesAsync_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpy3DWithAttributesAsync_ptsz_params = cuMemcpy3DWithAttributesAsync_ptsz_params_st;
 pub type cuMemcpy3D_params = cuMemcpy3D_params_st;
 pub type cuMemcpy3D_v2_params = cuMemcpy3D_v2_params_st;
@@ -639,13 +641,13 @@ pub type cuMemcpyAtoHAsync_v2_ptsz_params = cuMemcpyAtoHAsync_v2_ptsz_params_st;
 pub type cuMemcpyAtoH_params = cuMemcpyAtoH_params_st;
 pub type cuMemcpyAtoH_v2_params = cuMemcpyAtoH_v2_params_st;
 pub type cuMemcpyAtoH_v2_ptds_params = cuMemcpyAtoH_v2_ptds_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpyBatchAsync_params = cuMemcpyBatchAsync_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpyBatchAsync_ptsz_params = cuMemcpyBatchAsync_ptsz_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpyBatchAsync_v2_params = cuMemcpyBatchAsync_v2_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpyBatchAsync_v2_ptsz_params = cuMemcpyBatchAsync_v2_ptsz_params_st;
 pub type cuMemcpyDtoA_params = cuMemcpyDtoA_params_st;
 pub type cuMemcpyDtoA_v2_params = cuMemcpyDtoA_v2_params_st;
@@ -678,9 +680,9 @@ pub type cuMemcpyPeerAsync_params = cuMemcpyPeerAsync_params_st;
 pub type cuMemcpyPeerAsync_ptsz_params = cuMemcpyPeerAsync_ptsz_params_st;
 pub type cuMemcpyPeer_params = cuMemcpyPeer_params_st;
 pub type cuMemcpyPeer_ptds_params = cuMemcpyPeer_ptds_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpyWithAttributesAsync_params = cuMemcpyWithAttributesAsync_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMemcpyWithAttributesAsync_ptsz_params = cuMemcpyWithAttributesAsync_ptsz_params_st;
 pub type cuMemcpy_params = cuMemcpy_params_st;
 pub type cuMemcpy_ptds_params = cuMemcpy_ptds_params_st;
@@ -717,17 +719,17 @@ pub type cuMemsetD8_v2_ptds_params = cuMemsetD8_v2_ptds_params_st;
 pub type cuMipmappedArrayCreate_params = cuMipmappedArrayCreate_params_st;
 pub type cuMipmappedArrayDestroy_params = cuMipmappedArrayDestroy_params_st;
 pub type cuMipmappedArrayGetLevel_params = cuMipmappedArrayGetLevel_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMipmappedArrayGetMemoryRequirements_params = cuMipmappedArrayGetMemoryRequirements_params_st;
 pub type cuMipmappedArrayGetSparseProperties_params = cuMipmappedArrayGetSparseProperties_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuModuleEnumerateFunctions_params = cuModuleEnumerateFunctions_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuModuleGetFunctionCount_params = cuModuleGetFunctionCount_params_st;
 pub type cuModuleGetFunction_params = cuModuleGetFunction_params_st;
 pub type cuModuleGetGlobal_params = cuModuleGetGlobal_params_st;
 pub type cuModuleGetGlobal_v2_params = cuModuleGetGlobal_v2_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuModuleGetLoadingMode_params = cuModuleGetLoadingMode_params_st;
 pub type cuModuleGetSurfRef_params = cuModuleGetSurfRef_params_st;
 pub type cuModuleGetTexRef_params = cuModuleGetTexRef_params_st;
@@ -736,30 +738,30 @@ pub type cuModuleLoadData_params = cuModuleLoadData_params_st;
 pub type cuModuleLoadFatBinary_params = cuModuleLoadFatBinary_params_st;
 pub type cuModuleLoad_params = cuModuleLoad_params_st;
 pub type cuModuleUnload_params = cuModuleUnload_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMulticastAddDevice_params = cuMulticastAddDevice_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMulticastBindAddr_params = cuMulticastBindAddr_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMulticastBindAddr_v2_params = cuMulticastBindAddr_v2_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMulticastBindMem_params = cuMulticastBindMem_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMulticastBindMem_v2_params = cuMulticastBindMem_v2_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMulticastCreate_params = cuMulticastCreate_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMulticastGetGranularity_params = cuMulticastGetGranularity_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuMulticastUnbind_params = cuMulticastUnbind_params_st;
 pub type cuOccupancyAvailableDynamicSMemPerBlock_params = cuOccupancyAvailableDynamicSMemPerBlock_params_st;
 pub type cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_params = cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_params_st;
 pub type cuOccupancyMaxActiveBlocksPerMultiprocessor_params = cuOccupancyMaxActiveBlocksPerMultiprocessor_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuOccupancyMaxActiveClusters_params = cuOccupancyMaxActiveClusters_params_st;
 pub type cuOccupancyMaxPotentialBlockSizeWithFlags_params = cuOccupancyMaxPotentialBlockSizeWithFlags_params_st;
 pub type cuOccupancyMaxPotentialBlockSize_params = cuOccupancyMaxPotentialBlockSize_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuOccupancyMaxPotentialClusterSize_params = cuOccupancyMaxPotentialClusterSize_params_st;
 pub type cuParamSetSize_params = cuParamSetSize_params_st;
 pub type cuParamSetTexRef_params = cuParamSetTexRef_params_st;
@@ -777,31 +779,35 @@ pub type cuStreamAttachMemAsync_params = cuStreamAttachMemAsync_params_st;
 pub type cuStreamAttachMemAsync_ptsz_params = cuStreamAttachMemAsync_ptsz_params_st;
 pub type cuStreamBatchMemOp_params = cuStreamBatchMemOp_params_st;
 pub type cuStreamBatchMemOp_ptsz_params = cuStreamBatchMemOp_ptsz_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamBatchMemOp_v2_params = cuStreamBatchMemOp_v2_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamBatchMemOp_v2_ptsz_params = cuStreamBatchMemOp_v2_ptsz_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamBeginCaptureToCig_params = cuStreamBeginCaptureToCig_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamBeginCaptureToCig_ptsz_params = cuStreamBeginCaptureToCig_ptsz_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamBeginCaptureToGraph_params = cuStreamBeginCaptureToGraph_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamBeginCaptureToGraph_ptsz_params = cuStreamBeginCaptureToGraph_ptsz_params_st;
 pub type cuStreamBeginCapture_params = cuStreamBeginCapture_params_st;
 pub type cuStreamBeginCapture_ptsz_params = cuStreamBeginCapture_ptsz_params_st;
 pub type cuStreamBeginCapture_v2_params = cuStreamBeginCapture_v2_params_st;
 pub type cuStreamBeginCapture_v2_ptsz_params = cuStreamBeginCapture_v2_ptsz_params_st;
+#[cfg(any(feature = "cuda-13030"))]
+pub type cuStreamBeginRecaptureToGraph_params = cuStreamBeginRecaptureToGraph_params_st;
+#[cfg(any(feature = "cuda-13030"))]
+pub type cuStreamBeginRecaptureToGraph_ptsz_params = cuStreamBeginRecaptureToGraph_ptsz_params_st;
 pub type cuStreamCopyAttributes_params = cuStreamCopyAttributes_params_st;
 pub type cuStreamCopyAttributes_ptsz_params = cuStreamCopyAttributes_ptsz_params_st;
 pub type cuStreamCreateWithPriority_params = cuStreamCreateWithPriority_params_st;
 pub type cuStreamCreate_params = cuStreamCreate_params_st;
 pub type cuStreamDestroy_params = cuStreamDestroy_params_st;
 pub type cuStreamDestroy_v2_params = cuStreamDestroy_v2_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamEndCaptureToCig_params = cuStreamEndCaptureToCig_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamEndCaptureToCig_ptsz_params = cuStreamEndCaptureToCig_ptsz_params_st;
 pub type cuStreamEndCapture_params = cuStreamEndCapture_params_st;
 pub type cuStreamEndCapture_ptsz_params = cuStreamEndCapture_ptsz_params_st;
@@ -811,31 +817,31 @@ pub type cuStreamGetCaptureInfo_params = cuStreamGetCaptureInfo_params_st;
 pub type cuStreamGetCaptureInfo_ptsz_params = cuStreamGetCaptureInfo_ptsz_params_st;
 pub type cuStreamGetCaptureInfo_v2_params = cuStreamGetCaptureInfo_v2_params_st;
 pub type cuStreamGetCaptureInfo_v2_ptsz_params = cuStreamGetCaptureInfo_v2_ptsz_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetCaptureInfo_v3_params = cuStreamGetCaptureInfo_v3_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetCaptureInfo_v3_ptsz_params = cuStreamGetCaptureInfo_v3_ptsz_params_st;
 pub type cuStreamGetCtx_params = cuStreamGetCtx_params_st;
 pub type cuStreamGetCtx_ptsz_params = cuStreamGetCtx_ptsz_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetCtx_v2_params = cuStreamGetCtx_v2_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetCtx_v2_ptsz_params = cuStreamGetCtx_v2_ptsz_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetDevResource_params = cuStreamGetDevResource_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetDevResource_ptsz_params = cuStreamGetDevResource_ptsz_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetDevice_params = cuStreamGetDevice_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetDevice_ptsz_params = cuStreamGetDevice_ptsz_params_st;
 pub type cuStreamGetFlags_params = cuStreamGetFlags_params_st;
 pub type cuStreamGetFlags_ptsz_params = cuStreamGetFlags_ptsz_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetGreenCtx_params = cuStreamGetGreenCtx_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetId_params = cuStreamGetId_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamGetId_ptsz_params = cuStreamGetId_ptsz_params_st;
 pub type cuStreamGetPriority_params = cuStreamGetPriority_params_st;
 pub type cuStreamGetPriority_ptsz_params = cuStreamGetPriority_ptsz_params_st;
@@ -849,48 +855,48 @@ pub type cuStreamSynchronize_params = cuStreamSynchronize_params_st;
 pub type cuStreamSynchronize_ptsz_params = cuStreamSynchronize_ptsz_params_st;
 pub type cuStreamUpdateCaptureDependencies_params = cuStreamUpdateCaptureDependencies_params_st;
 pub type cuStreamUpdateCaptureDependencies_ptsz_params = cuStreamUpdateCaptureDependencies_ptsz_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamUpdateCaptureDependencies_v2_params = cuStreamUpdateCaptureDependencies_v2_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamUpdateCaptureDependencies_v2_ptsz_params = cuStreamUpdateCaptureDependencies_v2_ptsz_params_st;
 pub type cuStreamWaitEvent_params = cuStreamWaitEvent_params_st;
 pub type cuStreamWaitEvent_ptsz_params = cuStreamWaitEvent_ptsz_params_st;
 pub type cuStreamWaitValue32_params = cuStreamWaitValue32_params_st;
 pub type cuStreamWaitValue32_ptsz_params = cuStreamWaitValue32_ptsz_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamWaitValue32_v2_params = cuStreamWaitValue32_v2_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamWaitValue32_v2_ptsz_params = cuStreamWaitValue32_v2_ptsz_params_st;
 pub type cuStreamWaitValue64_params = cuStreamWaitValue64_params_st;
 pub type cuStreamWaitValue64_ptsz_params = cuStreamWaitValue64_ptsz_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamWaitValue64_v2_params = cuStreamWaitValue64_v2_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamWaitValue64_v2_ptsz_params = cuStreamWaitValue64_v2_ptsz_params_st;
 pub type cuStreamWriteValue32_params = cuStreamWriteValue32_params_st;
 pub type cuStreamWriteValue32_ptsz_params = cuStreamWriteValue32_ptsz_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamWriteValue32_v2_params = cuStreamWriteValue32_v2_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamWriteValue32_v2_ptsz_params = cuStreamWriteValue32_v2_ptsz_params_st;
 pub type cuStreamWriteValue64_params = cuStreamWriteValue64_params_st;
 pub type cuStreamWriteValue64_ptsz_params = cuStreamWriteValue64_ptsz_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamWriteValue64_v2_params = cuStreamWriteValue64_v2_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuStreamWriteValue64_v2_ptsz_params = cuStreamWriteValue64_v2_ptsz_params_st;
 pub type cuSurfObjectCreate_params = cuSurfObjectCreate_params_st;
 pub type cuSurfObjectDestroy_params = cuSurfObjectDestroy_params_st;
 pub type cuSurfObjectGetResourceDesc_params = cuSurfObjectGetResourceDesc_params_st;
 pub type cuSurfRefGetArray_params = cuSurfRefGetArray_params_st;
 pub type cuSurfRefSetArray_params = cuSurfRefSetArray_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuTensorMapEncodeIm2colWide_params = cuTensorMapEncodeIm2colWide_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuTensorMapEncodeIm2col_params = cuTensorMapEncodeIm2col_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuTensorMapEncodeTiled_params = cuTensorMapEncodeTiled_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cuTensorMapReplaceAddress_params = cuTensorMapReplaceAddress_params_st;
 pub type cuTexObjectCreate_params = cuTexObjectCreate_params_st;
 pub type cuTexObjectDestroy_params = cuTexObjectDestroy_params_st;
@@ -935,7 +941,7 @@ pub type cuUserObjectRetain_params = cuUserObjectRetain_params_st;
 pub type cuWaitExternalSemaphoresAsync_params = cuWaitExternalSemaphoresAsync_params_st;
 pub type cuWaitExternalSemaphoresAsync_ptsz_params = cuWaitExternalSemaphoresAsync_ptsz_params_st;
 pub type cudaArrayGetInfo_v4010_params = cudaArrayGetInfo_v4010_params_st;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaArrayGetMemoryRequirements_v11060_params = cudaArrayGetMemoryRequirements_v11060_params_st;
 pub type cudaArrayGetPlane_v11020_params = cudaArrayGetPlane_v11020_params_st;
 pub type cudaArrayGetSparseProperties_v11010_params = cudaArrayGetSparseProperties_v11010_params_st;
@@ -957,11 +963,11 @@ pub type cudaDestroyExternalMemory_v10000_params = cudaDestroyExternalMemory_v10
 pub type cudaDestroyExternalSemaphore_v10000_params = cudaDestroyExternalSemaphore_v10000_params_st;
 pub type cudaDestroySurfaceObject_v5000_params = cudaDestroySurfaceObject_v5000_params_st;
 pub type cudaDestroyTextureObject_v5000_params = cudaDestroyTextureObject_v5000_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDevResourceGenerateDesc_v13010_params = cudaDevResourceGenerateDesc_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDevSmResourceSplitByCount_v13010_params = cudaDevSmResourceSplitByCount_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDevSmResourceSplit_v13010_params = cudaDevSmResourceSplit_v13010_params_st;
 pub type cudaDeviceCanAccessPeer_v4000_params = cudaDeviceCanAccessPeer_v4000_params_st;
 pub type cudaDeviceDisablePeerAccess_v4000_params = cudaDeviceDisablePeerAccess_v4000_params_st;
@@ -971,17 +977,17 @@ pub type cudaDeviceGetAttribute_v5000_params = cudaDeviceGetAttribute_v5000_para
 pub type cudaDeviceGetByPCIBusId_v4010_params = cudaDeviceGetByPCIBusId_v4010_params_st;
 pub type cudaDeviceGetCacheConfig_v3020_params = cudaDeviceGetCacheConfig_v3020_params_st;
 pub type cudaDeviceGetDefaultMemPool_v11020_params = cudaDeviceGetDefaultMemPool_v11020_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDeviceGetDevResource_v13010_params = cudaDeviceGetDevResource_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDeviceGetExecutionCtx_v13010_params = cudaDeviceGetExecutionCtx_v13010_params_st;
 pub type cudaDeviceGetGraphMemAttribute_v11040_params = cudaDeviceGetGraphMemAttribute_v11040_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDeviceGetHostAtomicCapabilities_v13000_params = cudaDeviceGetHostAtomicCapabilities_v13000_params_st;
 pub type cudaDeviceGetLimit_v3020_params = cudaDeviceGetLimit_v3020_params_st;
 pub type cudaDeviceGetMemPool_v11020_params = cudaDeviceGetMemPool_v11020_params_st;
 pub type cudaDeviceGetNvSciSyncAttributes_v10020_params = cudaDeviceGetNvSciSyncAttributes_v10020_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDeviceGetP2PAtomicCapabilities_v13000_params = cudaDeviceGetP2PAtomicCapabilities_v13000_params_st;
 pub type cudaDeviceGetP2PAttribute_v8000_params = cudaDeviceGetP2PAttribute_v8000_params_st;
 pub type cudaDeviceGetPCIBusId_v4010_params = cudaDeviceGetPCIBusId_v4010_params_st;
@@ -989,20 +995,20 @@ pub type cudaDeviceGetSharedMemConfig_v4020_params = cudaDeviceGetSharedMemConfi
 pub type cudaDeviceGetStreamPriorityRange_v5050_params = cudaDeviceGetStreamPriorityRange_v5050_params_st;
 pub type cudaDeviceGetTexture1DLinearMaxWidth_v11010_params = cudaDeviceGetTexture1DLinearMaxWidth_v11010_params_st;
 pub type cudaDeviceGraphMemTrim_v11040_params = cudaDeviceGraphMemTrim_v11040_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDeviceRegisterAsyncNotification_v12040_params = cudaDeviceRegisterAsyncNotification_v12040_params_st;
 pub type cudaDeviceSetCacheConfig_v3020_params = cudaDeviceSetCacheConfig_v3020_params_st;
 pub type cudaDeviceSetGraphMemAttribute_v11040_params = cudaDeviceSetGraphMemAttribute_v11040_params_st;
 pub type cudaDeviceSetLimit_v3020_params = cudaDeviceSetLimit_v3020_params_st;
 pub type cudaDeviceSetMemPool_v11020_params = cudaDeviceSetMemPool_v11020_params_st;
 pub type cudaDeviceSetSharedMemConfig_v4020_params = cudaDeviceSetSharedMemConfig_v4020_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDeviceUnregisterAsyncNotification_v12040_params = cudaDeviceUnregisterAsyncNotification_v12040_params_st;
 pub type cudaDriverGetVersion_v3020_params = cudaDriverGetVersion_v3020_params_st;
 pub type cudaEventCreateWithFlags_v3020_params = cudaEventCreateWithFlags_v3020_params_st;
 pub type cudaEventCreate_v3020_params = cudaEventCreate_v3020_params_st;
 pub type cudaEventDestroy_v3020_params = cudaEventDestroy_v3020_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaEventElapsedTime_v12080_params = cudaEventElapsedTime_v12080_params_st;
 #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaEventElapsedTime_v2_v12080_params = cudaEventElapsedTime_v2_v12080_params_st;
@@ -1014,21 +1020,21 @@ pub type cudaEventRecordWithFlags_v11010_params = cudaEventRecordWithFlags_v1101
 pub type cudaEventRecord_ptsz_v7000_params = cudaEventRecord_ptsz_v7000_params_st;
 pub type cudaEventRecord_v3020_params = cudaEventRecord_v3020_params_st;
 pub type cudaEventSynchronize_v3020_params = cudaEventSynchronize_v3020_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaExecutionCtxDestroy_v13010_params = cudaExecutionCtxDestroy_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaExecutionCtxGetDevResource_v13010_params = cudaExecutionCtxGetDevResource_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaExecutionCtxGetDevice_v13010_params = cudaExecutionCtxGetDevice_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaExecutionCtxGetId_v13010_params = cudaExecutionCtxGetId_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaExecutionCtxRecordEvent_v13010_params = cudaExecutionCtxRecordEvent_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaExecutionCtxStreamCreate_v13010_params = cudaExecutionCtxStreamCreate_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaExecutionCtxSynchronize_v13010_params = cudaExecutionCtxSynchronize_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaExecutionCtxWaitEvent_v13010_params = cudaExecutionCtxWaitEvent_v13010_params_st;
 pub type cudaExternalMemoryGetMappedBuffer_v10000_params = cudaExternalMemoryGetMappedBuffer_v10000_params_st;
 pub type cudaExternalMemoryGetMappedMipmappedArray_v10000_params = cudaExternalMemoryGetMappedMipmappedArray_v10000_params_st;
@@ -1039,11 +1045,11 @@ pub type cudaFreeHost_v3020_params = cudaFreeHost_v3020_params_st;
 pub type cudaFreeMipmappedArray_v5000_params = cudaFreeMipmappedArray_v5000_params_st;
 pub type cudaFree_v3020_params = cudaFree_v3020_params_st;
 pub type cudaFuncGetAttributes_v3020_params = cudaFuncGetAttributes_v3020_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaFuncGetName_v12030_params = cudaFuncGetName_v12030_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaFuncGetParamCount_v13020_params = cudaFuncGetParamCount_v13020_params_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaFuncGetParamInfo_v12040_params = cudaFuncGetParamInfo_v12040_params_st;
 pub type cudaFuncSetAttribute_v9000_params = cudaFuncSetAttribute_v9000_params_st;
 pub type cudaFuncSetCacheConfig_v3020_params = cudaFuncSetCacheConfig_v3020_params_st;
@@ -1051,23 +1057,23 @@ pub type cudaFuncSetSharedMemConfig_v4020_params = cudaFuncSetSharedMemConfig_v4
 pub type cudaGetChannelDesc_v3020_params = cudaGetChannelDesc_v3020_params_st;
 pub type cudaGetDeviceCount_v3020_params = cudaGetDeviceCount_v3020_params_st;
 pub type cudaGetDeviceFlags_v7000_params = cudaGetDeviceFlags_v7000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGetDeviceProperties_v12000_params = cudaGetDeviceProperties_v12000_params_st;
 #[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGetDeviceProperties_v2_v12000_params = cudaGetDeviceProperties_v2_v12000_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGetDeviceProperties_v3020_params = cudaGetDeviceProperties_v3020_params_st;
 pub type cudaGetDevice_v3020_params = cudaGetDevice_v3020_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGetDriverEntryPointByVersion_ptsz_v12050_params = cudaGetDriverEntryPointByVersion_ptsz_v12050_params_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGetDriverEntryPointByVersion_v12050_params = cudaGetDriverEntryPointByVersion_v12050_params_st;
 pub type cudaGetDriverEntryPoint_ptsz_v11030_params = cudaGetDriverEntryPoint_ptsz_v11030_params_st;
 pub type cudaGetDriverEntryPoint_v11030_params = cudaGetDriverEntryPoint_v11030_params_st;
 pub type cudaGetErrorName_v6050_params = cudaGetErrorName_v6050_params_st;
 pub type cudaGetErrorString_v3020_params = cudaGetErrorString_v3020_params_st;
 pub type cudaGetFuncBySymbol_v11000_params = cudaGetFuncBySymbol_v11000_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGetKernel_v12000_params = cudaGetKernel_v12000_params_st;
 pub type cudaGetMipmappedArrayLevel_v5000_params = cudaGetMipmappedArrayLevel_v5000_params_st;
 pub type cudaGetSurfaceObjectResourceDesc_v5000_params = cudaGetSurfaceObjectResourceDesc_v5000_params_st;
@@ -1085,7 +1091,7 @@ pub type cudaGetTextureReference_v3020_params = cudaGetTextureReference_v3020_pa
 pub type cudaGraphAddChildGraphNode_v10000_params = cudaGraphAddChildGraphNode_v10000_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphAddDependencies_v10000_params = cudaGraphAddDependencies_v10000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphAddDependencies_v12030_params = cudaGraphAddDependencies_v12030_params_st;
 #[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphAddDependencies_v2_v12030_params = cudaGraphAddDependencies_v2_v12030_params_st;
@@ -1105,15 +1111,15 @@ pub type cudaGraphAddMemcpyNode_v10000_params = cudaGraphAddMemcpyNode_v10000_pa
 pub type cudaGraphAddMemsetNode_v10000_params = cudaGraphAddMemsetNode_v10000_params_st;
 #[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphAddNode_v12020_params = cudaGraphAddNode_v12020_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphAddNode_v12030_params = cudaGraphAddNode_v12030_params_st;
 #[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphAddNode_v2_v12030_params = cudaGraphAddNode_v2_v12030_params_st;
 pub type cudaGraphChildGraphNodeGetGraph_v10000_params = cudaGraphChildGraphNodeGetGraph_v10000_params_st;
 pub type cudaGraphClone_v10000_params = cudaGraphClone_v10000_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphConditionalHandleCreate_v12030_params = cudaGraphConditionalHandleCreate_v12030_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphConditionalHandleCreate_v2_v13010_params = cudaGraphConditionalHandleCreate_v2_v13010_params_st;
 pub type cudaGraphCreate_v10000_params = cudaGraphCreate_v10000_params_st;
 pub type cudaGraphDebugDotPrint_v11030_params = cudaGraphDebugDotPrint_v11030_params_st;
@@ -1129,9 +1135,9 @@ pub type cudaGraphExecEventRecordNodeSetEvent_v11010_params = cudaGraphExecEvent
 pub type cudaGraphExecEventWaitNodeSetEvent_v11010_params = cudaGraphExecEventWaitNodeSetEvent_v11010_params_st;
 pub type cudaGraphExecExternalSemaphoresSignalNodeSetParams_v11020_params = cudaGraphExecExternalSemaphoresSignalNodeSetParams_v11020_params_st;
 pub type cudaGraphExecExternalSemaphoresWaitNodeSetParams_v11020_params = cudaGraphExecExternalSemaphoresWaitNodeSetParams_v11020_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphExecGetFlags_v12000_params = cudaGraphExecGetFlags_v12000_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphExecGetId_v13010_params = cudaGraphExecGetId_v13010_params_st;
 pub type cudaGraphExecHostNodeSetParams_v10020_params = cudaGraphExecHostNodeSetParams_v10020_params_st;
 pub type cudaGraphExecKernelNodeSetParams_v10010_params = cudaGraphExecKernelNodeSetParams_v10010_params_st;
@@ -1140,7 +1146,7 @@ pub type cudaGraphExecMemcpyNodeSetParamsFromSymbol_v11010_params = cudaGraphExe
 pub type cudaGraphExecMemcpyNodeSetParamsToSymbol_v11010_params = cudaGraphExecMemcpyNodeSetParamsToSymbol_v11010_params_st;
 pub type cudaGraphExecMemcpyNodeSetParams_v10020_params = cudaGraphExecMemcpyNodeSetParams_v10020_params_st;
 pub type cudaGraphExecMemsetNodeSetParams_v10020_params = cudaGraphExecMemsetNodeSetParams_v10020_params_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphExecNodeSetParams_v12020_params = cudaGraphExecNodeSetParams_v12020_params_st;
 pub type cudaGraphExecUpdate_v10020_params = cudaGraphExecUpdate_v10020_params_st;
 pub type cudaGraphExternalSemaphoresSignalNodeGetParams_v11020_params = cudaGraphExternalSemaphoresSignalNodeGetParams_v11020_params_st;
@@ -1149,24 +1155,24 @@ pub type cudaGraphExternalSemaphoresWaitNodeGetParams_v11020_params = cudaGraphE
 pub type cudaGraphExternalSemaphoresWaitNodeSetParams_v11020_params = cudaGraphExternalSemaphoresWaitNodeSetParams_v11020_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphGetEdges_v10000_params = cudaGraphGetEdges_v10000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphGetEdges_v12030_params = cudaGraphGetEdges_v12030_params_st;
 #[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphGetEdges_v2_v12030_params = cudaGraphGetEdges_v2_v12030_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphGetId_v13010_params = cudaGraphGetId_v13010_params_st;
 pub type cudaGraphGetNodes_v10000_params = cudaGraphGetNodes_v10000_params_st;
 pub type cudaGraphGetRootNodes_v10000_params = cudaGraphGetRootNodes_v10000_params_st;
 pub type cudaGraphHostNodeGetParams_v10000_params = cudaGraphHostNodeGetParams_v10000_params_st;
 pub type cudaGraphHostNodeSetParams_v10000_params = cudaGraphHostNodeSetParams_v10000_params_st;
 pub type cudaGraphInstantiateWithFlags_v11040_params = cudaGraphInstantiateWithFlags_v11040_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphInstantiateWithParams_ptsz_v12000_params = cudaGraphInstantiateWithParams_ptsz_v12000_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphInstantiateWithParams_v12000_params = cudaGraphInstantiateWithParams_v12000_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080"))]
 pub type cudaGraphInstantiate_v10000_params = cudaGraphInstantiate_v10000_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphInstantiate_v12000_params = cudaGraphInstantiate_v12000_params_st;
 pub type cudaGraphKernelNodeCopyAttributes_v11000_params = cudaGraphKernelNodeCopyAttributes_v11000_params_st;
 pub type cudaGraphKernelNodeGetAttribute_v11000_params = cudaGraphKernelNodeGetAttribute_v11000_params_st;
@@ -1185,37 +1191,37 @@ pub type cudaGraphMemcpyNodeSetParams_v10000_params = cudaGraphMemcpyNodeSetPara
 pub type cudaGraphMemsetNodeGetParams_v10000_params = cudaGraphMemsetNodeGetParams_v10000_params_st;
 pub type cudaGraphMemsetNodeSetParams_v10000_params = cudaGraphMemsetNodeSetParams_v10000_params_st;
 pub type cudaGraphNodeFindInClone_v10000_params = cudaGraphNodeFindInClone_v10000_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphNodeGetContainingGraph_v13010_params = cudaGraphNodeGetContainingGraph_v13010_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphNodeGetDependencies_v10000_params = cudaGraphNodeGetDependencies_v10000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphNodeGetDependencies_v12030_params = cudaGraphNodeGetDependencies_v12030_params_st;
 #[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphNodeGetDependencies_v2_v12030_params = cudaGraphNodeGetDependencies_v2_v12030_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphNodeGetDependentNodes_v10000_params = cudaGraphNodeGetDependentNodes_v10000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphNodeGetDependentNodes_v12030_params = cudaGraphNodeGetDependentNodes_v12030_params_st;
 #[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphNodeGetDependentNodes_v2_v12030_params = cudaGraphNodeGetDependentNodes_v2_v12030_params_st;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphNodeGetEnabled_v11060_params = cudaGraphNodeGetEnabled_v11060_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphNodeGetLocalId_v13010_params = cudaGraphNodeGetLocalId_v13010_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphNodeGetParams_v13020_params = cudaGraphNodeGetParams_v13020_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphNodeGetToolsId_v13010_params = cudaGraphNodeGetToolsId_v13010_params_st;
 pub type cudaGraphNodeGetType_v10000_params = cudaGraphNodeGetType_v10000_params_st;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphNodeSetEnabled_v11060_params = cudaGraphNodeSetEnabled_v11060_params_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphNodeSetParams_v12020_params = cudaGraphNodeSetParams_v12020_params_st;
 pub type cudaGraphReleaseUserObject_v11030_params = cudaGraphReleaseUserObject_v11030_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphRemoveDependencies_v10000_params = cudaGraphRemoveDependencies_v10000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphRemoveDependencies_v12030_params = cudaGraphRemoveDependencies_v12030_params_st;
 #[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaGraphRemoveDependencies_v2_v12030_params = cudaGraphRemoveDependencies_v2_v12030_params_st;
@@ -1229,7 +1235,7 @@ pub type cudaGraphicsResourceSetMapFlags_v3020_params = cudaGraphicsResourceSetM
 pub type cudaGraphicsSubResourceGetMappedArray_v3020_params = cudaGraphicsSubResourceGetMappedArray_v3020_params_st;
 pub type cudaGraphicsUnmapResources_v3020_params = cudaGraphicsUnmapResources_v3020_params_st;
 pub type cudaGraphicsUnregisterResource_v3020_params = cudaGraphicsUnregisterResource_v3020_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGreenCtxCreate_v13010_params = cudaGreenCtxCreate_v13010_params_st;
 pub type cudaHostAlloc_v3020_params = cudaHostAlloc_v3020_params_st;
 pub type cudaHostGetDevicePointer_v3020_params = cudaHostGetDevicePointer_v3020_params_st;
@@ -1238,14 +1244,14 @@ pub type cudaHostRegister_v4000_params = cudaHostRegister_v4000_params_st;
 pub type cudaHostUnregister_v4000_params = cudaHostUnregister_v4000_params_st;
 pub type cudaImportExternalMemory_v10000_params = cudaImportExternalMemory_v10000_params_st;
 pub type cudaImportExternalSemaphore_v10000_params = cudaImportExternalSemaphore_v10000_params_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaInitDevice_v12000_params = cudaInitDevice_v12000_params_st;
 pub type cudaIpcCloseMemHandle_v4010_params = cudaIpcCloseMemHandle_v4010_params_st;
 pub type cudaIpcGetEventHandle_v4010_params = cudaIpcGetEventHandle_v4010_params_st;
 pub type cudaIpcGetMemHandle_v4010_params = cudaIpcGetMemHandle_v4010_params_st;
 pub type cudaIpcOpenEventHandle_v4010_params = cudaIpcOpenEventHandle_v4010_params_st;
 pub type cudaIpcOpenMemHandle_v4010_params = cudaIpcOpenMemHandle_v4010_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaKernelSetAttributeForDevice_v12060_params = cudaKernelSetAttributeForDevice_v12060_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaLaunchCooperativeKernelMultiDevice_v9000_params = cudaLaunchCooperativeKernelMultiDevice_v9000_params_st;
@@ -1253,43 +1259,43 @@ pub type cudaLaunchCooperativeKernel_ptsz_v9000_params = cudaLaunchCooperativeKe
 pub type cudaLaunchCooperativeKernel_v9000_params = cudaLaunchCooperativeKernel_v9000_params_st;
 pub type cudaLaunchHostFunc_ptsz_v10000_params = cudaLaunchHostFunc_ptsz_v10000_params_st;
 pub type cudaLaunchHostFunc_v10000_params = cudaLaunchHostFunc_v10000_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLaunchHostFunc_v2_ptsz_v13020_params = cudaLaunchHostFunc_v2_ptsz_v13020_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLaunchHostFunc_v2_v13020_params = cudaLaunchHostFunc_v2_v13020_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLaunchKernelExC_ptsz_v11060_params = cudaLaunchKernelExC_ptsz_v11060_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLaunchKernelExC_v11060_params = cudaLaunchKernelExC_v11060_params_st;
 pub type cudaLaunchKernel_ptsz_v7000_params = cudaLaunchKernel_ptsz_v7000_params_st;
 pub type cudaLaunchKernel_v7000_params = cudaLaunchKernel_v7000_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibraryEnumerateKernels_v12060_params = cudaLibraryEnumerateKernels_v12060_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibraryGetGlobal_v12060_params = cudaLibraryGetGlobal_v12060_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibraryGetKernelCount_v12060_params = cudaLibraryGetKernelCount_v12060_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibraryGetKernel_v12060_params = cudaLibraryGetKernel_v12060_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibraryGetManaged_v12060_params = cudaLibraryGetManaged_v12060_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibraryGetUnifiedFunction_v12060_params = cudaLibraryGetUnifiedFunction_v12060_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibraryLoadData_v12060_params = cudaLibraryLoadData_v12060_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibraryLoadFromFile_v12060_params = cudaLibraryLoadFromFile_v12060_params_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibraryUnload_v12060_params = cudaLibraryUnload_v12060_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLogsCurrent_v13000_params = cudaLogsCurrent_v13000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLogsDumpToFile_v13000_params = cudaLogsDumpToFile_v13000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLogsDumpToMemory_v13000_params = cudaLogsDumpToMemory_v13000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLogsRegisterCallback_v13000_params = cudaLogsRegisterCallback_v13000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLogsUnregisterCallback_v13000_params = cudaLogsUnregisterCallback_v13000_params_st;
 pub type cudaMalloc3DArray_v3020_params = cudaMalloc3DArray_v3020_params_st;
 pub type cudaMalloc3D_v3020_params = cudaMalloc3D_v3020_params_st;
@@ -1303,24 +1309,24 @@ pub type cudaMallocManaged_v6000_params = cudaMallocManaged_v6000_params_st;
 pub type cudaMallocMipmappedArray_v5000_params = cudaMallocMipmappedArray_v5000_params_st;
 pub type cudaMallocPitch_v3020_params = cudaMallocPitch_v3020_params_st;
 pub type cudaMalloc_v3020_params = cudaMalloc_v3020_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemAdvise_v12020_params = cudaMemAdvise_v12020_params_st;
 #[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaMemAdvise_v2_v12020_params = cudaMemAdvise_v2_v12020_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaMemAdvise_v8000_params = cudaMemAdvise_v8000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemDiscardAndPrefetchBatchAsync_ptsz_v13000_params = cudaMemDiscardAndPrefetchBatchAsync_ptsz_v13000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemDiscardAndPrefetchBatchAsync_v13000_params = cudaMemDiscardAndPrefetchBatchAsync_v13000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemDiscardBatchAsync_ptsz_v13000_params = cudaMemDiscardBatchAsync_ptsz_v13000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemDiscardBatchAsync_v13000_params = cudaMemDiscardBatchAsync_v13000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemGetDefaultMemPool_v13000_params = cudaMemGetDefaultMemPool_v13000_params_st;
 pub type cudaMemGetInfo_v3020_params = cudaMemGetInfo_v3020_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemGetMemPool_v13000_params = cudaMemGetMemPool_v13000_params_st;
 pub type cudaMemPoolCreate_v11020_params = cudaMemPoolCreate_v11020_params_st;
 pub type cudaMemPoolDestroy_v11020_params = cudaMemPoolDestroy_v11020_params_st;
@@ -1333,11 +1339,11 @@ pub type cudaMemPoolImportPointer_v11020_params = cudaMemPoolImportPointer_v1102
 pub type cudaMemPoolSetAccess_v11020_params = cudaMemPoolSetAccess_v11020_params_st;
 pub type cudaMemPoolSetAttribute_v11020_params = cudaMemPoolSetAttribute_v11020_params_st;
 pub type cudaMemPoolTrimTo_v11020_params = cudaMemPoolTrimTo_v11020_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemPrefetchAsync_ptsz_v12020_params = cudaMemPrefetchAsync_ptsz_v12020_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaMemPrefetchAsync_ptsz_v8000_params = cudaMemPrefetchAsync_ptsz_v8000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemPrefetchAsync_v12020_params = cudaMemPrefetchAsync_v12020_params_st;
 #[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaMemPrefetchAsync_v2_ptsz_v12020_params = cudaMemPrefetchAsync_v2_ptsz_v12020_params_st;
@@ -1345,13 +1351,13 @@ pub type cudaMemPrefetchAsync_v2_ptsz_v12020_params = cudaMemPrefetchAsync_v2_pt
 pub type cudaMemPrefetchAsync_v2_v12020_params = cudaMemPrefetchAsync_v2_v12020_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaMemPrefetchAsync_v8000_params = cudaMemPrefetchAsync_v8000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemPrefetchBatchAsync_ptsz_v13000_params = cudaMemPrefetchBatchAsync_ptsz_v13000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemPrefetchBatchAsync_v13000_params = cudaMemPrefetchBatchAsync_v13000_params_st;
 pub type cudaMemRangeGetAttribute_v8000_params = cudaMemRangeGetAttribute_v8000_params_st;
 pub type cudaMemRangeGetAttributes_v8000_params = cudaMemRangeGetAttributes_v8000_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemSetMemPool_v13000_params = cudaMemSetMemPool_v13000_params_st;
 pub type cudaMemcpy2DArrayToArray_ptds_v7000_params = cudaMemcpy2DArrayToArray_ptds_v7000_params_st;
 pub type cudaMemcpy2DArrayToArray_v3020_params = cudaMemcpy2DArrayToArray_v3020_params_st;
@@ -1371,19 +1377,19 @@ pub type cudaMemcpy3DAsync_ptsz_v7000_params = cudaMemcpy3DAsync_ptsz_v7000_para
 pub type cudaMemcpy3DAsync_v3020_params = cudaMemcpy3DAsync_v3020_params_st;
 #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaMemcpy3DBatchAsync_ptsz_v12080_params = cudaMemcpy3DBatchAsync_ptsz_v12080_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemcpy3DBatchAsync_ptsz_v13000_params = cudaMemcpy3DBatchAsync_ptsz_v13000_params_st;
 #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaMemcpy3DBatchAsync_v12080_params = cudaMemcpy3DBatchAsync_v12080_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemcpy3DBatchAsync_v13000_params = cudaMemcpy3DBatchAsync_v13000_params_st;
 pub type cudaMemcpy3DPeerAsync_ptsz_v7000_params = cudaMemcpy3DPeerAsync_ptsz_v7000_params_st;
 pub type cudaMemcpy3DPeerAsync_v4000_params = cudaMemcpy3DPeerAsync_v4000_params_st;
 pub type cudaMemcpy3DPeer_ptds_v7000_params = cudaMemcpy3DPeer_ptds_v7000_params_st;
 pub type cudaMemcpy3DPeer_v4000_params = cudaMemcpy3DPeer_v4000_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemcpy3DWithAttributesAsync_ptsz_v13020_params = cudaMemcpy3DWithAttributesAsync_ptsz_v13020_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemcpy3DWithAttributesAsync_v13020_params = cudaMemcpy3DWithAttributesAsync_v13020_params_st;
 pub type cudaMemcpy3D_ptds_v7000_params = cudaMemcpy3D_ptds_v7000_params_st;
 pub type cudaMemcpy3D_v3020_params = cudaMemcpy3D_v3020_params_st;
@@ -1393,11 +1399,11 @@ pub type cudaMemcpyAsync_ptsz_v7000_params = cudaMemcpyAsync_ptsz_v7000_params_s
 pub type cudaMemcpyAsync_v3020_params = cudaMemcpyAsync_v3020_params_st;
 #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaMemcpyBatchAsync_ptsz_v12080_params = cudaMemcpyBatchAsync_ptsz_v12080_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemcpyBatchAsync_ptsz_v13000_params = cudaMemcpyBatchAsync_ptsz_v13000_params_st;
 #[cfg(any(feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaMemcpyBatchAsync_v12080_params = cudaMemcpyBatchAsync_v12080_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemcpyBatchAsync_v13000_params = cudaMemcpyBatchAsync_v13000_params_st;
 pub type cudaMemcpyFromArrayAsync_ptsz_v7000_params = cudaMemcpyFromArrayAsync_ptsz_v7000_params_st;
 pub type cudaMemcpyFromArrayAsync_v3020_params = cudaMemcpyFromArrayAsync_v3020_params_st;
@@ -1417,9 +1423,9 @@ pub type cudaMemcpyToSymbolAsync_ptsz_v7000_params = cudaMemcpyToSymbolAsync_pts
 pub type cudaMemcpyToSymbolAsync_v3020_params = cudaMemcpyToSymbolAsync_v3020_params_st;
 pub type cudaMemcpyToSymbol_ptds_v7000_params = cudaMemcpyToSymbol_ptds_v7000_params_st;
 pub type cudaMemcpyToSymbol_v3020_params = cudaMemcpyToSymbol_v3020_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemcpyWithAttributesAsync_ptsz_v13020_params = cudaMemcpyWithAttributesAsync_ptsz_v13020_params_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemcpyWithAttributesAsync_v13020_params = cudaMemcpyWithAttributesAsync_v13020_params_st;
 pub type cudaMemcpy_ptds_v7000_params = cudaMemcpy_ptds_v7000_params_st;
 pub type cudaMemcpy_v3020_params = cudaMemcpy_v3020_params_st;
@@ -1435,15 +1441,15 @@ pub type cudaMemsetAsync_ptsz_v7000_params = cudaMemsetAsync_ptsz_v7000_params_s
 pub type cudaMemsetAsync_v3020_params = cudaMemsetAsync_v3020_params_st;
 pub type cudaMemset_ptds_v7000_params = cudaMemset_ptds_v7000_params_st;
 pub type cudaMemset_v3020_params = cudaMemset_v3020_params_st;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMipmappedArrayGetMemoryRequirements_v11060_params = cudaMipmappedArrayGetMemoryRequirements_v11060_params_st;
 pub type cudaMipmappedArrayGetSparseProperties_v11010_params = cudaMipmappedArrayGetSparseProperties_v11010_params_st;
 pub type cudaOccupancyAvailableDynamicSMemPerBlock_v10200_params = cudaOccupancyAvailableDynamicSMemPerBlock_v10200_params_st;
 pub type cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_v7000_params = cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_v7000_params_st;
 pub type cudaOccupancyMaxActiveBlocksPerMultiprocessor_v6050_params = cudaOccupancyMaxActiveBlocksPerMultiprocessor_v6050_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaOccupancyMaxActiveClusters_v11070_params = cudaOccupancyMaxActiveClusters_v11070_params_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaOccupancyMaxPotentialClusterSize_v11070_params = cudaOccupancyMaxPotentialClusterSize_v11070_params_st;
 pub type cudaPointerGetAttributes_v4000_params = cudaPointerGetAttributes_v4000_params_st;
 pub type cudaRuntimeGetVersion_v3020_params = cudaRuntimeGetVersion_v3020_params_st;
@@ -1454,9 +1460,9 @@ pub type cudaSetDoubleForDevice_v3020_params = cudaSetDoubleForDevice_v3020_para
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11070", feature = "cuda-12000", feature = "cuda-12090"))]
 pub type cudaSetDoubleForHost_v3020_params = cudaSetDoubleForHost_v3020_params_st;
 pub type cudaSetValidDevices_v3020_params = cudaSetValidDevices_v3020_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaSignalExternalSemaphoresAsync_ptsz_v11020_params = cudaSignalExternalSemaphoresAsync_ptsz_v11020_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaSignalExternalSemaphoresAsync_v11020_params = cudaSignalExternalSemaphoresAsync_v11020_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaSignalExternalSemaphoresAsync_v2_ptsz_v11020_params = cudaSignalExternalSemaphoresAsync_v2_ptsz_v11020_params_st;
@@ -1466,12 +1472,16 @@ pub type cudaStreamAddCallback_ptsz_v7000_params = cudaStreamAddCallback_ptsz_v7
 pub type cudaStreamAddCallback_v5000_params = cudaStreamAddCallback_v5000_params_st;
 pub type cudaStreamAttachMemAsync_ptsz_v7000_params = cudaStreamAttachMemAsync_ptsz_v7000_params_st;
 pub type cudaStreamAttachMemAsync_v6000_params = cudaStreamAttachMemAsync_v6000_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamBeginCaptureToGraph_ptsz_v12030_params = cudaStreamBeginCaptureToGraph_ptsz_v12030_params_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamBeginCaptureToGraph_v12030_params = cudaStreamBeginCaptureToGraph_v12030_params_st;
 pub type cudaStreamBeginCapture_ptsz_v10000_params = cudaStreamBeginCapture_ptsz_v10000_params_st;
 pub type cudaStreamBeginCapture_v10000_params = cudaStreamBeginCapture_v10000_params_st;
+#[cfg(any(feature = "cuda-13030"))]
+pub type cudaStreamBeginRecaptureToGraph_ptsz_v13030_params = cudaStreamBeginRecaptureToGraph_ptsz_v13030_params_st;
+#[cfg(any(feature = "cuda-13030"))]
+pub type cudaStreamBeginRecaptureToGraph_v13030_params = cudaStreamBeginRecaptureToGraph_v13030_params_st;
 pub type cudaStreamCopyAttributes_ptsz_v11000_params = cudaStreamCopyAttributes_ptsz_v11000_params_st;
 pub type cudaStreamCopyAttributes_v11000_params = cudaStreamCopyAttributes_v11000_params_st;
 pub type cudaStreamCreateWithFlags_v5000_params = cudaStreamCreateWithFlags_v5000_params_st;
@@ -1484,11 +1494,11 @@ pub type cudaStreamGetAttribute_ptsz_v11000_params = cudaStreamGetAttribute_ptsz
 pub type cudaStreamGetAttribute_v11000_params = cudaStreamGetAttribute_v11000_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaStreamGetCaptureInfo_ptsz_v10010_params = cudaStreamGetCaptureInfo_ptsz_v10010_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamGetCaptureInfo_ptsz_v12030_params = cudaStreamGetCaptureInfo_ptsz_v12030_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaStreamGetCaptureInfo_v10010_params = cudaStreamGetCaptureInfo_v10010_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamGetCaptureInfo_v12030_params = cudaStreamGetCaptureInfo_v12030_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaStreamGetCaptureInfo_v2_ptsz_v11030_params = cudaStreamGetCaptureInfo_v2_ptsz_v11030_params_st;
@@ -1498,19 +1508,19 @@ pub type cudaStreamGetCaptureInfo_v2_v11030_params = cudaStreamGetCaptureInfo_v2
 pub type cudaStreamGetCaptureInfo_v3_ptsz_v12030_params = cudaStreamGetCaptureInfo_v3_ptsz_v12030_params_st;
 #[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaStreamGetCaptureInfo_v3_v12030_params = cudaStreamGetCaptureInfo_v3_v12030_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamGetDevResource_ptsz_v13010_params = cudaStreamGetDevResource_ptsz_v13010_params_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamGetDevResource_v13010_params = cudaStreamGetDevResource_v13010_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamGetDevice_ptsz_v12080_params = cudaStreamGetDevice_ptsz_v12080_params_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamGetDevice_v12080_params = cudaStreamGetDevice_v12080_params_st;
 pub type cudaStreamGetFlags_ptsz_v7000_params = cudaStreamGetFlags_ptsz_v7000_params_st;
 pub type cudaStreamGetFlags_v5050_params = cudaStreamGetFlags_v5050_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamGetId_ptsz_v12000_params = cudaStreamGetId_ptsz_v12000_params_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamGetId_v12000_params = cudaStreamGetId_v12000_params_st;
 pub type cudaStreamGetPriority_ptsz_v7000_params = cudaStreamGetPriority_ptsz_v7000_params_st;
 pub type cudaStreamGetPriority_v5050_params = cudaStreamGetPriority_v5050_params_st;
@@ -1524,11 +1534,11 @@ pub type cudaStreamSynchronize_ptsz_v7000_params = cudaStreamSynchronize_ptsz_v7
 pub type cudaStreamSynchronize_v3020_params = cudaStreamSynchronize_v3020_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaStreamUpdateCaptureDependencies_ptsz_v11030_params = cudaStreamUpdateCaptureDependencies_ptsz_v11030_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamUpdateCaptureDependencies_ptsz_v12030_params = cudaStreamUpdateCaptureDependencies_ptsz_v12030_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaStreamUpdateCaptureDependencies_v11030_params = cudaStreamUpdateCaptureDependencies_v11030_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaStreamUpdateCaptureDependencies_v12030_params = cudaStreamUpdateCaptureDependencies_v12030_params_st;
 #[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaStreamUpdateCaptureDependencies_v2_ptsz_v12030_params = cudaStreamUpdateCaptureDependencies_v2_ptsz_v12030_params_st;
@@ -1550,9 +1560,9 @@ pub type cudaUnbindTexture_v3020_params = cudaUnbindTexture_v3020_params_st;
 pub type cudaUserObjectCreate_v11030_params = cudaUserObjectCreate_v11030_params_st;
 pub type cudaUserObjectRelease_v11030_params = cudaUserObjectRelease_v11030_params_st;
 pub type cudaUserObjectRetain_v11030_params = cudaUserObjectRetain_v11030_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaWaitExternalSemaphoresAsync_ptsz_v11020_params = cudaWaitExternalSemaphoresAsync_ptsz_v11020_params_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaWaitExternalSemaphoresAsync_v11020_params = cudaWaitExternalSemaphoresAsync_v11020_params_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090"))]
 pub type cudaWaitExternalSemaphoresAsync_v2_ptsz_v11020_params = cudaWaitExternalSemaphoresAsync_v2_ptsz_v11020_params_st;
@@ -1764,7 +1774,7 @@ pub enum CUptiResult {
     CUPTI_ERROR_UNKNOWN = 999,
     CUPTI_ERROR_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUptiResult {
@@ -1819,7 +1829,7 @@ pub enum CUptiResult {
     CUPTI_ERROR_UNKNOWN = 999,
     CUPTI_ERROR_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityApiFieldIds {
@@ -1911,6 +1921,36 @@ pub enum CUpti_ActivityAttribute {
     CUPTI_ACTIVITY_ATTR_CIG_MODE = 23,
     CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_FORCE_INT = 2147483647,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_ActivityAttribute {
+    CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_SIZE = 0,
+    CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_SIZE_CDP = 1,
+    CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_POOL_LIMIT = 2,
+    CUPTI_ACTIVITY_ATTR_PROFILING_SEMAPHORE_POOL_SIZE = 3,
+    CUPTI_ACTIVITY_ATTR_PROFILING_SEMAPHORE_POOL_LIMIT = 4,
+    CUPTI_ACTIVITY_ATTR_ZEROED_OUT_ACTIVITY_BUFFER = 5,
+    CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_PRE_ALLOCATE_VALUE = 6,
+    CUPTI_ACTIVITY_ATTR_PROFILING_SEMAPHORE_PRE_ALLOCATE_VALUE = 7,
+    CUPTI_ACTIVITY_ATTR_MEM_ALLOCATION_TYPE_HOST_PINNED = 8,
+    CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFER = 9,
+    CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_SIZE_DEVICE_GRAPHS = 10,
+    CUPTI_ACTIVITY_ATTR_USER_DEFINED_RECORDS = 11,
+    CUPTI_ACTIVITY_ATTR_MULTIPLE_SUBSCRIBER_STATE = 12,
+    CUPTI_ACTIVITY_ATTR_ENABLE_HES = 13,
+    CUPTI_ACTIVITY_ATTR_ENABLE_ALLOCATION_SOURCE_TRACKING = 14,
+    CUPTI_ACTIVITY_ATTR_ENABLE_KERNEL_LATENCY_TIMESTAMPS = 15,
+    CUPTI_ACTIVITY_ATTR_ENABLE_ALL_SYNC_RECORDS = 16,
+    CUPTI_ACTIVITY_ATTR_ENABLE_CUDA_EVENT_DEVICE_TIMESTAMPS = 17,
+    CUPTI_ACTIVITY_ATTR_ENABLE_KERNEL_LAUNCH_ATTRIBUTES = 18,
+    CUPTI_ACTIVITY_ATTR_ENABLE_DEVICE_GRAPH_TRACE = 19,
+    CUPTI_ACTIVITY_ATTR_ENABLE_MULTI_SUBSCRIBER_GRAPH_TRACE = 20,
+    CUPTI_ACTIVITY_ATTR_THREAD_ID_TYPE = 21,
+    CUPTI_ACTIVITY_ATTR_TIMESTAMP_CALLBACK = 22,
+    CUPTI_ACTIVITY_ATTR_ENABLE_CIG_MODE = 23,
+    CUPTI_ACTIVITY_ATTR_DEVICE_BUFFER_FORCE_INT = 2147483647,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityComputeApiKind {
@@ -1919,7 +1959,7 @@ pub enum CUpti_ActivityComputeApiKind {
     CUPTI_ACTIVITY_COMPUTE_API_CUDA_MPS = 2,
     CUPTI_ACTIVITY_COMPUTE_API_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityComputeEngineCtxSwitchFieldIds {
@@ -1929,7 +1969,7 @@ pub enum CUpti_ActivityComputeEngineCtxSwitchFieldIds {
     COMPUTE_ENGINE_CTX_SWITCH_FIELD_OPERATION_TYPE = 3,
     COMPUTE_ENGINE_CTX_SWITCH_FIELD_MAX = 4,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityConfidentialComputeRotationFieldIds {
@@ -1942,7 +1982,7 @@ pub enum CUpti_ActivityConfidentialComputeRotationFieldIds {
     CONFIDENTIAL_COMPUTE_ROTATION_FIELD_TIMESTAMP = 6,
     CONFIDENTIAL_COMPUTE_ROTATION_FIELD_MAX = 7,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityContextFieldIds {
@@ -1958,7 +1998,7 @@ pub enum CUpti_ActivityContextFieldIds {
     CONTEXT_FIELD_PROCESS_ID = 9,
     CONTEXT_FIELD_MAX = 10,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityCudaEventFieldIds {
@@ -1972,7 +2012,7 @@ pub enum CUpti_ActivityCudaEventFieldIds {
     CUDA_EVENT_FIELD_CUDA_EVENT_SYNC_ID = 7,
     CUDA_EVENT_FIELD_MAX = 8,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityDeviceFieldIds {
@@ -2016,7 +2056,7 @@ pub enum CUpti_ActivityDeviceFieldIds {
     DEVICE_FIELD_NUM_TPCS = 37,
     DEVICE_FIELD_MAX = 38,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityDeviceGraphTraceFieldIds {
@@ -2031,6 +2071,17 @@ pub enum CUpti_ActivityDeviceGraphTraceFieldIds {
     DEVICE_GRAPH_TRACE_FIELD_STREAM_ID = 8,
     DEVICE_GRAPH_TRACE_FIELD_MAX = 9,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_ActivityEnvironmentFieldIds {
+    ENVIRONMENT_FIELD_KIND = 0,
+    ENVIRONMENT_FIELD_DEVICE_ID = 1,
+    ENVIRONMENT_FIELD_TIMESTAMP = 2,
+    ENVIRONMENT_FIELD_ENVIRONMENT_KIND = 3,
+    ENVIRONMENT_FIELD_ENVIRONMENT_KIND_DATA = 4,
+    ENVIRONMENT_FIELD_MAX = 5,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityEnvironmentKind {
@@ -2042,7 +2093,7 @@ pub enum CUpti_ActivityEnvironmentKind {
     CUPTI_ACTIVITY_ENVIRONMENT_COUNT = 5,
     CUPTI_ACTIVITY_ENVIRONMENT_KIND_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityExternalCorrelationFieldIds {
@@ -2069,7 +2120,7 @@ pub enum CUpti_ActivityFlag {
     CUPTI_ACTIVITY_FLAG_INSTRUCTION_CLASS_MASK = 510,
     CUPTI_ACTIVITY_FLAG_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityGraphHostNodeFieldIds {
@@ -2086,7 +2137,7 @@ pub enum CUpti_ActivityGraphHostNodeFieldIds {
     GRAPH_HOST_NODE_FIELD_END = 10,
     GRAPH_HOST_NODE_FIELD_MAX = 11,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityGraphTraceFieldIds {
@@ -2102,7 +2153,7 @@ pub enum CUpti_ActivityGraphTraceFieldIds {
     GRAPH_TRACE_FIELD_END_CONTEXT_ID = 9,
     GRAPH_TRACE_FIELD_MAX = 10,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityGreenContextFieldIds {
@@ -2119,7 +2170,7 @@ pub enum CUpti_ActivityGreenContextFieldIds {
     GREEN_CONTEXT_FIELD_WORKQUEUE_SHARING_SCOPE = 10,
     GREEN_CONTEXT_FIELD_MAX = 11,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityHostLaunchFieldIds {
@@ -2160,7 +2211,7 @@ pub enum CUpti_ActivityInstructionClass {
     CUPTI_ACTIVITY_INSTRUCTION_CLASS_UNIFORM = 20,
     CUPTI_ACTIVITY_INSTRUCTION_CLASS_KIND_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityJitEntryType {
@@ -2169,7 +2220,7 @@ pub enum CUpti_ActivityJitEntryType {
     CUPTI_ACTIVITY_JIT_ENTRY_NVVM_IR_TO_PTX = 2,
     CUPTI_ACTIVITY_JIT_ENTRY_TYPE_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityJitFieldIds {
@@ -2187,7 +2238,7 @@ pub enum CUpti_ActivityJitFieldIds {
     JIT_FIELD_THREAD_ID = 11,
     JIT_FIELD_MAX = 12,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityJitOperationType {
@@ -2248,6 +2299,59 @@ pub enum CUpti_ActivityKernelFieldIds {
     KERNEL_FIELD_IS_DEVICE_LAUNCHED = 44,
     KERNEL_FIELD_LAUNCH_PRIORITY = 45,
     KERNEL_FIELD_MAX = 46,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_ActivityKernelFieldIds {
+    KERNEL_FIELD_KIND = 0,
+    KERNEL_FIELD_CACHE_CONFIG_REQUESTED = 1,
+    KERNEL_FIELD_CACHE_CONFIG_EXECUTED = 2,
+    KERNEL_FIELD_SHARED_MEMORY_CONFIG = 3,
+    KERNEL_FIELD_REGISTERS_PER_THREAD = 4,
+    KERNEL_FIELD_PARTITIONED_GLOBAL_CACHE_REQUESTED = 5,
+    KERNEL_FIELD_PARTITIONED_GLOBAL_CACHE_EXECUTED = 6,
+    KERNEL_FIELD_START = 7,
+    KERNEL_FIELD_END = 8,
+    KERNEL_FIELD_COMPLETED = 9,
+    KERNEL_FIELD_DEVICE_ID = 10,
+    KERNEL_FIELD_CONTEXT_ID = 11,
+    KERNEL_FIELD_STREAM_ID = 12,
+    KERNEL_FIELD_GRID_X = 13,
+    KERNEL_FIELD_GRID_Y = 14,
+    KERNEL_FIELD_GRID_Z = 15,
+    KERNEL_FIELD_BLOCK_X = 16,
+    KERNEL_FIELD_BLOCK_Y = 17,
+    KERNEL_FIELD_BLOCK_Z = 18,
+    KERNEL_FIELD_STATIC_SHARED_MEMORY = 19,
+    KERNEL_FIELD_DYNAMIC_SHARED_MEMORY = 20,
+    KERNEL_FIELD_LOCAL_MEMORY_PER_THREAD = 21,
+    KERNEL_FIELD_CORRELATION_ID = 22,
+    KERNEL_FIELD_GRID_ID = 23,
+    KERNEL_FIELD_NAME = 24,
+    KERNEL_FIELD_QUEUED = 25,
+    KERNEL_FIELD_SUBMITTED = 26,
+    KERNEL_FIELD_LAUNCH_TYPE = 27,
+    KERNEL_FIELD_IS_SHARED_MEMORY_CARVEOUT_REQUESTED = 28,
+    KERNEL_FIELD_SHARED_MEMORY_CARVEOUT_REQUESTED = 29,
+    KERNEL_FIELD_SHARED_MEMORY_EXECUTED = 30,
+    KERNEL_FIELD_GRAPH_NODE_ID = 31,
+    KERNEL_FIELD_SHMEM_LIMIT_CONFIG = 32,
+    KERNEL_FIELD_GRAPH_ID = 33,
+    KERNEL_FIELD_ACCESS_POLICY_WINDOW = 34,
+    KERNEL_FIELD_CHANNEL_ID = 35,
+    KERNEL_FIELD_CHANNEL_TYPE = 36,
+    KERNEL_FIELD_CLUSTER_X = 37,
+    KERNEL_FIELD_CLUSTER_Y = 38,
+    KERNEL_FIELD_CLUSTER_Z = 39,
+    KERNEL_FIELD_CLUSTER_SCHEDULING_POLICY = 40,
+    KERNEL_FIELD_LOCAL_MEMORY_TOTAL = 41,
+    KERNEL_FIELD_MAX_POTENTIAL_CLUSTER_SIZE = 42,
+    KERNEL_FIELD_MAX_ACTIVE_CLUSTERS = 43,
+    KERNEL_FIELD_IS_DEVICE_LAUNCHED = 44,
+    KERNEL_FIELD_LAUNCH_PRIORITY = 45,
+    KERNEL_FIELD_EXECUTION_MODEL = 46,
+    KERNEL_FIELD_MAX = 47,
 }
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060"))]
 #[repr(u32)]
@@ -2617,7 +2721,7 @@ pub enum CUpti_ActivityKind {
     CUPTI_ACTIVITY_KIND_COUNT = 59,
     CUPTI_ACTIVITY_KIND_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityKind {
@@ -2692,7 +2796,7 @@ pub enum CUpti_ActivityLaunchType {
     CUPTI_ACTIVITY_LAUNCH_TYPE_COOPERATIVE_SINGLE_DEVICE = 1,
     CUPTI_ACTIVITY_LAUNCH_TYPE_COOPERATIVE_MULTI_DEVICE = 2,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityLaunchType {
@@ -2701,7 +2805,7 @@ pub enum CUpti_ActivityLaunchType {
     CUPTI_ACTIVITY_LAUNCH_TYPE_COOPERATIVE_MULTI_DEVICE = 2,
     CUPTI_ACTIVITY_LAUNCH_TYPE_CBL_COMMANDLIST = 3,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityMarkerDataFieldIds {
@@ -2715,7 +2819,7 @@ pub enum CUpti_ActivityMarkerDataFieldIds {
     MARKER_DATA_FIELD_CUPTI_DOMAIN_ID = 7,
     MARKER_DATA_FIELD_MAX = 8,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityMarkerFieldIds {
@@ -2729,7 +2833,7 @@ pub enum CUpti_ActivityMarkerFieldIds {
     MARKER_FIELD_DOMAIN = 7,
     MARKER_FIELD_MAX = 8,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityMemDecompressFieldIds {
@@ -2746,7 +2850,7 @@ pub enum CUpti_ActivityMemDecompressFieldIds {
     MEM_DECOMPRESS_FIELD_END = 10,
     MEM_DECOMPRESS_FIELD_MAX = 11,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityMemcpy2FieldIds {
@@ -2772,7 +2876,7 @@ pub enum CUpti_ActivityMemcpy2FieldIds {
     MEMCPY2_FIELD_CHANNEL_TYPE = 19,
     MEMCPY2_FIELD_MAX = 20,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityMemcpyFieldIds {
@@ -2812,7 +2916,7 @@ pub enum CUpti_ActivityMemcpyKind {
     CUPTI_ACTIVITY_MEMCPY_KIND_PTOP = 10,
     CUPTI_ACTIVITY_MEMCPY_KIND_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityMemoryFieldIds {
@@ -2858,7 +2962,7 @@ pub enum CUpti_ActivityMemoryOperationType {
     CUPTI_ACTIVITY_MEMORY_OPERATION_TYPE_RELEASE = 2,
     CUPTI_ACTIVITY_MEMORY_OPERATION_TYPE_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityMemoryPoolFieldIds {
@@ -2894,7 +2998,7 @@ pub enum CUpti_ActivityMemoryPoolType {
     CUPTI_ACTIVITY_MEMORY_POOL_TYPE_IMPORTED = 2,
     CUPTI_ACTIVITY_MEMORY_POOL_TYPE_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityMemsetFieldIds {
@@ -2916,7 +3020,7 @@ pub enum CUpti_ActivityMemsetFieldIds {
     MEMSET_FIELD_IS_DEVICE_LAUNCHED = 15,
     MEMSET_FIELD_MAX = 16,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityNameFieldIds {
@@ -2925,6 +3029,24 @@ pub enum CUpti_ActivityNameFieldIds {
     NAME_FIELD_OBJECT_ID = 2,
     NAME_FIELD_NAME = 3,
     NAME_FIELD_MAX = 4,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_ActivityNvLinkFieldIds {
+    NVLINK_FIELD_KIND = 0,
+    NVLINK_FIELD_NVLINK_VERSION = 1,
+    NVLINK_FIELD_TYPE_DEV0 = 2,
+    NVLINK_FIELD_TYPE_DEV1 = 3,
+    NVLINK_FIELD_ID_DEV0 = 4,
+    NVLINK_FIELD_ID_DEV1 = 5,
+    NVLINK_FIELD_FLAG = 6,
+    NVLINK_FIELD_PHYSICAL_NVLINK_COUNT = 7,
+    NVLINK_FIELD_PORT_DEV0 = 8,
+    NVLINK_FIELD_PORT_DEV1 = 9,
+    NVLINK_FIELD_BANDWIDTH = 10,
+    NVLINK_FIELD_NVSWITCH_CONNECTED = 11,
+    NVLINK_FIELD_MAX = 12,
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -2937,7 +3059,117 @@ pub enum CUpti_ActivityObjectKind {
     CUPTI_ACTIVITY_OBJECT_STREAM = 5,
     CUPTI_ACTIVITY_OBJECT_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_ActivityOpenAccDataFieldIds {
+    OPENACC_DATA_FIELD_KIND = 0,
+    OPENACC_DATA_FIELD_EVENT_KIND = 1,
+    OPENACC_DATA_FIELD_PARENT_CONSTRUCT = 2,
+    OPENACC_DATA_FIELD_VERSION = 3,
+    OPENACC_DATA_FIELD_IMPLICIT = 4,
+    OPENACC_DATA_FIELD_DEVICE_TYPE = 5,
+    OPENACC_DATA_FIELD_DEVICE_NUMBER = 6,
+    OPENACC_DATA_FIELD_THREAD_ID = 7,
+    OPENACC_DATA_FIELD_ASYNC = 8,
+    OPENACC_DATA_FIELD_ASYNC_MAP = 9,
+    OPENACC_DATA_FIELD_LINE_NO = 10,
+    OPENACC_DATA_FIELD_END_LINE_NO = 11,
+    OPENACC_DATA_FIELD_FUNC_LINE_NO = 12,
+    OPENACC_DATA_FIELD_FUNC_END_LINE_NO = 13,
+    OPENACC_DATA_FIELD_START = 14,
+    OPENACC_DATA_FIELD_END = 15,
+    OPENACC_DATA_FIELD_CU_DEVICE_ID = 16,
+    OPENACC_DATA_FIELD_CU_CONTEXT_ID = 17,
+    OPENACC_DATA_FIELD_CU_STREAM_ID = 18,
+    OPENACC_DATA_FIELD_CU_PROCESS_ID = 19,
+    OPENACC_DATA_FIELD_CU_THREAD_ID = 20,
+    OPENACC_DATA_FIELD_EXTERNAL_ID = 21,
+    OPENACC_DATA_FIELD_SRC_FILE = 22,
+    OPENACC_DATA_FIELD_FUNC_NAME = 23,
+    OPENACC_DATA_FIELD_BYTES = 24,
+    OPENACC_DATA_FIELD_HOST_PTR = 25,
+    OPENACC_DATA_FIELD_DEVICE_PTR = 26,
+    OPENACC_DATA_FIELD_VAR_NAME = 27,
+    OPENACC_DATA_FIELD_MAX = 28,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_ActivityOpenAccLaunchFieldIds {
+    OPENACC_LAUNCH_FIELD_KIND = 0,
+    OPENACC_LAUNCH_FIELD_EVENT_KIND = 1,
+    OPENACC_LAUNCH_FIELD_PARENT_CONSTRUCT = 2,
+    OPENACC_LAUNCH_FIELD_VERSION = 3,
+    OPENACC_LAUNCH_FIELD_IMPLICIT = 4,
+    OPENACC_LAUNCH_FIELD_DEVICE_TYPE = 5,
+    OPENACC_LAUNCH_FIELD_DEVICE_NUMBER = 6,
+    OPENACC_LAUNCH_FIELD_THREAD_ID = 7,
+    OPENACC_LAUNCH_FIELD_ASYNC = 8,
+    OPENACC_LAUNCH_FIELD_ASYNC_MAP = 9,
+    OPENACC_LAUNCH_FIELD_LINE_NO = 10,
+    OPENACC_LAUNCH_FIELD_END_LINE_NO = 11,
+    OPENACC_LAUNCH_FIELD_FUNC_LINE_NO = 12,
+    OPENACC_LAUNCH_FIELD_FUNC_END_LINE_NO = 13,
+    OPENACC_LAUNCH_FIELD_START = 14,
+    OPENACC_LAUNCH_FIELD_END = 15,
+    OPENACC_LAUNCH_FIELD_CU_DEVICE_ID = 16,
+    OPENACC_LAUNCH_FIELD_CU_CONTEXT_ID = 17,
+    OPENACC_LAUNCH_FIELD_CU_STREAM_ID = 18,
+    OPENACC_LAUNCH_FIELD_CU_PROCESS_ID = 19,
+    OPENACC_LAUNCH_FIELD_CU_THREAD_ID = 20,
+    OPENACC_LAUNCH_FIELD_EXTERNAL_ID = 21,
+    OPENACC_LAUNCH_FIELD_SRC_FILE = 22,
+    OPENACC_LAUNCH_FIELD_FUNC_NAME = 23,
+    OPENACC_LAUNCH_FIELD_NUM_GANGS = 24,
+    OPENACC_LAUNCH_FIELD_NUM_WORKERS = 25,
+    OPENACC_LAUNCH_FIELD_VECTOR_LENGTH = 26,
+    OPENACC_LAUNCH_FIELD_KERNEL_NAME = 27,
+    OPENACC_LAUNCH_FIELD_MAX = 28,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_ActivityOpenAccOtherFieldIds {
+    OPENACC_OTHER_FIELD_KIND = 0,
+    OPENACC_OTHER_FIELD_EVENT_KIND = 1,
+    OPENACC_OTHER_FIELD_PARENT_CONSTRUCT = 2,
+    OPENACC_OTHER_FIELD_VERSION = 3,
+    OPENACC_OTHER_FIELD_IMPLICIT = 4,
+    OPENACC_OTHER_FIELD_DEVICE_TYPE = 5,
+    OPENACC_OTHER_FIELD_DEVICE_NUMBER = 6,
+    OPENACC_OTHER_FIELD_THREAD_ID = 7,
+    OPENACC_OTHER_FIELD_ASYNC = 8,
+    OPENACC_OTHER_FIELD_ASYNC_MAP = 9,
+    OPENACC_OTHER_FIELD_LINE_NO = 10,
+    OPENACC_OTHER_FIELD_END_LINE_NO = 11,
+    OPENACC_OTHER_FIELD_FUNC_LINE_NO = 12,
+    OPENACC_OTHER_FIELD_FUNC_END_LINE_NO = 13,
+    OPENACC_OTHER_FIELD_START = 14,
+    OPENACC_OTHER_FIELD_END = 15,
+    OPENACC_OTHER_FIELD_CU_DEVICE_ID = 16,
+    OPENACC_OTHER_FIELD_CU_CONTEXT_ID = 17,
+    OPENACC_OTHER_FIELD_CU_STREAM_ID = 18,
+    OPENACC_OTHER_FIELD_CU_PROCESS_ID = 19,
+    OPENACC_OTHER_FIELD_CU_THREAD_ID = 20,
+    OPENACC_OTHER_FIELD_EXTERNAL_ID = 21,
+    OPENACC_OTHER_FIELD_SRC_FILE = 22,
+    OPENACC_OTHER_FIELD_FUNC_NAME = 23,
+    OPENACC_OTHER_FIELD_MAX = 24,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_ActivityOpenMpFieldIds {
+    OPENMP_FIELD_KIND = 0,
+    OPENMP_FIELD_EVENT_KIND = 1,
+    OPENMP_FIELD_START = 2,
+    OPENMP_FIELD_END = 3,
+    OPENMP_FIELD_CU_THREAD_ID = 4,
+    OPENMP_FIELD_CU_PROCESS_ID = 5,
+    OPENMP_FIELD_MAX = 6,
+}
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityOverheadFieldIds {
@@ -3004,7 +3236,7 @@ pub enum CUpti_ActivityOverheadKind {
     CUPTI_ACTIVITY_OVERHEAD_ACTIVITY_BUFFER_REQUEST = 458752,
     CUPTI_ACTIVITY_OVERHEAD_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityOverheadKind {
@@ -3058,6 +3290,21 @@ pub enum CUpti_ActivityPartitionedGlobalCacheConfig {
     CUPTI_ACTIVITY_PARTITIONED_GLOBAL_CACHE_CONFIG_ON = 3,
     CUPTI_ACTIVITY_PARTITIONED_GLOBAL_CACHE_CONFIG_FORCE_INT = 2147483647,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_ActivityPcieFieldIds {
+    PCIE_FIELD_KIND = 0,
+    PCIE_FIELD_TYPE = 1,
+    PCIE_FIELD_ID = 2,
+    PCIE_FIELD_DOMAIN = 3,
+    PCIE_FIELD_PCIE_GENERATION = 4,
+    PCIE_FIELD_LINK_RATE = 5,
+    PCIE_FIELD_LINK_WIDTH = 6,
+    PCIE_FIELD_UPSTREAM_BUS = 7,
+    PCIE_FIELD_ATTR = 8,
+    PCIE_FIELD_MAX = 9,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityPreemptionKind {
@@ -3066,7 +3313,7 @@ pub enum CUpti_ActivityPreemptionKind {
     CUPTI_ACTIVITY_PREEMPTION_KIND_RESTORE = 2,
     CUPTI_ACTIVITY_PREEMPTION_KIND_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityStreamFieldIds {
@@ -3088,7 +3335,7 @@ pub enum CUpti_ActivityStreamFlag {
     CUPTI_ACTIVITY_STREAM_CREATE_MASK = 65535,
     CUPTI_ACTIVITY_STREAM_CREATE_FLAG_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivitySynchronizationFieldIds {
@@ -3122,7 +3369,7 @@ pub enum CUpti_ActivityThreadIdType {
     CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM = 1,
     CUPTI_ACTIVITY_THREAD_ID_TYPE_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityThreadIdType {
@@ -3184,7 +3431,7 @@ pub enum CUpti_ActivityUnifiedMemoryRemoteMapCause {
     CUPTI_ACTIVITY_UNIFIED_MEMORY_REMOTE_MAP_CAUSE_OUT_OF_MEMORY = 4,
     CUPTI_ACTIVITY_UNIFIED_MEMORY_REMOTE_MAP_CAUSE_EVICTION = 5,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ActivityUvmCounterFieldIds {
@@ -3222,7 +3469,7 @@ pub enum CUpti_CallbackDomain {
     CUPTI_CB_DOMAIN_SIZE = 6,
     CUPTI_CB_DOMAIN_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_CallbackDomain {
@@ -3293,7 +3540,7 @@ pub enum CUpti_CallbackIdResource {
     CUPTI_CBID_RESOURCE_SIZE = 22,
     CUPTI_CBID_RESOURCE_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_CallbackIdResource {
@@ -3324,7 +3571,7 @@ pub enum CUpti_CallbackIdResource {
     CUPTI_CBID_RESOURCE_SIZE = 24,
     CUPTI_CBID_RESOURCE_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_CallbackIdState {
@@ -3361,7 +3608,7 @@ pub enum CUpti_ChannelType {
     CUPTI_CHANNEL_TYPE_ASYNC_MEMCPY = 2,
     CUPTI_CHANNEL_TYPE_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ChannelType {
@@ -3371,7 +3618,7 @@ pub enum CUpti_ChannelType {
     CUPTI_CHANNEL_TYPE_DECOMP = 3,
     CUPTI_CHANNEL_TYPE_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ComputeEngineCtxSwitchOperationType {
@@ -3380,7 +3627,7 @@ pub enum CUpti_ComputeEngineCtxSwitchOperationType {
     CUPTI_COMPUTE_ENGINE_CTX_SWITCH_OPERATION_END = 2,
     CUPTI_COMPUTE_ENGINE_CTX_SWITCH_OPERATION_COUNT = 2147483647,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ConfidentialComputeRotationEventType {
@@ -3390,7 +3637,7 @@ pub enum CUpti_ConfidentialComputeRotationEventType {
     CUPTI_CONFIDENTIAL_COMPUTE_KEY_ROTATION_CHANNEL_UNBLOCKED = 3,
     CUPTI_CONFIDENTIAL_COMPUTE_EVENT_TYPE_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_ContextCigMode {
@@ -3440,7 +3687,7 @@ pub enum CUpti_DeviceAttributeDeviceClass {
     CUPTI_DEVICE_ATTR_DEVICE_CLASS_GEFORCE = 2,
     CUPTI_DEVICE_ATTR_DEVICE_CLASS_TEGRA = 3,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_DeviceGraphLaunchMode {
@@ -3546,6 +3793,16 @@ pub enum CUpti_ExternalCorrelationKind {
     CUPTI_EXTERNAL_CORRELATION_KIND_SIZE = 6,
     CUPTI_EXTERNAL_CORRELATION_KIND_FORCE_INT = 2147483647,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_FuncExecutionModel {
+    CUPTI_FUNC_EXECUTION_MODEL_UNKNOWN = 0,
+    CUPTI_FUNC_EXECUTION_MODEL_SIMT = 1,
+    CUPTI_FUNC_EXECUTION_MODEL_TILE = 2,
+    CUPTI_FUNC_EXECUTION_MODEL_SIZE = 3,
+    CUPTI_FUNC_EXECUTION_MODEL_FORCE_INT = 2147483647,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_FuncShmemLimitConfig {
@@ -3633,7 +3890,7 @@ pub enum CUpti_MetricValueKind {
     CUPTI_METRIC_VALUE_KIND_UTILIZATION_LEVEL = 5,
     CUPTI_METRIC_VALUE_KIND_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_MetricValueKind {
@@ -3656,7 +3913,7 @@ pub enum CUpti_MetricValueUtilizationLevel {
     CUPTI_METRIC_VALUE_UTILIZATION_MAX = 10,
     CUPTI_METRIC_VALUE_UTILIZATION_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_NvtxExtPayloadType {
@@ -3739,7 +3996,7 @@ pub enum CUpti_PcieGen {
     CUPTI_PCIE_GEN_GEN5 = 5,
     CUPTI_PCIE_GEN_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_PcieGen {
@@ -14199,6 +14456,861 @@ pub enum CUpti_driver_api_trace_cbid_enum {
     CUPTI_DRIVER_TRACE_CBID_SIZE = 846,
     CUPTI_DRIVER_TRACE_CBID_FORCE_INT = 2147483647,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUpti_driver_api_trace_cbid_enum {
+    CUPTI_DRIVER_TRACE_CBID_INVALID = 0,
+    CUPTI_DRIVER_TRACE_CBID_cuInit = 1,
+    CUPTI_DRIVER_TRACE_CBID_cuDriverGetVersion = 2,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGet = 3,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetCount = 4,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetName = 5,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceComputeCapability = 6,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceTotalMem = 7,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetProperties = 8,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetAttribute = 9,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxCreate = 10,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxDestroy = 11,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxAttach = 12,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxDetach = 13,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxPushCurrent = 14,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxPopCurrent = 15,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetDevice = 16,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxSynchronize = 17,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleLoad = 18,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleLoadData = 19,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleLoadDataEx = 20,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleLoadFatBinary = 21,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleUnload = 22,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleGetFunction = 23,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleGetGlobal = 24,
+    CUPTI_DRIVER_TRACE_CBID_cu64ModuleGetGlobal = 25,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleGetTexRef = 26,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetInfo = 27,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemGetInfo = 28,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAlloc = 29,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemAlloc = 30,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAllocPitch = 31,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemAllocPitch = 32,
+    CUPTI_DRIVER_TRACE_CBID_cuMemFree = 33,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemFree = 34,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetAddressRange = 35,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemGetAddressRange = 36,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAllocHost = 37,
+    CUPTI_DRIVER_TRACE_CBID_cuMemFreeHost = 38,
+    CUPTI_DRIVER_TRACE_CBID_cuMemHostAlloc = 39,
+    CUPTI_DRIVER_TRACE_CBID_cuMemHostGetDevicePointer = 40,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemHostGetDevicePointer = 41,
+    CUPTI_DRIVER_TRACE_CBID_cuMemHostGetFlags = 42,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoD = 43,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemcpyHtoD = 44,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoH = 45,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemcpyDtoH = 46,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoD = 47,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemcpyDtoD = 48,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoA = 49,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemcpyDtoA = 50,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoD = 51,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemcpyAtoD = 52,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoA = 53,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoH = 54,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoA = 55,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy2D = 56,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy2DUnaligned = 57,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3D = 58,
+    CUPTI_DRIVER_TRACE_CBID_cu64Memcpy3D = 59,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoDAsync = 60,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemcpyHtoDAsync = 61,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoHAsync = 62,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemcpyDtoHAsync = 63,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoDAsync = 64,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemcpyDtoDAsync = 65,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoAAsync = 66,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoHAsync = 67,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy2DAsync = 68,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DAsync = 69,
+    CUPTI_DRIVER_TRACE_CBID_cu64Memcpy3DAsync = 70,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD8 = 71,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD8 = 72,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD16 = 73,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD16 = 74,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD32 = 75,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD32 = 76,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D8 = 77,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD2D8 = 78,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D16 = 79,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD2D16 = 80,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D32 = 81,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD2D32 = 82,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncSetBlockShape = 83,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncSetSharedSize = 84,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncGetAttribute = 85,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncSetCacheConfig = 86,
+    CUPTI_DRIVER_TRACE_CBID_cuArrayCreate = 87,
+    CUPTI_DRIVER_TRACE_CBID_cuArrayGetDescriptor = 88,
+    CUPTI_DRIVER_TRACE_CBID_cuArrayDestroy = 89,
+    CUPTI_DRIVER_TRACE_CBID_cuArray3DCreate = 90,
+    CUPTI_DRIVER_TRACE_CBID_cuArray3DGetDescriptor = 91,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefCreate = 92,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefDestroy = 93,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetArray = 94,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetAddress = 95,
+    CUPTI_DRIVER_TRACE_CBID_cu64TexRefSetAddress = 96,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetAddress2D = 97,
+    CUPTI_DRIVER_TRACE_CBID_cu64TexRefSetAddress2D = 98,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetFormat = 99,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetAddressMode = 100,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetFilterMode = 101,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetFlags = 102,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetAddress = 103,
+    CUPTI_DRIVER_TRACE_CBID_cu64TexRefGetAddress = 104,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetArray = 105,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetAddressMode = 106,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetFilterMode = 107,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetFormat = 108,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetFlags = 109,
+    CUPTI_DRIVER_TRACE_CBID_cuParamSetSize = 110,
+    CUPTI_DRIVER_TRACE_CBID_cuParamSeti = 111,
+    CUPTI_DRIVER_TRACE_CBID_cuParamSetf = 112,
+    CUPTI_DRIVER_TRACE_CBID_cuParamSetv = 113,
+    CUPTI_DRIVER_TRACE_CBID_cuParamSetTexRef = 114,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunch = 115,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchGrid = 116,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchGridAsync = 117,
+    CUPTI_DRIVER_TRACE_CBID_cuEventCreate = 118,
+    CUPTI_DRIVER_TRACE_CBID_cuEventRecord = 119,
+    CUPTI_DRIVER_TRACE_CBID_cuEventQuery = 120,
+    CUPTI_DRIVER_TRACE_CBID_cuEventSynchronize = 121,
+    CUPTI_DRIVER_TRACE_CBID_cuEventDestroy = 122,
+    CUPTI_DRIVER_TRACE_CBID_cuEventElapsedTime = 123,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamCreate = 124,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamQuery = 125,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamSynchronize = 126,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamDestroy = 127,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsUnregisterResource = 128,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsSubResourceGetMappedArray = 129,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsResourceGetMappedPointer = 130,
+    CUPTI_DRIVER_TRACE_CBID_cu64GraphicsResourceGetMappedPointer = 131,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsResourceSetMapFlags = 132,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsMapResources = 133,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsUnmapResources = 134,
+    CUPTI_DRIVER_TRACE_CBID_cuGetExportTable = 135,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxSetLimit = 136,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetLimit = 137,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10GetDevice = 138,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10CtxCreate = 139,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsD3D10RegisterResource = 140,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10RegisterResource = 141,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10UnregisterResource = 142,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10MapResources = 143,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10UnmapResources = 144,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceSetMapFlags = 145,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceGetMappedArray = 146,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceGetMappedPointer = 147,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceGetMappedSize = 148,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceGetMappedPitch = 149,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceGetSurfaceDimensions = 150,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D11GetDevice = 151,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D11CtxCreate = 152,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsD3D11RegisterResource = 153,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9GetDevice = 154,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9CtxCreate = 155,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsD3D9RegisterResource = 156,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9GetDirect3DDevice = 157,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9RegisterResource = 158,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9UnregisterResource = 159,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9MapResources = 160,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9UnmapResources = 161,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceSetMapFlags = 162,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceGetSurfaceDimensions = 163,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceGetMappedArray = 164,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceGetMappedPointer = 165,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceGetMappedSize = 166,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceGetMappedPitch = 167,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9Begin = 168,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9End = 169,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9RegisterVertexBuffer = 170,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9MapVertexBuffer = 171,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9UnmapVertexBuffer = 172,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9UnregisterVertexBuffer = 173,
+    CUPTI_DRIVER_TRACE_CBID_cuGLCtxCreate = 174,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsGLRegisterBuffer = 175,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsGLRegisterImage = 176,
+    CUPTI_DRIVER_TRACE_CBID_cuWGLGetDevice = 177,
+    CUPTI_DRIVER_TRACE_CBID_cuGLInit = 178,
+    CUPTI_DRIVER_TRACE_CBID_cuGLRegisterBufferObject = 179,
+    CUPTI_DRIVER_TRACE_CBID_cuGLMapBufferObject = 180,
+    CUPTI_DRIVER_TRACE_CBID_cuGLUnmapBufferObject = 181,
+    CUPTI_DRIVER_TRACE_CBID_cuGLUnregisterBufferObject = 182,
+    CUPTI_DRIVER_TRACE_CBID_cuGLSetBufferObjectMapFlags = 183,
+    CUPTI_DRIVER_TRACE_CBID_cuGLMapBufferObjectAsync = 184,
+    CUPTI_DRIVER_TRACE_CBID_cuGLUnmapBufferObjectAsync = 185,
+    CUPTI_DRIVER_TRACE_CBID_cuVDPAUGetDevice = 186,
+    CUPTI_DRIVER_TRACE_CBID_cuVDPAUCtxCreate = 187,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsVDPAURegisterVideoSurface = 188,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsVDPAURegisterOutputSurface = 189,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleGetSurfRef = 190,
+    CUPTI_DRIVER_TRACE_CBID_cuSurfRefCreate = 191,
+    CUPTI_DRIVER_TRACE_CBID_cuSurfRefDestroy = 192,
+    CUPTI_DRIVER_TRACE_CBID_cuSurfRefSetFormat = 193,
+    CUPTI_DRIVER_TRACE_CBID_cuSurfRefSetArray = 194,
+    CUPTI_DRIVER_TRACE_CBID_cuSurfRefGetFormat = 195,
+    CUPTI_DRIVER_TRACE_CBID_cuSurfRefGetArray = 196,
+    CUPTI_DRIVER_TRACE_CBID_cu64DeviceTotalMem = 197,
+    CUPTI_DRIVER_TRACE_CBID_cu64D3D10ResourceGetMappedPointer = 198,
+    CUPTI_DRIVER_TRACE_CBID_cu64D3D10ResourceGetMappedSize = 199,
+    CUPTI_DRIVER_TRACE_CBID_cu64D3D10ResourceGetMappedPitch = 200,
+    CUPTI_DRIVER_TRACE_CBID_cu64D3D10ResourceGetSurfaceDimensions = 201,
+    CUPTI_DRIVER_TRACE_CBID_cu64D3D9ResourceGetSurfaceDimensions = 202,
+    CUPTI_DRIVER_TRACE_CBID_cu64D3D9ResourceGetMappedPointer = 203,
+    CUPTI_DRIVER_TRACE_CBID_cu64D3D9ResourceGetMappedSize = 204,
+    CUPTI_DRIVER_TRACE_CBID_cu64D3D9ResourceGetMappedPitch = 205,
+    CUPTI_DRIVER_TRACE_CBID_cu64D3D9MapVertexBuffer = 206,
+    CUPTI_DRIVER_TRACE_CBID_cu64GLMapBufferObject = 207,
+    CUPTI_DRIVER_TRACE_CBID_cu64GLMapBufferObjectAsync = 208,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D11GetDevices = 209,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D11CtxCreateOnDevice = 210,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10GetDevices = 211,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10CtxCreateOnDevice = 212,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9GetDevices = 213,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9CtxCreateOnDevice = 214,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemHostAlloc = 215,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD8Async = 216,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD8Async = 217,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD16Async = 218,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD16Async = 219,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD32Async = 220,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD32Async = 221,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D8Async = 222,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD2D8Async = 223,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D16Async = 224,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD2D16Async = 225,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D32Async = 226,
+    CUPTI_DRIVER_TRACE_CBID_cu64MemsetD2D32Async = 227,
+    CUPTI_DRIVER_TRACE_CBID_cu64ArrayCreate = 228,
+    CUPTI_DRIVER_TRACE_CBID_cu64ArrayGetDescriptor = 229,
+    CUPTI_DRIVER_TRACE_CBID_cu64Array3DCreate = 230,
+    CUPTI_DRIVER_TRACE_CBID_cu64Array3DGetDescriptor = 231,
+    CUPTI_DRIVER_TRACE_CBID_cu64Memcpy2D = 232,
+    CUPTI_DRIVER_TRACE_CBID_cu64Memcpy2DUnaligned = 233,
+    CUPTI_DRIVER_TRACE_CBID_cu64Memcpy2DAsync = 234,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxCreate_v2 = 235,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10CtxCreate_v2 = 236,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D11CtxCreate_v2 = 237,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9CtxCreate_v2 = 238,
+    CUPTI_DRIVER_TRACE_CBID_cuGLCtxCreate_v2 = 239,
+    CUPTI_DRIVER_TRACE_CBID_cuVDPAUCtxCreate_v2 = 240,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleGetGlobal_v2 = 241,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetInfo_v2 = 242,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAlloc_v2 = 243,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAllocPitch_v2 = 244,
+    CUPTI_DRIVER_TRACE_CBID_cuMemFree_v2 = 245,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetAddressRange_v2 = 246,
+    CUPTI_DRIVER_TRACE_CBID_cuMemHostGetDevicePointer_v2 = 247,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy_v2 = 248,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD8_v2 = 249,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD16_v2 = 250,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD32_v2 = 251,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D8_v2 = 252,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D16_v2 = 253,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D32_v2 = 254,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetAddress_v2 = 255,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetAddress2D_v2 = 256,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetAddress_v2 = 257,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsResourceGetMappedPointer_v2 = 258,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceTotalMem_v2 = 259,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceGetMappedPointer_v2 = 260,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceGetMappedSize_v2 = 261,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceGetMappedPitch_v2 = 262,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10ResourceGetSurfaceDimensions_v2 = 263,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceGetSurfaceDimensions_v2 = 264,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceGetMappedPointer_v2 = 265,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceGetMappedSize_v2 = 266,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9ResourceGetMappedPitch_v2 = 267,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D9MapVertexBuffer_v2 = 268,
+    CUPTI_DRIVER_TRACE_CBID_cuGLMapBufferObject_v2 = 269,
+    CUPTI_DRIVER_TRACE_CBID_cuGLMapBufferObjectAsync_v2 = 270,
+    CUPTI_DRIVER_TRACE_CBID_cuMemHostAlloc_v2 = 271,
+    CUPTI_DRIVER_TRACE_CBID_cuArrayCreate_v2 = 272,
+    CUPTI_DRIVER_TRACE_CBID_cuArrayGetDescriptor_v2 = 273,
+    CUPTI_DRIVER_TRACE_CBID_cuArray3DCreate_v2 = 274,
+    CUPTI_DRIVER_TRACE_CBID_cuArray3DGetDescriptor_v2 = 275,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoD_v2 = 276,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoDAsync_v2 = 277,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoH_v2 = 278,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoHAsync_v2 = 279,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoD_v2 = 280,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoDAsync_v2 = 281,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoH_v2 = 282,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoHAsync_v2 = 283,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoD_v2 = 284,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoA_v2 = 285,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoA_v2 = 286,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy2D_v2 = 287,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy2DUnaligned_v2 = 288,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy2DAsync_v2 = 289,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3D_v2 = 290,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DAsync_v2 = 291,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoA_v2 = 292,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoAAsync_v2 = 293,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAllocHost_v2 = 294,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitEvent = 295,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetApiVersion = 296,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D10GetDirect3DDevice = 297,
+    CUPTI_DRIVER_TRACE_CBID_cuD3D11GetDirect3DDevice = 298,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetCacheConfig = 299,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxSetCacheConfig = 300,
+    CUPTI_DRIVER_TRACE_CBID_cuMemHostRegister = 301,
+    CUPTI_DRIVER_TRACE_CBID_cuMemHostUnregister = 302,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxSetCurrent = 303,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetCurrent = 304,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy = 305,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAsync = 306,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel = 307,
+    CUPTI_DRIVER_TRACE_CBID_cuProfilerStart = 308,
+    CUPTI_DRIVER_TRACE_CBID_cuProfilerStop = 309,
+    CUPTI_DRIVER_TRACE_CBID_cuPointerGetAttribute = 310,
+    CUPTI_DRIVER_TRACE_CBID_cuProfilerInitialize = 311,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceCanAccessPeer = 312,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxEnablePeerAccess = 313,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxDisablePeerAccess = 314,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPeerRegister = 315,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPeerUnregister = 316,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPeerGetDevicePointer = 317,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyPeer = 318,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyPeerAsync = 319,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DPeer = 320,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DPeerAsync = 321,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxDestroy_v2 = 322,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxPushCurrent_v2 = 323,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxPopCurrent_v2 = 324,
+    CUPTI_DRIVER_TRACE_CBID_cuEventDestroy_v2 = 325,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamDestroy_v2 = 326,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetAddress2D_v3 = 327,
+    CUPTI_DRIVER_TRACE_CBID_cuIpcGetMemHandle = 328,
+    CUPTI_DRIVER_TRACE_CBID_cuIpcOpenMemHandle = 329,
+    CUPTI_DRIVER_TRACE_CBID_cuIpcCloseMemHandle = 330,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetByPCIBusId = 331,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetPCIBusId = 332,
+    CUPTI_DRIVER_TRACE_CBID_cuGLGetDevices = 333,
+    CUPTI_DRIVER_TRACE_CBID_cuIpcGetEventHandle = 334,
+    CUPTI_DRIVER_TRACE_CBID_cuIpcOpenEventHandle = 335,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxSetSharedMemConfig = 336,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetSharedMemConfig = 337,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncSetSharedMemConfig = 338,
+    CUPTI_DRIVER_TRACE_CBID_cuTexObjectCreate = 339,
+    CUPTI_DRIVER_TRACE_CBID_cuTexObjectDestroy = 340,
+    CUPTI_DRIVER_TRACE_CBID_cuTexObjectGetResourceDesc = 341,
+    CUPTI_DRIVER_TRACE_CBID_cuTexObjectGetTextureDesc = 342,
+    CUPTI_DRIVER_TRACE_CBID_cuSurfObjectCreate = 343,
+    CUPTI_DRIVER_TRACE_CBID_cuSurfObjectDestroy = 344,
+    CUPTI_DRIVER_TRACE_CBID_cuSurfObjectGetResourceDesc = 345,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamAddCallback = 346,
+    CUPTI_DRIVER_TRACE_CBID_cuMipmappedArrayCreate = 347,
+    CUPTI_DRIVER_TRACE_CBID_cuMipmappedArrayGetLevel = 348,
+    CUPTI_DRIVER_TRACE_CBID_cuMipmappedArrayDestroy = 349,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetMipmappedArray = 350,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetMipmapFilterMode = 351,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetMipmapLevelBias = 352,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetMipmapLevelClamp = 353,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetMaxAnisotropy = 354,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetMipmappedArray = 355,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetMipmapFilterMode = 356,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetMipmapLevelBias = 357,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetMipmapLevelClamp = 358,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetMaxAnisotropy = 359,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsResourceGetMappedMipmappedArray = 360,
+    CUPTI_DRIVER_TRACE_CBID_cuTexObjectGetResourceViewDesc = 361,
+    CUPTI_DRIVER_TRACE_CBID_cuLinkCreate = 362,
+    CUPTI_DRIVER_TRACE_CBID_cuLinkAddData = 363,
+    CUPTI_DRIVER_TRACE_CBID_cuLinkAddFile = 364,
+    CUPTI_DRIVER_TRACE_CBID_cuLinkComplete = 365,
+    CUPTI_DRIVER_TRACE_CBID_cuLinkDestroy = 366,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamCreateWithPriority = 367,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetPriority = 368,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetFlags = 369,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetStreamPriorityRange = 370,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAllocManaged = 371,
+    CUPTI_DRIVER_TRACE_CBID_cuGetErrorString = 372,
+    CUPTI_DRIVER_TRACE_CBID_cuGetErrorName = 373,
+    CUPTI_DRIVER_TRACE_CBID_cuOccupancyMaxActiveBlocksPerMultiprocessor = 374,
+    CUPTI_DRIVER_TRACE_CBID_cuCompilePtx = 375,
+    CUPTI_DRIVER_TRACE_CBID_cuBinaryFree = 376,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamAttachMemAsync = 377,
+    CUPTI_DRIVER_TRACE_CBID_cuPointerSetAttribute = 378,
+    CUPTI_DRIVER_TRACE_CBID_cuMemHostRegister_v2 = 379,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsResourceSetMapFlags_v2 = 380,
+    CUPTI_DRIVER_TRACE_CBID_cuLinkCreate_v2 = 381,
+    CUPTI_DRIVER_TRACE_CBID_cuLinkAddData_v2 = 382,
+    CUPTI_DRIVER_TRACE_CBID_cuLinkAddFile_v2 = 383,
+    CUPTI_DRIVER_TRACE_CBID_cuOccupancyMaxPotentialBlockSize = 384,
+    CUPTI_DRIVER_TRACE_CBID_cuGLGetDevices_v2 = 385,
+    CUPTI_DRIVER_TRACE_CBID_cuDevicePrimaryCtxRetain = 386,
+    CUPTI_DRIVER_TRACE_CBID_cuDevicePrimaryCtxRelease = 387,
+    CUPTI_DRIVER_TRACE_CBID_cuDevicePrimaryCtxSetFlags = 388,
+    CUPTI_DRIVER_TRACE_CBID_cuDevicePrimaryCtxReset = 389,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsEGLRegisterImage = 390,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetFlags = 391,
+    CUPTI_DRIVER_TRACE_CBID_cuDevicePrimaryCtxGetState = 392,
+    CUPTI_DRIVER_TRACE_CBID_cuEGLStreamConsumerConnect = 393,
+    CUPTI_DRIVER_TRACE_CBID_cuEGLStreamConsumerDisconnect = 394,
+    CUPTI_DRIVER_TRACE_CBID_cuEGLStreamConsumerAcquireFrame = 395,
+    CUPTI_DRIVER_TRACE_CBID_cuEGLStreamConsumerReleaseFrame = 396,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoD_v2_ptds = 397,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoH_v2_ptds = 398,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoD_v2_ptds = 399,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoA_v2_ptds = 400,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoD_v2_ptds = 401,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoA_v2_ptds = 402,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoH_v2_ptds = 403,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoA_v2_ptds = 404,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy2D_v2_ptds = 405,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy2DUnaligned_v2_ptds = 406,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3D_v2_ptds = 407,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy_ptds = 408,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyPeer_ptds = 409,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DPeer_ptds = 410,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD8_v2_ptds = 411,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD16_v2_ptds = 412,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD32_v2_ptds = 413,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D8_v2_ptds = 414,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D16_v2_ptds = 415,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D32_v2_ptds = 416,
+    CUPTI_DRIVER_TRACE_CBID_cuGLMapBufferObject_v2_ptds = 417,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAsync_ptsz = 418,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoAAsync_v2_ptsz = 419,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyAtoHAsync_v2_ptsz = 420,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoDAsync_v2_ptsz = 421,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoHAsync_v2_ptsz = 422,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoDAsync_v2_ptsz = 423,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy2DAsync_v2_ptsz = 424,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DAsync_v2_ptsz = 425,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyPeerAsync_ptsz = 426,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DPeerAsync_ptsz = 427,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD8Async_ptsz = 428,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD16Async_ptsz = 429,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD32Async_ptsz = 430,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D8Async_ptsz = 431,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D16Async_ptsz = 432,
+    CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D32Async_ptsz = 433,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetPriority_ptsz = 434,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetFlags_ptsz = 435,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitEvent_ptsz = 436,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamAddCallback_ptsz = 437,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamAttachMemAsync_ptsz = 438,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamQuery_ptsz = 439,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamSynchronize_ptsz = 440,
+    CUPTI_DRIVER_TRACE_CBID_cuEventRecord_ptsz = 441,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel_ptsz = 442,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsMapResources_ptsz = 443,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsUnmapResources_ptsz = 444,
+    CUPTI_DRIVER_TRACE_CBID_cuGLMapBufferObjectAsync_v2_ptsz = 445,
+    CUPTI_DRIVER_TRACE_CBID_cuEGLStreamProducerConnect = 446,
+    CUPTI_DRIVER_TRACE_CBID_cuEGLStreamProducerDisconnect = 447,
+    CUPTI_DRIVER_TRACE_CBID_cuEGLStreamProducerPresentFrame = 448,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphicsResourceGetMappedEglFrame = 449,
+    CUPTI_DRIVER_TRACE_CBID_cuPointerGetAttributes = 450,
+    CUPTI_DRIVER_TRACE_CBID_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags = 451,
+    CUPTI_DRIVER_TRACE_CBID_cuOccupancyMaxPotentialBlockSizeWithFlags = 452,
+    CUPTI_DRIVER_TRACE_CBID_cuEGLStreamProducerReturnFrame = 453,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetP2PAttribute = 454,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefSetBorderColor = 455,
+    CUPTI_DRIVER_TRACE_CBID_cuTexRefGetBorderColor = 456,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAdvise = 457,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitValue32 = 458,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitValue32_ptsz = 459,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWriteValue32 = 460,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWriteValue32_ptsz = 461,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBatchMemOp = 462,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBatchMemOp_ptsz = 463,
+    CUPTI_DRIVER_TRACE_CBID_cuNVNbufferGetPointer = 464,
+    CUPTI_DRIVER_TRACE_CBID_cuNVNtextureGetArray = 465,
+    CUPTI_DRIVER_TRACE_CBID_cuNNSetAllocator = 466,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPrefetchAsync = 467,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPrefetchAsync_ptsz = 468,
+    CUPTI_DRIVER_TRACE_CBID_cuEventCreateFromNVNSync = 469,
+    CUPTI_DRIVER_TRACE_CBID_cuEGLStreamConsumerConnectWithFlags = 470,
+    CUPTI_DRIVER_TRACE_CBID_cuMemRangeGetAttribute = 471,
+    CUPTI_DRIVER_TRACE_CBID_cuMemRangeGetAttributes = 472,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitValue64 = 473,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitValue64_ptsz = 474,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWriteValue64 = 475,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWriteValue64_ptsz = 476,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel = 477,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel_ptsz = 478,
+    CUPTI_DRIVER_TRACE_CBID_cuEventCreateFromEGLSync = 479,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernelMultiDevice = 480,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncSetAttribute = 481,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetUuid = 482,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCtx = 483,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCtx_ptsz = 484,
+    CUPTI_DRIVER_TRACE_CBID_cuImportExternalMemory = 485,
+    CUPTI_DRIVER_TRACE_CBID_cuExternalMemoryGetMappedBuffer = 486,
+    CUPTI_DRIVER_TRACE_CBID_cuExternalMemoryGetMappedMipmappedArray = 487,
+    CUPTI_DRIVER_TRACE_CBID_cuDestroyExternalMemory = 488,
+    CUPTI_DRIVER_TRACE_CBID_cuImportExternalSemaphore = 489,
+    CUPTI_DRIVER_TRACE_CBID_cuSignalExternalSemaphoresAsync = 490,
+    CUPTI_DRIVER_TRACE_CBID_cuSignalExternalSemaphoresAsync_ptsz = 491,
+    CUPTI_DRIVER_TRACE_CBID_cuWaitExternalSemaphoresAsync = 492,
+    CUPTI_DRIVER_TRACE_CBID_cuWaitExternalSemaphoresAsync_ptsz = 493,
+    CUPTI_DRIVER_TRACE_CBID_cuDestroyExternalSemaphore = 494,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCapture = 495,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCapture_ptsz = 496,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamEndCapture = 497,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamEndCapture_ptsz = 498,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamIsCapturing = 499,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamIsCapturing_ptsz = 500,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphCreate = 501,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode = 502,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphKernelNodeGetParams = 503,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddMemcpyNode = 504,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphMemcpyNodeGetParams = 505,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddMemsetNode = 506,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphMemsetNodeGetParams = 507,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphMemsetNodeSetParams = 508,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetType = 509,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphGetRootNodes = 510,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetDependencies = 511,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetDependentNodes = 512,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphInstantiate = 513,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch = 514,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch_ptsz = 515,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecDestroy = 516,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphDestroy = 517,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddDependencies = 518,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphRemoveDependencies = 519,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphMemcpyNodeSetParams = 520,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphKernelNodeSetParams = 521,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphDestroyNode = 522,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphClone = 523,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeFindInClone = 524,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddChildGraphNode = 525,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddEmptyNode = 526,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchHostFunc = 527,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchHostFunc_ptsz = 528,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphChildGraphNodeGetGraph = 529,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddHostNode = 530,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphHostNodeGetParams = 531,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetLuid = 532,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphHostNodeSetParams = 533,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphGetNodes = 534,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphGetEdges = 535,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCaptureInfo = 536,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCaptureInfo_ptsz = 537,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecKernelNodeSetParams = 538,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCapture_v2 = 539,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCapture_v2_ptsz = 540,
+    CUPTI_DRIVER_TRACE_CBID_cuThreadExchangeStreamCaptureMode = 541,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetNvSciSyncAttributes = 542,
+    CUPTI_DRIVER_TRACE_CBID_cuOccupancyAvailableDynamicSMemPerBlock = 543,
+    CUPTI_DRIVER_TRACE_CBID_cuDevicePrimaryCtxRelease_v2 = 544,
+    CUPTI_DRIVER_TRACE_CBID_cuDevicePrimaryCtxReset_v2 = 545,
+    CUPTI_DRIVER_TRACE_CBID_cuDevicePrimaryCtxSetFlags_v2 = 546,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAddressReserve = 547,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAddressFree = 548,
+    CUPTI_DRIVER_TRACE_CBID_cuMemCreate = 549,
+    CUPTI_DRIVER_TRACE_CBID_cuMemRelease = 550,
+    CUPTI_DRIVER_TRACE_CBID_cuMemMap = 551,
+    CUPTI_DRIVER_TRACE_CBID_cuMemUnmap = 552,
+    CUPTI_DRIVER_TRACE_CBID_cuMemSetAccess = 553,
+    CUPTI_DRIVER_TRACE_CBID_cuMemExportToShareableHandle = 554,
+    CUPTI_DRIVER_TRACE_CBID_cuMemImportFromShareableHandle = 555,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetAllocationGranularity = 556,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetAllocationPropertiesFromHandle = 557,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetAccess = 558,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamSetFlags = 559,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamSetFlags_ptsz = 560,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecUpdate = 561,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecMemcpyNodeSetParams = 562,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecMemsetNodeSetParams = 563,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecHostNodeSetParams = 564,
+    CUPTI_DRIVER_TRACE_CBID_cuMemRetainAllocationHandle = 565,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncGetModule = 566,
+    CUPTI_DRIVER_TRACE_CBID_cuIpcOpenMemHandle_v2 = 567,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxResetPersistingL2Cache = 568,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphKernelNodeCopyAttributes = 569,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphKernelNodeGetAttribute = 570,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphKernelNodeSetAttribute = 571,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamCopyAttributes = 572,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamCopyAttributes_ptsz = 573,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetAttribute = 574,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetAttribute_ptsz = 575,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamSetAttribute = 576,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamSetAttribute_ptsz = 577,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphInstantiate_v2 = 578,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetTexture1DLinearMaxWidth = 579,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphUpload = 580,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphUpload_ptsz = 581,
+    CUPTI_DRIVER_TRACE_CBID_cuArrayGetSparseProperties = 582,
+    CUPTI_DRIVER_TRACE_CBID_cuMipmappedArrayGetSparseProperties = 583,
+    CUPTI_DRIVER_TRACE_CBID_cuMemMapArrayAsync = 584,
+    CUPTI_DRIVER_TRACE_CBID_cuMemMapArrayAsync_ptsz = 585,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecChildGraphNodeSetParams = 586,
+    CUPTI_DRIVER_TRACE_CBID_cuEventRecordWithFlags = 587,
+    CUPTI_DRIVER_TRACE_CBID_cuEventRecordWithFlags_ptsz = 588,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddEventRecordNode = 589,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddEventWaitNode = 590,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphEventRecordNodeGetEvent = 591,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphEventWaitNodeGetEvent = 592,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphEventRecordNodeSetEvent = 593,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphEventWaitNodeSetEvent = 594,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecEventRecordNodeSetEvent = 595,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecEventWaitNodeSetEvent = 596,
+    CUPTI_DRIVER_TRACE_CBID_cuArrayGetPlane = 597,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAllocAsync = 598,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAllocAsync_ptsz = 599,
+    CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync = 600,
+    CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync_ptsz = 601,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolTrimTo = 602,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolSetAttribute = 603,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolGetAttribute = 604,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolSetAccess = 605,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetDefaultMemPool = 606,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolCreate = 607,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolDestroy = 608,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceSetMemPool = 609,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetMemPool = 610,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAllocFromPoolAsync = 611,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAllocFromPoolAsync_ptsz = 612,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolExportToShareableHandle = 613,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolImportFromShareableHandle = 614,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolExportPointer = 615,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolImportPointer = 616,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPoolGetAccess = 617,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddExternalSemaphoresSignalNode = 618,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExternalSemaphoresSignalNodeGetParams = 619,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExternalSemaphoresSignalNodeSetParams = 620,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddExternalSemaphoresWaitNode = 621,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExternalSemaphoresWaitNodeGetParams = 622,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExternalSemaphoresWaitNodeSetParams = 623,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecExternalSemaphoresSignalNodeSetParams = 624,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecExternalSemaphoresWaitNodeSetParams = 625,
+    CUPTI_DRIVER_TRACE_CBID_cuGetProcAddress = 626,
+    CUPTI_DRIVER_TRACE_CBID_cuFlushGPUDirectRDMAWrites = 627,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphDebugDotPrint = 628,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCaptureInfo_v2 = 629,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCaptureInfo_v2_ptsz = 630,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamUpdateCaptureDependencies = 631,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamUpdateCaptureDependencies_ptsz = 632,
+    CUPTI_DRIVER_TRACE_CBID_cuUserObjectCreate = 633,
+    CUPTI_DRIVER_TRACE_CBID_cuUserObjectRetain = 634,
+    CUPTI_DRIVER_TRACE_CBID_cuUserObjectRelease = 635,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphRetainUserObject = 636,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphReleaseUserObject = 637,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddMemAllocNode = 638,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddMemFreeNode = 639,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGraphMemTrim = 640,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetGraphMemAttribute = 641,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceSetGraphMemAttribute = 642,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphInstantiateWithFlags = 643,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetExecAffinitySupport = 644,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxCreate_v3 = 645,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetExecAffinity = 646,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetUuid_v2 = 647,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphMemAllocNodeGetParams = 648,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphMemFreeNodeGetParams = 649,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeSetEnabled = 650,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetEnabled = 651,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx = 652,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz = 653,
+    CUPTI_DRIVER_TRACE_CBID_cuArrayGetMemoryRequirements = 654,
+    CUPTI_DRIVER_TRACE_CBID_cuMipmappedArrayGetMemoryRequirements = 655,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphInstantiateWithParams = 656,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphInstantiateWithParams_ptsz = 657,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecGetFlags = 658,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitValue32_v2 = 659,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitValue32_v2_ptsz = 660,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitValue64_v2 = 661,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWaitValue64_v2_ptsz = 662,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWriteValue32_v2 = 663,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWriteValue32_v2_ptsz = 664,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWriteValue64_v2 = 665,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamWriteValue64_v2_ptsz = 666,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBatchMemOp_v2 = 667,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBatchMemOp_v2_ptsz = 668,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddBatchMemOpNode = 669,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphBatchMemOpNodeGetParams = 670,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphBatchMemOpNodeSetParams = 671,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecBatchMemOpNodeSetParams = 672,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleGetLoadingMode = 673,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetHandleForAddressRange = 674,
+    CUPTI_DRIVER_TRACE_CBID_cuOccupancyMaxPotentialClusterSize = 675,
+    CUPTI_DRIVER_TRACE_CBID_cuOccupancyMaxActiveClusters = 676,
+    CUPTI_DRIVER_TRACE_CBID_cuGetProcAddress_v2 = 677,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryLoadData = 678,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryLoadFromFile = 679,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryUnload = 680,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryGetKernel = 681,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryGetModule = 682,
+    CUPTI_DRIVER_TRACE_CBID_cuKernelGetFunction = 683,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryGetGlobal = 684,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryGetManaged = 685,
+    CUPTI_DRIVER_TRACE_CBID_cuKernelGetAttribute = 686,
+    CUPTI_DRIVER_TRACE_CBID_cuKernelSetAttribute = 687,
+    CUPTI_DRIVER_TRACE_CBID_cuKernelSetCacheConfig = 688,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddKernelNode_v2 = 689,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphKernelNodeGetParams_v2 = 690,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphKernelNodeSetParams_v2 = 691,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecKernelNodeSetParams_v2 = 692,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetId = 693,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetId_ptsz = 694,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetId = 695,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecUpdate_v2 = 696,
+    CUPTI_DRIVER_TRACE_CBID_cuTensorMapEncodeTiled = 697,
+    CUPTI_DRIVER_TRACE_CBID_cuTensorMapEncodeIm2col = 698,
+    CUPTI_DRIVER_TRACE_CBID_cuTensorMapReplaceAddress = 699,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryGetUnifiedFunction = 700,
+    CUPTI_DRIVER_TRACE_CBID_cuCoredumpGetAttribute = 701,
+    CUPTI_DRIVER_TRACE_CBID_cuCoredumpGetAttributeGlobal = 702,
+    CUPTI_DRIVER_TRACE_CBID_cuCoredumpSetAttribute = 703,
+    CUPTI_DRIVER_TRACE_CBID_cuCoredumpSetAttributeGlobal = 704,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxSetFlags = 705,
+    CUPTI_DRIVER_TRACE_CBID_cuMulticastCreate = 706,
+    CUPTI_DRIVER_TRACE_CBID_cuMulticastAddDevice = 707,
+    CUPTI_DRIVER_TRACE_CBID_cuMulticastBindMem = 708,
+    CUPTI_DRIVER_TRACE_CBID_cuMulticastBindAddr = 709,
+    CUPTI_DRIVER_TRACE_CBID_cuMulticastUnbind = 710,
+    CUPTI_DRIVER_TRACE_CBID_cuMulticastGetGranularity = 711,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddNode = 712,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeSetParams = 713,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecNodeSetParams = 714,
+    CUPTI_DRIVER_TRACE_CBID_cuMemAdvise_v2 = 715,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPrefetchAsync_v2 = 716,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPrefetchAsync_v2_ptsz = 717,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncGetName = 718,
+    CUPTI_DRIVER_TRACE_CBID_cuKernelGetName = 719,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCaptureToGraph = 720,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCaptureToGraph_ptsz = 721,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphConditionalHandleCreate = 722,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddNode_v2 = 723,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphGetEdges_v2 = 724,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetDependencies_v2 = 725,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetDependentNodes_v2 = 726,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphAddDependencies_v2 = 727,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphRemoveDependencies_v2 = 728,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCaptureInfo_v3 = 729,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCaptureInfo_v3_ptsz = 730,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamUpdateCaptureDependencies_v2 = 731,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamUpdateCaptureDependencies_v2_ptsz = 732,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncGetParamInfo = 733,
+    CUPTI_DRIVER_TRACE_CBID_cuKernelGetParamInfo = 734,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceRegisterAsyncNotification = 735,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceUnregisterAsyncNotification = 736,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleGetFunctionCount = 737,
+    CUPTI_DRIVER_TRACE_CBID_cuModuleEnumerateFunctions = 738,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryGetKernelCount = 739,
+    CUPTI_DRIVER_TRACE_CBID_cuLibraryEnumerateKernels = 740,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncIsLoaded = 741,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncLoad = 742,
+    CUPTI_DRIVER_TRACE_CBID_cuGreenCtxCreate = 743,
+    CUPTI_DRIVER_TRACE_CBID_cuGreenCtxDestroy = 744,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetDevResource = 745,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetDevResource = 746,
+    CUPTI_DRIVER_TRACE_CBID_cuGreenCtxGetDevResource = 747,
+    CUPTI_DRIVER_TRACE_CBID_cuDevResourceGenerateDesc = 748,
+    CUPTI_DRIVER_TRACE_CBID_cuGreenCtxRecordEvent = 749,
+    CUPTI_DRIVER_TRACE_CBID_cuGreenCtxWaitEvent = 750,
+    CUPTI_DRIVER_TRACE_CBID_cuDevSmResourceSplitByCount = 751,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetGreenCtx = 752,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxFromGreenCtx = 753,
+    CUPTI_DRIVER_TRACE_CBID_cuKernelGetLibrary = 754,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxRecordEvent = 755,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxWaitEvent = 756,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxCreate_v4 = 757,
+    CUPTI_DRIVER_TRACE_CBID_cuGreenCtxStreamCreate = 758,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCtx_v2 = 759,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetCtx_v2_ptsz = 760,
+    CUPTI_DRIVER_TRACE_CBID_cuMemBatchDecompressAsync = 761,
+    CUPTI_DRIVER_TRACE_CBID_cuMemBatchDecompressAsync_ptsz = 762,
+    CUPTI_DRIVER_TRACE_CBID_cuLogsRegisterCallback = 763,
+    CUPTI_DRIVER_TRACE_CBID_cuLogsUnregisterCallback = 764,
+    CUPTI_DRIVER_TRACE_CBID_cuLogsCurrent = 765,
+    CUPTI_DRIVER_TRACE_CBID_cuLogsDumpToFile = 766,
+    CUPTI_DRIVER_TRACE_CBID_cuLogsDumpToMemory = 767,
+    CUPTI_DRIVER_TRACE_CBID_cuCheckpointProcessGetRestoreThreadId = 768,
+    CUPTI_DRIVER_TRACE_CBID_cuCheckpointProcessGetState = 769,
+    CUPTI_DRIVER_TRACE_CBID_cuCheckpointProcessLock = 770,
+    CUPTI_DRIVER_TRACE_CBID_cuCheckpointProcessCheckpoint = 771,
+    CUPTI_DRIVER_TRACE_CBID_cuCheckpointProcessRestore = 772,
+    CUPTI_DRIVER_TRACE_CBID_cuCheckpointProcessUnlock = 773,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetDevice = 774,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetDevice_ptsz = 775,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyBatchAsync = 776,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyBatchAsync_ptsz = 777,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DBatchAsync = 778,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DBatchAsync_ptsz = 779,
+    CUPTI_DRIVER_TRACE_CBID_cuEventElapsedTime_v2 = 780,
+    CUPTI_DRIVER_TRACE_CBID_cuTensorMapEncodeIm2colWide = 781,
+    CUPTI_DRIVER_TRACE_CBID_cuGreenCtxGetId = 782,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCaptureToCig = 783,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPrefetchBatchAsync = 784,
+    CUPTI_DRIVER_TRACE_CBID_cuMemPrefetchBatchAsync_ptsz = 785,
+    CUPTI_DRIVER_TRACE_CBID_cuSemaphoreCreate = 786,
+    CUPTI_DRIVER_TRACE_CBID_cuSemaphoreExport = 787,
+    CUPTI_DRIVER_TRACE_CBID_cuSemaphoreDestroy = 788,
+    CUPTI_DRIVER_TRACE_CBID_cuMemDiscardBatchAsync = 789,
+    CUPTI_DRIVER_TRACE_CBID_cuMemDiscardBatchAsync_ptsz = 790,
+    CUPTI_DRIVER_TRACE_CBID_cuMemDiscardAndPrefetchBatchAsync = 791,
+    CUPTI_DRIVER_TRACE_CBID_cuMemDiscardAndPrefetchBatchAsync_ptsz = 792,
+    CUPTI_DRIVER_TRACE_CBID_cuMultiKernelCooperativeDomainCreate = 793,
+    CUPTI_DRIVER_TRACE_CBID_cuMultiKernelCooperativeDomainDestroy = 794,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxGetDevice_v2 = 795,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyBatchAsync_v2 = 796,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyBatchAsync_v2_ptsz = 797,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DBatchAsync_v2 = 798,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DBatchAsync_v2_ptsz = 799,
+    CUPTI_DRIVER_TRACE_CBID_cuCtxSynchronize_v2 = 800,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetDefaultMemPool = 801,
+    CUPTI_DRIVER_TRACE_CBID_cuMemGetMemPool = 802,
+    CUPTI_DRIVER_TRACE_CBID_cuMemSetMemPool = 803,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetP2PAtomicCapabilities = 804,
+    CUPTI_DRIVER_TRACE_CBID_cuDeviceGetHostAtomicCapabilities = 805,
+    CUPTI_DRIVER_TRACE_CBID_cuDriverGetGpuCodeIsaVersion = 806,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetDevResource = 807,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamGetDevResource_ptsz = 808,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetContainingGraph = 809,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetLocalId = 810,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetToolsId = 811,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphGetId = 812,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphExecGetId = 813,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginCaptureToCig_ptsz = 814,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamEndCaptureToCig = 815,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamEndCaptureToCig_ptsz = 816,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphCreateWithArguments = 817,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeAddRelocation = 818,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphLaunchWithArguments = 819,
+    CUPTI_DRIVER_TRACE_CBID_cuMulticastBindMem_v2 = 820,
+    CUPTI_DRIVER_TRACE_CBID_cuMulticastBindAddr_v2 = 821,
+    CUPTI_DRIVER_TRACE_CBID_cuDevSmResourceSplit = 822,
+    CUPTI_DRIVER_TRACE_CBID_cuSubgridScheduleCreate = 823,
+    CUPTI_DRIVER_TRACE_CBID_cuSubgridWorkerGridCreate = 824,
+    CUPTI_DRIVER_TRACE_CBID_cuSubgridWorksetCreate = 825,
+    CUPTI_DRIVER_TRACE_CBID_cuSubgridCreate = 826,
+    CUPTI_DRIVER_TRACE_CBID_cuSubgridScheduleFinalize = 827,
+    CUPTI_DRIVER_TRACE_CBID_cuSubgridScheduleLaunch = 828,
+    CUPTI_DRIVER_TRACE_CBID_cuSubgridScheduleLaunch_ptsz = 829,
+    CUPTI_DRIVER_TRACE_CBID_cuSubgridScheduleDestroy = 830,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchHostFunc_v2 = 831,
+    CUPTI_DRIVER_TRACE_CBID_cuLaunchHostFunc_v2_ptsz = 832,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncGetDeviceCodeInfo = 833,
+    CUPTI_DRIVER_TRACE_CBID_cuKernelGetDeviceCodeInfo = 834,
+    CUPTI_DRIVER_TRACE_CBID_cuFuncGetParamCount = 835,
+    CUPTI_DRIVER_TRACE_CBID_cuKernelGetParamCount = 836,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyWithAttributesAsync = 837,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpyWithAttributesAsync_ptsz = 838,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DWithAttributesAsync = 839,
+    CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DWithAttributesAsync_ptsz = 840,
+    CUPTI_DRIVER_TRACE_CBID_cuGraphNodeGetParams = 841,
+    CUPTI_DRIVER_TRACE_CBID_cuCoredumpRegisterStartCallback = 842,
+    CUPTI_DRIVER_TRACE_CBID_cuCoredumpRegisterCompleteCallback = 843,
+    CUPTI_DRIVER_TRACE_CBID_cuCoredumpDeregisterStartCallback = 844,
+    CUPTI_DRIVER_TRACE_CBID_cuCoredumpDeregisterCompleteCallback = 845,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginRecaptureToGraph = 846,
+    CUPTI_DRIVER_TRACE_CBID_cuStreamBeginRecaptureToGraph_ptsz = 847,
+    CUPTI_DRIVER_TRACE_CBID_SIZE = 848,
+    CUPTI_DRIVER_TRACE_CBID_FORCE_INT = 2147483647,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_nvtx_api_trace_cbid {
@@ -20914,7 +22026,7 @@ pub enum CUpti_runtime_api_trace_cbid_enum {
     CUPTI_RUNTIME_TRACE_CBID_SIZE = 550,
     CUPTI_RUNTIME_TRACE_CBID_FORCE_INT = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpti_runtime_api_trace_cbid_enum {
@@ -21589,7 +22701,7 @@ pub struct CUpti_ActivityCdpKernel__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityComputeEngineCtxSwitch {
@@ -21599,7 +22711,7 @@ pub struct CUpti_ActivityComputeEngineCtxSwitch {
     pub operationType: CUpti_ComputeEngineCtxSwitchOperationType,
     pub padding: u32,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityConfidentialComputeRotation {
@@ -21611,7 +22723,7 @@ pub struct CUpti_ActivityConfidentialComputeRotation {
     pub channelType: CUpti_ChannelType,
     pub timestamp: u64,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityConfig {
@@ -21642,7 +22754,7 @@ pub struct CUpti_ActivityContext2 {
     pub isGreenContext: u8,
     pub padding: [u8; 3usize],
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -21657,7 +22769,7 @@ pub struct CUpti_ActivityContext2 {
     pub padding: u8,
     pub numMultiprocessors: u16,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -21674,7 +22786,7 @@ pub struct CUpti_ActivityContext3 {
     pub cigMode: CUpti_ContextCigMode,
     pub padding2: u32,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityContext4 {
@@ -21702,7 +22814,7 @@ pub struct CUpti_ActivityCudaEvent {
     pub eventId: u32,
     pub pad: u32,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityCudaEvent2 {
@@ -21782,7 +22894,7 @@ pub struct CUpti_ActivityDevice2 {
     pub uuid: CUuuid,
     pub name: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 pub struct CUpti_ActivityDevice3 {
     pub kind: CUpti_ActivityKind,
@@ -21818,7 +22930,7 @@ pub struct CUpti_ActivityDevice3 {
     pub isCudaVisible: u8,
     pub reserved: [u8; 7usize],
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 pub struct CUpti_ActivityDevice4 {
     pub kind: CUpti_ActivityKind,
@@ -21858,7 +22970,7 @@ pub struct CUpti_ActivityDevice4 {
     pub computeInstanceId: u32,
     pub migUuid: CUuuid,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 pub struct CUpti_ActivityDevice5 {
     pub kind: CUpti_ActivityKind,
@@ -21900,7 +23012,7 @@ pub struct CUpti_ActivityDevice5 {
     pub isNumaNode: u32,
     pub numaId: u32,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 pub struct CUpti_ActivityDevice6 {
     pub kind: CUpti_ActivityKind,
@@ -21958,7 +23070,7 @@ pub struct CUpti_ActivityDeviceAttribute__bindgen_ty_1 {
     pub cupti: __BindgenUnionField<CUpti_DeviceAttribute>,
     pub bindgen_union_field: u32,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityDeviceGraphTrace {
@@ -21982,6 +23094,36 @@ pub struct CUpti_ActivityEnvironment {
     pub environmentKind: CUpti_ActivityEnvironmentKind,
     pub data: CUpti_ActivityEnvironment__bindgen_ty_1,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUpti_ActivityEnvironmentCooling {
+    pub fanSpeed: u32,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUpti_ActivityEnvironmentPower {
+    pub power: u32,
+    pub powerLimit: u32,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUpti_ActivityEnvironmentSpeed {
+    pub smClock: u32,
+    pub memoryClock: u32,
+    pub pcieLinkGen: u32,
+    pub pcieLinkWidth: u32,
+    pub clocksThrottleReasons: CUpti_EnvironmentClocksThrottleReason,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUpti_ActivityEnvironmentTemperature {
+    pub gpuTemperature: u32,
+}
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityEnvironment__bindgen_ty_1__bindgen_ty_1 {
@@ -21991,17 +23133,20 @@ pub struct CUpti_ActivityEnvironment__bindgen_ty_1__bindgen_ty_1 {
     pub pcieLinkWidth: u32,
     pub clocksThrottleReasons: CUpti_EnvironmentClocksThrottleReason,
 }
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityEnvironment__bindgen_ty_1__bindgen_ty_2 {
     pub gpuTemperature: u32,
 }
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityEnvironment__bindgen_ty_1__bindgen_ty_3 {
     pub power: u32,
     pub powerLimit: u32,
 }
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityEnvironment__bindgen_ty_1__bindgen_ty_4 {
@@ -22036,7 +23181,7 @@ pub struct CUpti_ActivityExternalCorrelation {
     pub correlationId: u32,
     pub reserved: u32,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityFieldLayoutEntry {
@@ -22046,7 +23191,7 @@ pub struct CUpti_ActivityFieldLayoutEntry {
     pub size: usize,
     pub alignment: usize,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityFieldSelection {
@@ -22106,7 +23251,7 @@ pub struct CUpti_ActivityGlobalAccess3 {
     pub l2_transactions: u64,
     pub theoreticalL2Transactions: u64,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityGraphHostNode {
@@ -22122,7 +23267,7 @@ pub struct CUpti_ActivityGraphHostNode {
     pub start: u64,
     pub end: u64,
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityGraphTrace {
@@ -22136,7 +23281,7 @@ pub struct CUpti_ActivityGraphTrace {
     pub streamId: u32,
     pub reserved: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityGraphTrace2 {
@@ -22152,7 +23297,7 @@ pub struct CUpti_ActivityGraphTrace2 {
     pub endDeviceId: u32,
     pub endContextId: u32,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -22167,7 +23312,7 @@ pub struct CUpti_ActivityGreenContext {
     pub padding: u8,
     pub logicalTpcMask: [u32; 32usize],
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityGreenContext2 {
@@ -22184,7 +23329,7 @@ pub struct CUpti_ActivityGreenContext2 {
     pub workqueueConcurrencyLimit: u32,
     pub workqueueSharingScope: u32,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityHostLaunch {
@@ -22268,7 +23413,7 @@ pub struct CUpti_ActivityInstructionExecution {
     pub executed: u32,
     pub pad: u32,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityJit {
@@ -22284,7 +23429,7 @@ pub struct CUpti_ActivityJit {
     pub cacheSize: u64,
     pub cachePath: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityJit2 {
@@ -22330,7 +23475,7 @@ pub struct CUpti_ActivityKernel {
     pub name: *const ::core::ffi::c_char,
     pub reserved0: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityKernel10 {
@@ -22383,14 +23528,14 @@ pub struct CUpti_ActivityKernel10 {
     pub isDeviceLaunched: u8,
     pub padding3: [u8; 7usize],
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityKernel10__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityKernel11 {
@@ -22445,10 +23590,74 @@ pub struct CUpti_ActivityKernel11 {
     pub priority: i32,
     pub padding4: u32,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityKernel11__bindgen_ty_1__bindgen_ty_1 {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C, packed(8))]
+#[derive(Copy, Clone)]
+pub struct CUpti_ActivityKernel12 {
+    pub kind: CUpti_ActivityKind,
+    pub cacheConfig: CUpti_ActivityKernel12__bindgen_ty_1,
+    pub sharedMemoryConfig: u8,
+    pub registersPerThread: u16,
+    pub partitionedGlobalCacheRequested: CUpti_ActivityPartitionedGlobalCacheConfig,
+    pub partitionedGlobalCacheExecuted: CUpti_ActivityPartitionedGlobalCacheConfig,
+    pub start: u64,
+    pub end: u64,
+    pub completed: u64,
+    pub deviceId: u32,
+    pub contextId: u32,
+    pub streamId: u32,
+    pub gridX: i32,
+    pub gridY: i32,
+    pub gridZ: i32,
+    pub blockX: i32,
+    pub blockY: i32,
+    pub blockZ: i32,
+    pub staticSharedMemory: i32,
+    pub dynamicSharedMemory: i32,
+    pub localMemoryPerThread: u32,
+    pub localMemoryTotal: u32,
+    pub correlationId: u32,
+    pub gridId: i64,
+    pub name: *const ::core::ffi::c_char,
+    pub reserved0: *mut ::core::ffi::c_void,
+    pub queued: u64,
+    pub submitted: u64,
+    pub launchType: u8,
+    pub isSharedMemoryCarveoutRequested: u8,
+    pub sharedMemoryCarveoutRequested: u8,
+    pub padding: u8,
+    pub sharedMemoryExecuted: u32,
+    pub graphNodeId: u64,
+    pub shmemLimitConfig: CUpti_FuncShmemLimitConfig,
+    pub graphId: u32,
+    pub pAccessPolicyWindow: *mut CUaccessPolicyWindow,
+    pub channelID: u32,
+    pub channelType: CUpti_ChannelType,
+    pub clusterX: u32,
+    pub clusterY: u32,
+    pub clusterZ: u32,
+    pub clusterSchedulingPolicy: u32,
+    pub localMemoryTotal_v2: u64,
+    pub maxPotentialClusterSize: u32,
+    pub maxActiveClusters: u32,
+    pub isDeviceLaunched: u8,
+    pub padding3: [u8; 7usize],
+    pub priority: i32,
+    pub padding4: u32,
+    pub executionModel: u32,
+    pub padding5: u32,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUpti_ActivityKernel12__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
@@ -22658,7 +23867,7 @@ pub struct CUpti_ActivityKernel6__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityKernel7 {
@@ -22702,14 +23911,14 @@ pub struct CUpti_ActivityKernel7 {
     pub channelID: u32,
     pub channelType: CUpti_ChannelType,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityKernel7__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityKernel8 {
@@ -22758,14 +23967,14 @@ pub struct CUpti_ActivityKernel8 {
     pub clusterSchedulingPolicy: u32,
     pub localMemoryTotal_v2: u64,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityKernel8__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityKernel9 {
@@ -22816,7 +24025,7 @@ pub struct CUpti_ActivityKernel9 {
     pub maxPotentialClusterSize: u32,
     pub maxActiveClusters: u32,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityKernel9__bindgen_ty_1__bindgen_ty_1 {
@@ -22859,7 +24068,7 @@ pub struct CUpti_ActivityMarkerData {
     pub color: u32,
     pub category: u32,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityMarkerData2 {
@@ -22873,7 +24082,7 @@ pub struct CUpti_ActivityMarkerData2 {
     pub cuptiDomainId: u32,
     pub padding: u32,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityMemDecompress {
@@ -22951,7 +24160,7 @@ pub struct CUpti_ActivityMemcpy4 {
     pub graphId: u32,
     pub padding: u32,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityMemcpy5 {
@@ -23002,7 +24211,7 @@ pub struct CUpti_ActivityMemcpy6 {
     pub pad2: u32,
     pub copyCount: u64,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityMemcpy6 {
@@ -23096,7 +24305,7 @@ pub struct CUpti_ActivityMemcpyPtoP3 {
     pub graphId: u32,
     pub padding: u32,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityMemcpyPtoP4 {
@@ -23169,7 +24378,7 @@ pub struct CUpti_ActivityMemory2__bindgen_ty_1 {
     pub releaseThreshold: u64,
     pub pool: CUpti_ActivityMemory2__bindgen_ty_1__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityMemory2__bindgen_ty_1 {
@@ -23179,7 +24388,7 @@ pub struct CUpti_ActivityMemory2__bindgen_ty_1 {
     pub releaseThreshold: u64,
     pub pool: CUpti_ActivityMemory2__bindgen_ty_1__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityMemory3 {
@@ -23200,7 +24409,7 @@ pub struct CUpti_ActivityMemory3 {
     pub pad1: u32,
     pub memoryPoolConfig: CUpti_ActivityMemory3__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityMemory3__bindgen_ty_1 {
@@ -23211,7 +24420,7 @@ pub struct CUpti_ActivityMemory3__bindgen_ty_1 {
     pub pool: CUpti_ActivityMemory3__bindgen_ty_1__bindgen_ty_1,
     pub utilizedSize: u64,
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityMemory4 {
@@ -23233,7 +24442,7 @@ pub struct CUpti_ActivityMemory4 {
     pub memoryPoolConfig: CUpti_ActivityMemory4__bindgen_ty_1,
     pub source: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityMemory4__bindgen_ty_1 {
@@ -23259,7 +24468,7 @@ pub struct CUpti_ActivityMemoryPool {
     pub releaseThreshold: u64,
     pub timestamp: u64,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityMemoryPool2 {
@@ -23276,7 +24485,7 @@ pub struct CUpti_ActivityMemoryPool2 {
     pub timestamp: u64,
     pub utilizedSize: u64,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityMemoryPool3 {
@@ -23373,7 +24582,7 @@ pub struct CUpti_ActivityMemset4 {
     pub channelType: CUpti_ChannelType,
     pub pad2: u32,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityMemset4 {
@@ -23480,7 +24689,7 @@ pub struct CUpti_ActivityNvLink2 {
     pub portDev1: [i8; 32usize],
     pub bandwidth: u64,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 pub struct CUpti_ActivityNvLink2 {
     pub kind: CUpti_ActivityKind,
@@ -23553,7 +24762,7 @@ pub struct CUpti_ActivityNvLink3 {
     pub nvswitchConnected: u8,
     pub pad: [u8; 7usize],
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 pub struct CUpti_ActivityNvLink3 {
     pub kind: CUpti_ActivityKind,
@@ -23594,7 +24803,7 @@ pub struct CUpti_ActivityNvLink3__bindgen_ty_2__bindgen_ty_1 {
     pub index: u32,
     pub domainId: u32,
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 pub struct CUpti_ActivityNvLink4 {
     pub kind: CUpti_ActivityKind,
@@ -23611,35 +24820,35 @@ pub struct CUpti_ActivityNvLink4 {
     pub nvswitchConnected: u8,
     pub pad: [u8; 7usize],
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct CUpti_ActivityNvLink4__bindgen_ty_1 {
     pub uuidDev: __BindgenUnionField<CUuuid>,
     pub npu: __BindgenUnionField<CUpti_ActivityNvLink4__bindgen_ty_1__bindgen_ty_1>,
     pub bindgen_union_field: [u32; 4usize],
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityNvLink4__bindgen_ty_1__bindgen_ty_1 {
     pub index: u32,
     pub domainId: u32,
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct CUpti_ActivityNvLink4__bindgen_ty_2 {
     pub uuidDev: __BindgenUnionField<CUuuid>,
     pub npu: __BindgenUnionField<CUpti_ActivityNvLink4__bindgen_ty_2__bindgen_ty_1>,
     pub bindgen_union_field: [u32; 4usize],
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityNvLink4__bindgen_ty_2__bindgen_ty_1 {
     pub index: u32,
     pub domainId: u32,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 pub struct CUpti_ActivityNvLink5 {
     pub kind: CUpti_ActivityKind,
@@ -23663,6 +24872,13 @@ pub struct CUpti_ActivityNvLink5__bindgen_ty_1 {
     pub npu: __BindgenUnionField<CUpti_ActivityNvLink5__bindgen_ty_1__bindgen_ty_1>,
     pub bindgen_union_field: [u32; 4usize],
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+pub struct CUpti_ActivityNvLink5__bindgen_ty_1 {
+    pub uuidDev: __BindgenUnionField<CUuuid>,
+    pub npu: __BindgenUnionField<CUpti_ActivityNvLinkNpu>,
+    pub bindgen_union_field: [u32; 4usize],
+}
 #[cfg(any(feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -23677,10 +24893,24 @@ pub struct CUpti_ActivityNvLink5__bindgen_ty_2 {
     pub npu: __BindgenUnionField<CUpti_ActivityNvLink5__bindgen_ty_2__bindgen_ty_1>,
     pub bindgen_union_field: [u32; 4usize],
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+pub struct CUpti_ActivityNvLink5__bindgen_ty_2 {
+    pub uuidDev: __BindgenUnionField<CUuuid>,
+    pub npu: __BindgenUnionField<CUpti_ActivityNvLinkNpu>,
+    pub bindgen_union_field: [u32; 4usize],
+}
 #[cfg(any(feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityNvLink5__bindgen_ty_2__bindgen_ty_1 {
+    pub index: u32,
+    pub domainId: u32,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUpti_ActivityNvLinkNpu {
     pub index: u32,
     pub domainId: u32,
 }
@@ -23863,7 +25093,7 @@ pub struct CUpti_ActivityOverhead {
     pub start: u64,
     pub end: u64,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityOverhead2 {
@@ -23876,7 +25106,7 @@ pub struct CUpti_ActivityOverhead2 {
     pub correlationId: u32,
     pub reserved0: u32,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Copy, Clone)]
 pub struct CUpti_ActivityOverhead3 {
@@ -23890,7 +25120,7 @@ pub struct CUpti_ActivityOverhead3 {
     pub reserved0: u32,
     pub overheadData: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityOverheadCommandBufferFullData {
@@ -23969,23 +25199,48 @@ pub struct CUpti_ActivityPcie {
     pub upstreamBus: u16,
     pub attr: CUpti_ActivityPcie__bindgen_ty_2,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUpti_ActivityPcieBridgeAttr {
+    pub secondaryBus: u16,
+    pub deviceId: u16,
+    pub vendorId: u16,
+    pub pad0: u16,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+pub struct CUpti_ActivityPcieGpuAttr {
+    pub uuidDev: CUuuid,
+    pub peerDev: [CUdevice; 32usize],
+}
 #[repr(C)]
 pub struct CUpti_ActivityPcie__bindgen_ty_1 {
     pub devId: __BindgenUnionField<CUdevice>,
     pub bridgeId: __BindgenUnionField<u32>,
     pub bindgen_union_field: u32,
 }
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 pub struct CUpti_ActivityPcie__bindgen_ty_2 {
     pub gpuAttr: __BindgenUnionField<CUpti_ActivityPcie__bindgen_ty_2__bindgen_ty_1>,
     pub bridgeAttr: __BindgenUnionField<CUpti_ActivityPcie__bindgen_ty_2__bindgen_ty_2>,
     pub bindgen_union_field: [u32; 36usize],
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+pub struct CUpti_ActivityPcie__bindgen_ty_2 {
+    pub gpuAttr: __BindgenUnionField<CUpti_ActivityPcieGpuAttr>,
+    pub bridgeAttr: __BindgenUnionField<CUpti_ActivityPcieBridgeAttr>,
+    pub bindgen_union_field: [u32; 36usize],
+}
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 pub struct CUpti_ActivityPcie__bindgen_ty_2__bindgen_ty_1 {
     pub uuidDev: CUuuid,
     pub peerDev: [CUdevice; 32usize],
 }
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityPcie__bindgen_ty_2__bindgen_ty_2 {
@@ -24006,7 +25261,7 @@ pub struct CUpti_ActivityPreemption {
     pub blockZ: u32,
     pub pad: u32,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityRecordLayout {
@@ -24062,7 +25317,7 @@ pub struct CUpti_ActivitySynchronization {
     pub streamId: u32,
     pub cudaEventId: u32,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivitySynchronization2 {
@@ -24106,7 +25361,7 @@ pub struct CUpti_ActivityUnifiedMemoryCounter2 {
     pub flags: u32,
     pub pad: u32,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C, packed(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_ActivityUnifiedMemoryCounter3 {
@@ -24133,7 +25388,7 @@ pub struct CUpti_ActivityUnifiedMemoryCounterConfig {
     pub deviceId: u32,
     pub enable: u32,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_BufferCallbackCompleteInfo {
@@ -24142,7 +25397,7 @@ pub struct CUpti_BufferCallbackCompleteInfo {
     pub ppRecordLayouts: *mut *mut CUpti_ActivityRecordLayout,
     pub numRecordLayouts: usize,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_BufferCallbackRequestInfo {
@@ -24196,7 +25451,7 @@ pub struct CUpti_NvtxData {
     pub functionName: *const ::core::ffi::c_char,
     pub functionParams: *const ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_NvtxData {
@@ -24204,7 +25459,7 @@ pub struct CUpti_NvtxData {
     pub functionParams: *const ::core::ffi::c_void,
     pub functionReturnValue: *const ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_NvtxExtPayloadAttr {
@@ -24223,20 +25478,20 @@ pub struct CUpti_ResourceData__bindgen_ty_1 {
     pub stream: __BindgenUnionField<CUstream>,
     pub bindgen_union_field: u64,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUpti_StateData {
     pub __bindgen_anon_1: CUpti_StateData__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_StateData__bindgen_ty_1__bindgen_ty_1 {
     pub result: CUptiResult,
     pub message: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct CUpti_StreamAttrData {
     pub stream: CUstream,
@@ -24252,7 +25507,7 @@ pub struct CUpti_SubscriberParams {
     pub oldSubscriberName: *mut ::core::ffi::c_char,
     pub oldSubscriberSize: usize,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUpti_SubscriberParams {
@@ -24328,7 +25583,7 @@ pub struct cuArrayGetDescriptor_v2_params_st {
     pub pArrayDescriptor: *mut CUDA_ARRAY_DESCRIPTOR,
     pub hArray: CUarray,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuArrayGetMemoryRequirements_params_st {
     pub memoryRequirements: *mut CUDA_ARRAY_MEMORY_REQUIREMENTS,
@@ -24346,94 +25601,94 @@ pub struct cuArrayGetSparseProperties_params_st {
     pub sparseProperties: *mut CUDA_ARRAY_SPARSE_PROPERTIES,
     pub array: CUarray,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuCheckpointProcessCheckpoint_params_st {
     pub pid: ::core::ffi::c_int,
     pub args: *mut CUcheckpointCheckpointArgs,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuCheckpointProcessGetRestoreThreadId_params_st {
     pub pid: ::core::ffi::c_int,
     pub tid: *mut ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuCheckpointProcessGetState_params_st {
     pub pid: ::core::ffi::c_int,
     pub state: *mut CUprocessState,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuCheckpointProcessLock_params_st {
     pub pid: ::core::ffi::c_int,
     pub args: *mut CUcheckpointLockArgs,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuCheckpointProcessRestore_params_st {
     pub pid: ::core::ffi::c_int,
     pub args: *mut CUcheckpointRestoreArgs,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuCheckpointProcessUnlock_params_st {
     pub pid: ::core::ffi::c_int,
     pub args: *mut CUcheckpointUnlockArgs,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCoredumpDeregisterCompleteCallback_params_st {
     pub callback: CUcoredumpCallbackHandle,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCoredumpDeregisterStartCallback_params_st {
     pub callback: CUcoredumpCallbackHandle,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCoredumpGetAttributeGlobal_params_st {
     pub attrib: CUcoredumpSettings,
     pub value: *mut ::core::ffi::c_void,
     pub size: *mut usize,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCoredumpGetAttribute_params_st {
     pub attrib: CUcoredumpSettings,
     pub value: *mut ::core::ffi::c_void,
     pub size: *mut usize,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCoredumpRegisterCompleteCallback_params_st {
     pub callback: CUcoredumpStatusCallback,
     pub userData: *mut ::core::ffi::c_void,
     pub callbackOut: *mut CUcoredumpCallbackHandle,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCoredumpRegisterStartCallback_params_st {
     pub callback: CUcoredumpStatusCallback,
     pub userData: *mut ::core::ffi::c_void,
     pub callbackOut: *mut CUcoredumpCallbackHandle,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCoredumpSetAttributeGlobal_params_st {
     pub attrib: CUcoredumpSettings,
     pub value: *mut ::core::ffi::c_void,
     pub size: *mut usize,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCoredumpSetAttribute_params_st {
     pub attrib: CUcoredumpSettings,
@@ -24466,7 +25721,7 @@ pub struct cuCtxCreate_v3_params_st {
     pub flags: ::core::ffi::c_uint,
     pub dev: CUdevice,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCtxCreate_v4_params_st {
     pub pctx: *mut CUcontext,
@@ -24495,7 +25750,7 @@ pub struct cuCtxEnablePeerAccess_params_st {
     pub peerContext: CUcontext,
     pub Flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCtxFromGreenCtx_params_st {
     pub pContext: *mut CUcontext,
@@ -24516,7 +25771,7 @@ pub struct cuCtxGetCacheConfig_params_st {
 pub struct cuCtxGetCurrent_params_st {
     pub pctx: *mut CUcontext,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCtxGetDevResource_params_st {
     pub hCtx: CUcontext,
@@ -24528,7 +25783,7 @@ pub struct cuCtxGetDevResource_params_st {
 pub struct cuCtxGetDevice_params_st {
     pub device: *mut CUdevice,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCtxGetDevice_v2_params_st {
     pub device: *mut CUdevice,
@@ -24544,7 +25799,7 @@ pub struct cuCtxGetExecAffinity_params_st {
 pub struct cuCtxGetFlags_params_st {
     pub flags: *mut ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCtxGetId_params_st {
     pub ctx: CUcontext,
@@ -24584,7 +25839,7 @@ pub struct cuCtxPushCurrent_params_st {
 pub struct cuCtxPushCurrent_v2_params_st {
     pub ctx: CUcontext,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCtxRecordEvent_params_st {
     pub hCtx: CUcontext,
@@ -24598,7 +25853,7 @@ pub struct cuCtxSetCacheConfig_params_st {
 pub struct cuCtxSetCurrent_params_st {
     pub ctx: CUcontext,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuCtxSetFlags_params_st {
@@ -24613,12 +25868,12 @@ pub struct cuCtxSetLimit_params_st {
 pub struct cuCtxSetSharedMemConfig_params_st {
     pub config: CUsharedconfig,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCtxSynchronize_v2_params_st {
     pub ctx: CUcontext,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuCtxWaitEvent_params_st {
     pub hCtx: CUcontext,
@@ -24632,7 +25887,7 @@ pub struct cuDestroyExternalMemory_params_st {
 pub struct cuDestroyExternalSemaphore_params_st {
     pub extSem: CUexternalSemaphore,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuDevResourceGenerateDesc_params_st {
@@ -24651,7 +25906,7 @@ pub struct cuDevSmResourceSplitByCount_params_st {
     pub useFlags: ::core::ffi::c_uint,
     pub minCount: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuDevSmResourceSplitByCount_params_st {
@@ -24662,7 +25917,7 @@ pub struct cuDevSmResourceSplitByCount_params_st {
     pub flags: ::core::ffi::c_uint,
     pub minCount: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuDevSmResourceSplit_params_st {
@@ -24707,7 +25962,7 @@ pub struct cuDeviceGetDefaultMemPool_params_st {
     pub pool_out: *mut CUmemoryPool,
     pub dev: CUdevice,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuDeviceGetDevResource_params_st {
     pub device: CUdevice,
@@ -24726,7 +25981,7 @@ pub struct cuDeviceGetGraphMemAttribute_params_st {
     pub attr: CUgraphMem_attribute,
     pub value: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuDeviceGetHostAtomicCapabilities_params_st {
     pub capabilities: *mut ::core::ffi::c_uint,
@@ -24757,7 +26012,7 @@ pub struct cuDeviceGetNvSciSyncAttributes_params_st {
     pub dev: CUdevice,
     pub flags: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuDeviceGetP2PAtomicCapabilities_params_st {
     pub capabilities: *mut ::core::ffi::c_uint,
@@ -24848,7 +26103,7 @@ pub struct cuDevicePrimaryCtxSetFlags_v2_params_st {
     pub dev: CUdevice,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuDeviceRegisterAsyncNotification_params_st {
     pub device: CUdevice,
@@ -24877,7 +26132,7 @@ pub struct cuDeviceTotalMem_v2_params_st {
     pub bytes: *mut usize,
     pub dev: CUdevice,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuDeviceUnregisterAsyncNotification_params_st {
     pub device: CUdevice,
@@ -24908,7 +26163,7 @@ pub struct cuEventElapsedTime_params_st {
     pub hStart: CUevent,
     pub hEnd: CUevent,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuEventElapsedTime_v2_params_st {
     pub pMilliseconds: *mut f32,
@@ -24957,7 +26212,7 @@ pub struct cuExternalMemoryGetMappedMipmappedArray_params_st {
     pub extMem: CUexternalMemory,
     pub mipmapDesc: *const CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC,
 }
-#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuFlushGPUDirectRDMAWrites_params_st {
     pub target: CUflushGPUDirectRDMAWritesTarget,
@@ -24974,19 +26229,19 @@ pub struct cuFuncGetModule_params_st {
     pub hmod: *mut CUmodule,
     pub hfunc: CUfunction,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuFuncGetName_params_st {
     pub name: *mut *const ::core::ffi::c_char,
     pub hfunc: CUfunction,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuFuncGetParamCount_params_st {
     pub func: CUfunction,
     pub paramCount: *mut usize,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuFuncGetParamInfo_params_st {
     pub func: CUfunction,
@@ -24994,13 +26249,13 @@ pub struct cuFuncGetParamInfo_params_st {
     pub paramOffset: *mut usize,
     pub paramSize: *mut usize,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuFuncIsLoaded_params_st {
     pub state: *mut CUfunctionLoadingState,
     pub function: CUfunction,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuFuncLoad_params_st {
     pub function: CUfunction,
@@ -25049,7 +26304,7 @@ pub struct cuGetExportTable_params_st {
     pub ppExportTable: *mut *const ::core::ffi::c_void,
     pub pExportTableId: *const CUuuid,
 }
-#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGetProcAddress_params_st {
     pub symbol: *const ::core::ffi::c_char,
@@ -25057,7 +26312,7 @@ pub struct cuGetProcAddress_params_st {
     pub cudaVersion: ::core::ffi::c_int,
     pub flags: cuuint64_t,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGetProcAddress_v2_params_st {
     pub symbol: *const ::core::ffi::c_char,
@@ -25066,7 +26321,7 @@ pub struct cuGetProcAddress_v2_params_st {
     pub flags: cuuint64_t,
     pub symbolStatus: *mut CUdriverProcAddressQueryResult,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphAddBatchMemOpNode_params_st {
     pub phGraphNode: *mut CUgraphNode,
@@ -25090,7 +26345,7 @@ pub struct cuGraphAddDependencies_params_st {
     pub to: *const CUgraphNode,
     pub numDependencies: usize,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphAddDependencies_v2_params_st {
     pub hGraph: CUgraph,
@@ -25155,7 +26410,7 @@ pub struct cuGraphAddKernelNode_params_st {
     pub numDependencies: usize,
     pub nodeParams: *const CUDA_KERNEL_NODE_PARAMS,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphAddKernelNode_params_st {
     pub phGraphNode: *mut CUgraphNode,
@@ -25164,7 +26419,7 @@ pub struct cuGraphAddKernelNode_params_st {
     pub numDependencies: usize,
     pub nodeParams: *const CUDA_KERNEL_NODE_PARAMS_v1,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphAddKernelNode_v2_params_st {
     pub phGraphNode: *mut CUgraphNode,
@@ -25207,7 +26462,7 @@ pub struct cuGraphAddMemsetNode_params_st {
     pub memsetParams: *const CUDA_MEMSET_NODE_PARAMS,
     pub ctx: CUcontext,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphAddNode_params_st {
     pub phGraphNode: *mut CUgraphNode,
@@ -25216,7 +26471,7 @@ pub struct cuGraphAddNode_params_st {
     pub numDependencies: usize,
     pub nodeParams: *mut CUgraphNodeParams,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphAddNode_v2_params_st {
     pub phGraphNode: *mut CUgraphNode,
@@ -25226,13 +26481,13 @@ pub struct cuGraphAddNode_v2_params_st {
     pub numDependencies: usize,
     pub nodeParams: *mut CUgraphNodeParams,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphBatchMemOpNodeGetParams_params_st {
     pub hNode: CUgraphNode,
     pub nodeParams_out: *mut CUDA_BATCH_MEM_OP_NODE_PARAMS,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphBatchMemOpNodeSetParams_params_st {
     pub hNode: CUgraphNode,
@@ -25248,7 +26503,7 @@ pub struct cuGraphClone_params_st {
     pub phGraphClone: *mut CUgraph,
     pub originalGraph: CUgraph,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphConditionalHandleCreate_params_st {
     pub pHandle_out: *mut CUgraphConditionalHandle,
@@ -25297,7 +26552,7 @@ pub struct cuGraphEventWaitNodeSetEvent_params_st {
     pub hNode: CUgraphNode,
     pub event: CUevent,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphExecBatchMemOpNodeSetParams_params_st {
     pub hGraphExec: CUgraphExec,
@@ -25338,13 +26593,13 @@ pub struct cuGraphExecExternalSemaphoresWaitNodeSetParams_params_st {
     pub hNode: CUgraphNode,
     pub nodeParams: *const CUDA_EXT_SEM_WAIT_NODE_PARAMS,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphExecGetFlags_params_st {
     pub hGraphExec: CUgraphExec,
     pub flags: *mut cuuint64_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphExecGetId_params_st {
     pub hGraphExec: CUgraphExec,
@@ -25363,14 +26618,14 @@ pub struct cuGraphExecKernelNodeSetParams_params_st {
     pub hNode: CUgraphNode,
     pub nodeParams: *const CUDA_KERNEL_NODE_PARAMS,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphExecKernelNodeSetParams_params_st {
     pub hGraphExec: CUgraphExec,
     pub hNode: CUgraphNode,
     pub nodeParams: *const CUDA_KERNEL_NODE_PARAMS_v1,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphExecKernelNodeSetParams_v2_params_st {
     pub hGraphExec: CUgraphExec,
@@ -25391,7 +26646,7 @@ pub struct cuGraphExecMemsetNodeSetParams_params_st {
     pub memsetParams: *const CUDA_MEMSET_NODE_PARAMS,
     pub ctx: CUcontext,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphExecNodeSetParams_params_st {
     pub hGraphExec: CUgraphExec,
@@ -25405,7 +26660,7 @@ pub struct cuGraphExecUpdate_params_st {
     pub hErrorNode_out: *mut CUgraphNode,
     pub updateResult_out: *mut CUgraphExecUpdateResult,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphExecUpdate_v2_params_st {
     pub hGraphExec: CUgraphExec,
@@ -25439,7 +26694,7 @@ pub struct cuGraphGetEdges_params_st {
     pub to: *mut CUgraphNode,
     pub numEdges: *mut usize,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphGetEdges_v2_params_st {
     pub hGraph: CUgraph,
@@ -25448,7 +26703,7 @@ pub struct cuGraphGetEdges_v2_params_st {
     pub edgeData: *mut CUgraphEdgeData,
     pub numEdges: *mut usize,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphGetId_params_st {
     pub hGraph: CUgraph,
@@ -25482,14 +26737,14 @@ pub struct cuGraphInstantiateWithFlags_params_st {
     pub hGraph: CUgraph,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphInstantiateWithParams_params_st {
     pub phGraphExec: *mut CUgraphExec,
     pub hGraph: CUgraph,
     pub instantiateParams: *mut CUDA_GRAPH_INSTANTIATE_PARAMS,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphInstantiateWithParams_ptsz_params_st {
     pub phGraphExec: *mut CUgraphExec,
@@ -25529,13 +26784,13 @@ pub struct cuGraphKernelNodeGetParams_params_st {
     pub hNode: CUgraphNode,
     pub nodeParams: *mut CUDA_KERNEL_NODE_PARAMS,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphKernelNodeGetParams_params_st {
     pub hNode: CUgraphNode,
     pub nodeParams: *mut CUDA_KERNEL_NODE_PARAMS_v1,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphKernelNodeGetParams_v2_params_st {
     pub hNode: CUgraphNode,
@@ -25553,13 +26808,13 @@ pub struct cuGraphKernelNodeSetParams_params_st {
     pub hNode: CUgraphNode,
     pub nodeParams: *const CUDA_KERNEL_NODE_PARAMS,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphKernelNodeSetParams_params_st {
     pub hNode: CUgraphNode,
     pub nodeParams: *const CUDA_KERNEL_NODE_PARAMS_v1,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphKernelNodeSetParams_v2_params_st {
     pub hNode: CUgraphNode,
@@ -25611,7 +26866,7 @@ pub struct cuGraphNodeFindInClone_params_st {
     pub hOriginalNode: CUgraphNode,
     pub hClonedGraph: CUgraph,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphNodeGetContainingGraph_params_st {
     pub hNode: CUgraphNode,
@@ -25623,7 +26878,7 @@ pub struct cuGraphNodeGetDependencies_params_st {
     pub dependencies: *mut CUgraphNode,
     pub numDependencies: *mut usize,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphNodeGetDependencies_v2_params_st {
     pub hNode: CUgraphNode,
@@ -25637,7 +26892,7 @@ pub struct cuGraphNodeGetDependentNodes_params_st {
     pub dependentNodes: *mut CUgraphNode,
     pub numDependentNodes: *mut usize,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphNodeGetDependentNodes_v2_params_st {
     pub hNode: CUgraphNode,
@@ -25645,26 +26900,26 @@ pub struct cuGraphNodeGetDependentNodes_v2_params_st {
     pub edgeData: *mut CUgraphEdgeData,
     pub numDependentNodes: *mut usize,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphNodeGetEnabled_params_st {
     pub hGraphExec: CUgraphExec,
     pub hNode: CUgraphNode,
     pub isEnabled: *mut ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphNodeGetLocalId_params_st {
     pub hNode: CUgraphNode,
     pub nodeId: *mut ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphNodeGetParams_params_st {
     pub hNode: CUgraphNode,
     pub nodeParams: *mut CUgraphNodeParams,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphNodeGetToolsId_params_st {
     pub hNode: CUgraphNode,
@@ -25675,14 +26930,14 @@ pub struct cuGraphNodeGetType_params_st {
     pub hNode: CUgraphNode,
     pub type_: *mut CUgraphNodeType,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphNodeSetEnabled_params_st {
     pub hGraphExec: CUgraphExec,
     pub hNode: CUgraphNode,
     pub isEnabled: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphNodeSetParams_params_st {
     pub hNode: CUgraphNode,
@@ -25701,7 +26956,7 @@ pub struct cuGraphRemoveDependencies_params_st {
     pub to: *const CUgraphNode,
     pub numDependencies: usize,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGraphRemoveDependencies_v2_params_st {
     pub hGraph: CUgraph,
@@ -25789,7 +27044,7 @@ pub struct cuGraphicsUnmapResources_ptsz_params_st {
 pub struct cuGraphicsUnregisterResource_params_st {
     pub resource: CUgraphicsResource,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGreenCtxCreate_params_st {
     pub phCtx: *mut CUgreenCtx,
@@ -25797,31 +27052,31 @@ pub struct cuGreenCtxCreate_params_st {
     pub dev: CUdevice,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGreenCtxDestroy_params_st {
     pub hCtx: CUgreenCtx,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGreenCtxGetDevResource_params_st {
     pub hCtx: CUgreenCtx,
     pub resource: *mut CUdevResource,
     pub type_: CUdevResourceType,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGreenCtxGetId_params_st {
     pub greenCtx: CUgreenCtx,
     pub greenCtxId: *mut ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGreenCtxRecordEvent_params_st {
     pub hCtx: CUgreenCtx,
     pub hEvent: CUevent,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGreenCtxStreamCreate_params_st {
     pub phStream: *mut CUstream,
@@ -25829,7 +27084,7 @@ pub struct cuGreenCtxStreamCreate_params_st {
     pub flags: ::core::ffi::c_uint,
     pub priority: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuGreenCtxWaitEvent_params_st {
     pub hCtx: CUgreenCtx,
@@ -25883,7 +27138,7 @@ pub struct cuIpcOpenMemHandle_v2_params_st {
     pub handle: CUipcMemHandle,
     pub Flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuKernelGetAttribute_params_st {
     pub pi: *mut ::core::ffi::c_int,
@@ -25891,31 +27146,31 @@ pub struct cuKernelGetAttribute_params_st {
     pub kernel: CUkernel,
     pub dev: CUdevice,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuKernelGetFunction_params_st {
     pub pFunc: *mut CUfunction,
     pub kernel: CUkernel,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuKernelGetLibrary_params_st {
     pub pLib: *mut CUlibrary,
     pub kernel: CUkernel,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuKernelGetName_params_st {
     pub name: *mut *const ::core::ffi::c_char,
     pub hfunc: CUkernel,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuKernelGetParamCount_params_st {
     pub kernel: CUkernel,
     pub paramCount: *mut usize,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuKernelGetParamInfo_params_st {
     pub kernel: CUkernel,
@@ -25923,7 +27178,7 @@ pub struct cuKernelGetParamInfo_params_st {
     pub paramOffset: *mut usize,
     pub paramSize: *mut usize,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuKernelSetAttribute_params_st {
     pub attrib: CUfunction_attribute,
@@ -25931,7 +27186,7 @@ pub struct cuKernelSetAttribute_params_st {
     pub kernel: CUkernel,
     pub dev: CUdevice,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuKernelSetCacheConfig_params_st {
     pub kernel: CUkernel,
@@ -25996,7 +27251,7 @@ pub struct cuLaunchHostFunc_ptsz_params_st {
     pub fn_: CUhostFn,
     pub userData: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLaunchHostFunc_v2_params_st {
     pub hStream: CUstream,
@@ -26004,7 +27259,7 @@ pub struct cuLaunchHostFunc_v2_params_st {
     pub userData: *mut ::core::ffi::c_void,
     pub syncMode: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLaunchHostFunc_v2_ptsz_params_st {
     pub hStream: CUstream,
@@ -26012,7 +27267,7 @@ pub struct cuLaunchHostFunc_v2_ptsz_params_st {
     pub userData: *mut ::core::ffi::c_void,
     pub syncMode: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLaunchKernelEx_params_st {
     pub config: *const CUlaunchConfig,
@@ -26020,7 +27275,7 @@ pub struct cuLaunchKernelEx_params_st {
     pub kernelParams: *mut *mut ::core::ffi::c_void,
     pub extra: *mut *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLaunchKernelEx_ptsz_params_st {
     pub config: *const CUlaunchConfig,
@@ -26060,14 +27315,14 @@ pub struct cuLaunchKernel_ptsz_params_st {
 pub struct cuLaunch_params_st {
     pub f: CUfunction,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLibraryEnumerateKernels_params_st {
     pub kernels: *mut CUkernel,
     pub numKernels: ::core::ffi::c_uint,
     pub lib: CUlibrary,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLibraryGetGlobal_params_st {
     pub dptr: *mut CUdeviceptr,
@@ -26075,20 +27330,20 @@ pub struct cuLibraryGetGlobal_params_st {
     pub library: CUlibrary,
     pub name: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLibraryGetKernelCount_params_st {
     pub count: *mut ::core::ffi::c_uint,
     pub lib: CUlibrary,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLibraryGetKernel_params_st {
     pub pKernel: *mut CUkernel,
     pub library: CUlibrary,
     pub name: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLibraryGetManaged_params_st {
     pub dptr: *mut CUdeviceptr,
@@ -26096,20 +27351,20 @@ pub struct cuLibraryGetManaged_params_st {
     pub library: CUlibrary,
     pub name: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLibraryGetModule_params_st {
     pub pMod: *mut CUmodule,
     pub library: CUlibrary,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLibraryGetUnifiedFunction_params_st {
     pub fptr: *mut *mut ::core::ffi::c_void,
     pub library: CUlibrary,
     pub symbol: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuLibraryLoadData_params_st {
@@ -26122,7 +27377,7 @@ pub struct cuLibraryLoadData_params_st {
     pub libraryOptionValues: *mut *mut ::core::ffi::c_void,
     pub numLibraryOptions: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuLibraryLoadFromFile_params_st {
@@ -26135,7 +27390,7 @@ pub struct cuLibraryLoadFromFile_params_st {
     pub libraryOptionValues: *mut *mut ::core::ffi::c_void,
     pub numLibraryOptions: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLibraryUnload_params_st {
     pub library: CUlibrary,
@@ -26206,14 +27461,14 @@ pub struct cuLinkCreate_v2_params_st {
 pub struct cuLinkDestroy_params_st {
     pub state: CUlinkState,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuLogsCurrent_params_st {
     pub iterator_out: *mut CUlogIterator,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuLogsDumpToFile_params_st {
@@ -26221,7 +27476,7 @@ pub struct cuLogsDumpToFile_params_st {
     pub pathToFile: *const ::core::ffi::c_char,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuLogsDumpToMemory_params_st {
@@ -26230,14 +27485,14 @@ pub struct cuLogsDumpToMemory_params_st {
     pub size: *mut usize,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLogsRegisterCallback_params_st {
     pub callbackFunc: CUlogsCallback,
     pub userData: *mut ::core::ffi::c_void,
     pub callback_out: *mut CUlogsCallbackHandle,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuLogsUnregisterCallback_params_st {
     pub callback: CUlogsCallbackHandle,
@@ -26262,7 +27517,7 @@ pub struct cuMemAdvise_params_st {
     pub advice: CUmem_advise,
     pub device: CUdevice,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemAdvise_v2_params_st {
     pub devPtr: CUdeviceptr,
@@ -26345,7 +27600,7 @@ pub struct cuMemAlloc_v2_params_st {
     pub dptr: *mut CUdeviceptr,
     pub bytesize: usize,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemBatchDecompressAsync_params_st {
     pub paramsArray: *mut CUmemDecompressParams,
@@ -26354,7 +27609,7 @@ pub struct cuMemBatchDecompressAsync_params_st {
     pub errorIndex: *mut usize,
     pub stream: CUstream,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemBatchDecompressAsync_ptsz_params_st {
     pub paramsArray: *mut CUmemDecompressParams,
@@ -26371,7 +27626,7 @@ pub struct cuMemCreate_params_st {
     pub prop: *const CUmemAllocationProp,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemDiscardAndPrefetchBatchAsync_params_st {
     pub dptrs: *mut CUdeviceptr,
@@ -26383,7 +27638,7 @@ pub struct cuMemDiscardAndPrefetchBatchAsync_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemDiscardAndPrefetchBatchAsync_ptsz_params_st {
     pub dptrs: *mut CUdeviceptr,
@@ -26395,7 +27650,7 @@ pub struct cuMemDiscardAndPrefetchBatchAsync_ptsz_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemDiscardBatchAsync_params_st {
     pub dptrs: *mut CUdeviceptr,
@@ -26404,7 +27659,7 @@ pub struct cuMemDiscardBatchAsync_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemDiscardBatchAsync_ptsz_params_st {
     pub dptrs: *mut CUdeviceptr,
@@ -26474,14 +27729,14 @@ pub struct cuMemGetAllocationPropertiesFromHandle_params_st {
     pub prop: *mut CUmemAllocationProp,
     pub handle: CUmemGenericAllocationHandle,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemGetDefaultMemPool_params_st {
     pub pool_out: *mut CUmemoryPool,
     pub location: *mut CUmemLocation,
     pub type_: CUmemAllocationType,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemGetHandleForAddressRange_params_st {
     pub handle: *mut ::core::ffi::c_void,
@@ -26502,7 +27757,7 @@ pub struct cuMemGetInfo_v2_params_st {
     pub free: *mut usize,
     pub total: *mut usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemGetMemPool_params_st {
     pub pool: *mut CUmemoryPool,
@@ -26659,7 +27914,7 @@ pub struct cuMemPrefetchAsync_ptsz_params_st {
     pub dstDevice: CUdevice,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemPrefetchAsync_v2_params_st {
     pub devPtr: CUdeviceptr,
@@ -26668,7 +27923,7 @@ pub struct cuMemPrefetchAsync_v2_params_st {
     pub flags: ::core::ffi::c_uint,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemPrefetchAsync_v2_ptsz_params_st {
     pub devPtr: CUdeviceptr,
@@ -26677,7 +27932,7 @@ pub struct cuMemPrefetchAsync_v2_ptsz_params_st {
     pub flags: ::core::ffi::c_uint,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemPrefetchBatchAsync_params_st {
     pub dptrs: *mut CUdeviceptr,
@@ -26689,7 +27944,7 @@ pub struct cuMemPrefetchBatchAsync_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemPrefetchBatchAsync_ptsz_params_st {
     pub dptrs: *mut CUdeviceptr,
@@ -26735,7 +27990,7 @@ pub struct cuMemSetAccess_params_st {
     pub desc: *const CUmemAccessDesc,
     pub count: usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemSetMemPool_params_st {
     pub location: *mut CUmemLocation,
@@ -26807,7 +28062,7 @@ pub struct cuMemcpy3DAsync_v2_ptsz_params_st {
     pub pCopy: *const CUDA_MEMCPY3D,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpy3DBatchAsync_params_st {
     pub numOps: usize,
@@ -26816,7 +28071,7 @@ pub struct cuMemcpy3DBatchAsync_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpy3DBatchAsync_ptsz_params_st {
     pub numOps: usize,
@@ -26825,7 +28080,7 @@ pub struct cuMemcpy3DBatchAsync_ptsz_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpy3DBatchAsync_v2_params_st {
     pub numOps: usize,
@@ -26833,7 +28088,7 @@ pub struct cuMemcpy3DBatchAsync_v2_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpy3DBatchAsync_v2_ptsz_params_st {
     pub numOps: usize,
@@ -26861,14 +28116,14 @@ pub struct cuMemcpy3DPeer_params_st {
 pub struct cuMemcpy3DPeer_ptds_params_st {
     pub pCopy: *const CUDA_MEMCPY3D_PEER,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpy3DWithAttributesAsync_params_st {
     pub op: *mut CUDA_MEMCPY3D_BATCH_OP,
     pub flags: ::core::ffi::c_ulonglong,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpy3DWithAttributesAsync_ptsz_params_st {
     pub op: *mut CUDA_MEMCPY3D_BATCH_OP,
@@ -26994,7 +28249,7 @@ pub struct cuMemcpyAtoH_v2_ptds_params_st {
     pub srcOffset: usize,
     pub ByteCount: usize,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpyBatchAsync_params_st {
     pub dsts: *mut CUdeviceptr,
@@ -27007,7 +28262,7 @@ pub struct cuMemcpyBatchAsync_params_st {
     pub failIdx: *mut usize,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpyBatchAsync_ptsz_params_st {
     pub dsts: *mut CUdeviceptr,
@@ -27020,7 +28275,7 @@ pub struct cuMemcpyBatchAsync_ptsz_params_st {
     pub failIdx: *mut usize,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpyBatchAsync_v2_params_st {
     pub dsts: *mut CUdeviceptr,
@@ -27032,7 +28287,7 @@ pub struct cuMemcpyBatchAsync_v2_params_st {
     pub numAttrs: usize,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpyBatchAsync_v2_ptsz_params_st {
     pub dsts: *mut CUdeviceptr,
@@ -27264,7 +28519,7 @@ pub struct cuMemcpyPeer_ptds_params_st {
     pub srcContext: CUcontext,
     pub ByteCount: usize,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpyWithAttributesAsync_params_st {
     pub dst: CUdeviceptr,
@@ -27273,7 +28528,7 @@ pub struct cuMemcpyWithAttributesAsync_params_st {
     pub attr: *mut CUmemcpyAttributes,
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMemcpyWithAttributesAsync_ptsz_params_st {
     pub dst: CUdeviceptr,
@@ -27539,7 +28794,7 @@ pub struct cuMipmappedArrayGetLevel_params_st {
     pub hMipmappedArray: CUmipmappedArray,
     pub level: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMipmappedArrayGetMemoryRequirements_params_st {
     pub memoryRequirements: *mut CUDA_ARRAY_MEMORY_REQUIREMENTS,
@@ -27551,14 +28806,14 @@ pub struct cuMipmappedArrayGetSparseProperties_params_st {
     pub sparseProperties: *mut CUDA_ARRAY_SPARSE_PROPERTIES,
     pub mipmap: CUmipmappedArray,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuModuleEnumerateFunctions_params_st {
     pub functions: *mut CUfunction,
     pub numFunctions: ::core::ffi::c_uint,
     pub mod_: CUmodule,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuModuleGetFunctionCount_params_st {
     pub count: *mut ::core::ffi::c_uint,
@@ -27584,7 +28839,7 @@ pub struct cuModuleGetGlobal_v2_params_st {
     pub hmod: CUmodule,
     pub name: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuModuleGetLoadingMode_params_st {
@@ -27633,13 +28888,13 @@ pub struct cuModuleLoad_params_st {
 pub struct cuModuleUnload_params_st {
     pub hmod: CUmodule,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMulticastAddDevice_params_st {
     pub mcHandle: CUmemGenericAllocationHandle,
     pub dev: CUdevice,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMulticastBindAddr_params_st {
     pub mcHandle: CUmemGenericAllocationHandle,
@@ -27648,7 +28903,7 @@ pub struct cuMulticastBindAddr_params_st {
     pub size: usize,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMulticastBindAddr_v2_params_st {
     pub mcHandle: CUmemGenericAllocationHandle,
@@ -27658,7 +28913,7 @@ pub struct cuMulticastBindAddr_v2_params_st {
     pub size: usize,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMulticastBindMem_params_st {
     pub mcHandle: CUmemGenericAllocationHandle,
@@ -27668,7 +28923,7 @@ pub struct cuMulticastBindMem_params_st {
     pub size: usize,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMulticastBindMem_v2_params_st {
     pub mcHandle: CUmemGenericAllocationHandle,
@@ -27679,21 +28934,21 @@ pub struct cuMulticastBindMem_v2_params_st {
     pub size: usize,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuMulticastCreate_params_st {
     pub mcHandle: *mut CUmemGenericAllocationHandle,
     pub prop: *const CUmulticastObjectProp,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMulticastGetGranularity_params_st {
     pub granularity: *mut usize,
     pub prop: *const CUmulticastObjectProp,
     pub option: CUmulticastGranularity_flags,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuMulticastUnbind_params_st {
     pub mcHandle: CUmemGenericAllocationHandle,
@@ -27723,7 +28978,7 @@ pub struct cuOccupancyMaxActiveBlocksPerMultiprocessor_params_st {
     pub blockSize: ::core::ffi::c_int,
     pub dynamicSMemSize: usize,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuOccupancyMaxActiveClusters_params_st {
     pub numClusters: *mut ::core::ffi::c_int,
@@ -27749,7 +29004,7 @@ pub struct cuOccupancyMaxPotentialBlockSize_params_st {
     pub dynamicSMemSize: usize,
     pub blockSizeLimit: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuOccupancyMaxPotentialClusterSize_params_st {
     pub clusterSize: *mut ::core::ffi::c_int,
@@ -27861,7 +29116,7 @@ pub struct cuStreamBatchMemOp_ptsz_params_st {
     pub paramArray: *mut CUstreamBatchMemOpParams,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamBatchMemOp_v2_params_st {
     pub stream: CUstream,
@@ -27869,7 +29124,7 @@ pub struct cuStreamBatchMemOp_v2_params_st {
     pub paramArray: *mut CUstreamBatchMemOpParams,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamBatchMemOp_v2_ptsz_params_st {
     pub stream: CUstream,
@@ -27877,19 +29132,19 @@ pub struct cuStreamBatchMemOp_v2_ptsz_params_st {
     pub paramArray: *mut CUstreamBatchMemOpParams,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamBeginCaptureToCig_params_st {
     pub hStream: CUstream,
     pub streamCigCaptureParams: *mut CUstreamCigCaptureParams,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamBeginCaptureToCig_ptsz_params_st {
     pub hStream: CUstream,
     pub streamCigCaptureParams: *mut CUstreamCigCaptureParams,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamBeginCaptureToGraph_params_st {
     pub hStream: CUstream,
@@ -27899,7 +29154,7 @@ pub struct cuStreamBeginCaptureToGraph_params_st {
     pub numDependencies: usize,
     pub mode: CUstreamCaptureMode,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamBeginCaptureToGraph_ptsz_params_st {
     pub hStream: CUstream,
@@ -27926,6 +29181,24 @@ pub struct cuStreamBeginCapture_v2_params_st {
 pub struct cuStreamBeginCapture_v2_ptsz_params_st {
     pub hStream: CUstream,
     pub mode: CUstreamCaptureMode,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+pub struct cuStreamBeginRecaptureToGraph_params_st {
+    pub hStream: CUstream,
+    pub mode: CUstreamCaptureMode,
+    pub hGraph: CUgraph,
+    pub callbackFunc: CUgraphRecaptureCallback,
+    pub userData: *mut ::core::ffi::c_void,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+pub struct cuStreamBeginRecaptureToGraph_ptsz_params_st {
+    pub hStream: CUstream,
+    pub mode: CUstreamCaptureMode,
+    pub hGraph: CUgraph,
+    pub callbackFunc: CUgraphRecaptureCallback,
+    pub userData: *mut ::core::ffi::c_void,
 }
 #[repr(C)]
 pub struct cuStreamCopyAttributes_params_st {
@@ -27958,12 +29231,12 @@ pub struct cuStreamDestroy_params_st {
 pub struct cuStreamDestroy_v2_params_st {
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamEndCaptureToCig_params_st {
     pub hStream: CUstream,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamEndCaptureToCig_ptsz_params_st {
     pub hStream: CUstream,
@@ -28020,7 +29293,7 @@ pub struct cuStreamGetCaptureInfo_v2_ptsz_params_st {
     pub dependencies_out: *mut *const CUgraphNode,
     pub numDependencies_out: *mut usize,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetCaptureInfo_v3_params_st {
     pub hStream: CUstream,
@@ -28031,7 +29304,7 @@ pub struct cuStreamGetCaptureInfo_v3_params_st {
     pub edgeData_out: *mut *const CUgraphEdgeData,
     pub numDependencies_out: *mut usize,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetCaptureInfo_v3_ptsz_params_st {
     pub hStream: CUstream,
@@ -28052,41 +29325,41 @@ pub struct cuStreamGetCtx_ptsz_params_st {
     pub hStream: CUstream,
     pub pctx: *mut CUcontext,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetCtx_v2_params_st {
     pub hStream: CUstream,
     pub pCtx: *mut CUcontext,
     pub pGreenCtx: *mut CUgreenCtx,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetCtx_v2_ptsz_params_st {
     pub hStream: CUstream,
     pub pCtx: *mut CUcontext,
     pub pGreenCtx: *mut CUgreenCtx,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetDevResource_params_st {
     pub hStream: CUstream,
     pub resource: *mut CUdevResource,
     pub type_: CUdevResourceType,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetDevResource_ptsz_params_st {
     pub hStream: CUstream,
     pub resource: *mut CUdevResource,
     pub type_: CUdevResourceType,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetDevice_params_st {
     pub hStream: CUstream,
     pub device: *mut CUdevice,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetDevice_ptsz_params_st {
     pub hStream: CUstream,
@@ -28102,19 +29375,19 @@ pub struct cuStreamGetFlags_ptsz_params_st {
     pub hStream: CUstream,
     pub flags: *mut ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetGreenCtx_params_st {
     pub hStream: CUstream,
     pub phCtx: *mut CUgreenCtx,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetId_params_st {
     pub hStream: CUstream,
     pub streamId: *mut ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamGetId_ptsz_params_st {
     pub hStream: CUstream,
@@ -28182,7 +29455,7 @@ pub struct cuStreamUpdateCaptureDependencies_ptsz_params_st {
     pub numDependencies: usize,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamUpdateCaptureDependencies_v2_params_st {
     pub hStream: CUstream,
@@ -28191,7 +29464,7 @@ pub struct cuStreamUpdateCaptureDependencies_v2_params_st {
     pub numDependencies: usize,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamUpdateCaptureDependencies_v2_ptsz_params_st {
     pub hStream: CUstream,
@@ -28226,7 +29499,7 @@ pub struct cuStreamWaitValue32_ptsz_params_st {
     pub value: cuuint32_t,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamWaitValue32_v2_params_st {
     pub stream: CUstream,
@@ -28234,7 +29507,7 @@ pub struct cuStreamWaitValue32_v2_params_st {
     pub value: cuuint32_t,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamWaitValue32_v2_ptsz_params_st {
     pub stream: CUstream,
@@ -28256,7 +29529,7 @@ pub struct cuStreamWaitValue64_ptsz_params_st {
     pub value: cuuint64_t,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamWaitValue64_v2_params_st {
     pub stream: CUstream,
@@ -28264,7 +29537,7 @@ pub struct cuStreamWaitValue64_v2_params_st {
     pub value: cuuint64_t,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamWaitValue64_v2_ptsz_params_st {
     pub stream: CUstream,
@@ -28286,7 +29559,7 @@ pub struct cuStreamWriteValue32_ptsz_params_st {
     pub value: cuuint32_t,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamWriteValue32_v2_params_st {
     pub stream: CUstream,
@@ -28294,7 +29567,7 @@ pub struct cuStreamWriteValue32_v2_params_st {
     pub value: cuuint32_t,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamWriteValue32_v2_ptsz_params_st {
     pub stream: CUstream,
@@ -28316,7 +29589,7 @@ pub struct cuStreamWriteValue64_ptsz_params_st {
     pub value: cuuint64_t,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamWriteValue64_v2_params_st {
     pub stream: CUstream,
@@ -28324,7 +29597,7 @@ pub struct cuStreamWriteValue64_v2_params_st {
     pub value: cuuint64_t,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuStreamWriteValue64_v2_ptsz_params_st {
     pub stream: CUstream,
@@ -28358,7 +29631,7 @@ pub struct cuSurfRefSetArray_params_st {
     pub hArray: CUarray,
     pub Flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuTensorMapEncodeIm2colWide_params_st {
     pub tensorMap: *mut CUtensorMap,
@@ -28378,7 +29651,7 @@ pub struct cuTensorMapEncodeIm2colWide_params_st {
     pub l2Promotion: CUtensorMapL2promotion,
     pub oobFill: CUtensorMapFloatOOBfill,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuTensorMapEncodeIm2col_params_st {
     pub tensorMap: *mut CUtensorMap,
@@ -28397,7 +29670,7 @@ pub struct cuTensorMapEncodeIm2col_params_st {
     pub l2Promotion: CUtensorMapL2promotion,
     pub oobFill: CUtensorMapFloatOOBfill,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cuTensorMapEncodeTiled_params_st {
     pub tensorMap: *mut CUtensorMap,
@@ -28413,7 +29686,7 @@ pub struct cuTensorMapEncodeTiled_params_st {
     pub l2Promotion: CUtensorMapL2promotion,
     pub oobFill: CUtensorMapFloatOOBfill,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cuTensorMapReplaceAddress_params_st {
@@ -28663,7 +29936,7 @@ pub struct cudaArrayGetInfo_v4010_params_st {
     pub flags: *mut ::core::ffi::c_uint,
     pub array: cudaArray_t,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaArrayGetMemoryRequirements_v11060_params_st {
     pub memoryRequirements: *mut cudaArrayMemoryRequirements,
@@ -28768,7 +30041,7 @@ pub struct cudaDestroySurfaceObject_v5000_params_st {
 pub struct cudaDestroyTextureObject_v5000_params_st {
     pub texObject: cudaTextureObject_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDevResourceGenerateDesc_v13010_params_st {
@@ -28787,7 +30060,7 @@ pub struct cudaDevSmResourceSplitByCount_v13010_params_st {
     pub useFlags: ::core::ffi::c_uint,
     pub minCount: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDevSmResourceSplitByCount_v13010_params_st {
@@ -28798,7 +30071,7 @@ pub struct cudaDevSmResourceSplitByCount_v13010_params_st {
     pub flags: ::core::ffi::c_uint,
     pub minCount: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDevSmResourceSplit_v13010_params_st {
@@ -28855,14 +30128,14 @@ pub struct cudaDeviceGetDefaultMemPool_v11020_params_st {
     pub memPool: *mut cudaMemPool_t,
     pub device: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaDeviceGetDevResource_v13010_params_st {
     pub device: ::core::ffi::c_int,
     pub resource: *mut cudaDevResource,
     pub type_: cudaDevResourceType,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDeviceGetExecutionCtx_v13010_params_st {
@@ -28875,7 +30148,7 @@ pub struct cudaDeviceGetGraphMemAttribute_v11040_params_st {
     pub attr: cudaGraphMemAttributeType,
     pub value: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDeviceGetHostAtomicCapabilities_v13000_params_st {
@@ -28902,7 +30175,7 @@ pub struct cudaDeviceGetNvSciSyncAttributes_v10020_params_st {
     pub device: ::core::ffi::c_int,
     pub flags: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDeviceGetP2PAtomicCapabilities_v13000_params_st {
@@ -28949,7 +30222,7 @@ pub struct cudaDeviceGetTexture1DLinearMaxWidth_v11010_params_st {
 pub struct cudaDeviceGraphMemTrim_v11040_params_st {
     pub device: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaDeviceRegisterAsyncNotification_v12040_params_st {
     pub device: ::core::ffi::c_int,
@@ -28981,7 +30254,7 @@ pub struct cudaDeviceSetMemPool_v11020_params_st {
 pub struct cudaDeviceSetSharedMemConfig_v4020_params_st {
     pub config: cudaSharedMemConfig,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaDeviceUnregisterAsyncNotification_v12040_params_st {
     pub device: ::core::ffi::c_int,
@@ -29007,7 +30280,7 @@ pub struct cudaEventCreate_v3020_params_st {
 pub struct cudaEventDestroy_v3020_params_st {
     pub event: cudaEvent_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaEventElapsedTime_v12080_params_st {
     pub ms: *mut f32,
@@ -29058,37 +30331,37 @@ pub struct cudaEventRecord_v3020_params_st {
 pub struct cudaEventSynchronize_v3020_params_st {
     pub event: cudaEvent_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaExecutionCtxDestroy_v13010_params_st {
     pub ctx: cudaExecutionContext_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaExecutionCtxGetDevResource_v13010_params_st {
     pub ctx: cudaExecutionContext_t,
     pub resource: *mut cudaDevResource,
     pub type_: cudaDevResourceType,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaExecutionCtxGetDevice_v13010_params_st {
     pub device: *mut ::core::ffi::c_int,
     pub ctx: cudaExecutionContext_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaExecutionCtxGetId_v13010_params_st {
     pub ctx: cudaExecutionContext_t,
     pub ctxId: *mut ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaExecutionCtxRecordEvent_v13010_params_st {
     pub ctx: cudaExecutionContext_t,
     pub event: cudaEvent_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaExecutionCtxStreamCreate_v13010_params_st {
     pub phStream: *mut cudaStream_t,
@@ -29096,12 +30369,12 @@ pub struct cudaExecutionCtxStreamCreate_v13010_params_st {
     pub flags: ::core::ffi::c_uint,
     pub priority: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaExecutionCtxSynchronize_v13010_params_st {
     pub ctx: cudaExecutionContext_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaExecutionCtxWaitEvent_v13010_params_st {
     pub ctx: cudaExecutionContext_t,
@@ -29153,21 +30426,21 @@ pub struct cudaFuncGetAttributes_v3020_params_st {
     pub attr: *mut cudaFuncAttributes,
     pub func: *const ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaFuncGetName_v12030_params_st {
     pub name: *mut *const ::core::ffi::c_char,
     pub func: *const ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaFuncGetParamCount_v13020_params_st {
     pub func: *const ::core::ffi::c_void,
     pub paramCount: *mut usize,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaFuncGetParamInfo_v12040_params_st {
@@ -29207,7 +30480,7 @@ pub struct cudaGetDeviceCount_v3020_params_st {
 pub struct cudaGetDeviceFlags_v7000_params_st {
     pub flags: *mut ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGetDeviceProperties_v12000_params_st {
@@ -29233,7 +30506,7 @@ pub struct cudaGetDeviceProperties_v3020_params_st {
 pub struct cudaGetDevice_v3020_params_st {
     pub device: *mut ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGetDriverEntryPointByVersion_ptsz_v12050_params_st {
@@ -29243,7 +30516,7 @@ pub struct cudaGetDriverEntryPointByVersion_ptsz_v12050_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub driverStatus: *mut cudaDriverEntryPointQueryResult,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGetDriverEntryPointByVersion_v12050_params_st {
@@ -29261,7 +30534,7 @@ pub struct cudaGetDriverEntryPoint_ptsz_v11030_params_st {
     pub funcPtr: *mut *mut ::core::ffi::c_void,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGetDriverEntryPoint_ptsz_v11030_params_st {
@@ -29278,7 +30551,7 @@ pub struct cudaGetDriverEntryPoint_v11030_params_st {
     pub funcPtr: *mut *mut ::core::ffi::c_void,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGetDriverEntryPoint_v11030_params_st {
@@ -29301,7 +30574,7 @@ pub struct cudaGetFuncBySymbol_v11000_params_st {
     pub functionPtr: *mut cudaFunction_t,
     pub symbolPtr: *const ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGetKernel_v12000_params_st {
@@ -29383,7 +30656,7 @@ pub struct cudaGraphAddDependencies_v10000_params_st {
     pub to: *const cudaGraphNode_t,
     pub numDependencies: usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphAddDependencies_v12030_params_st {
     pub graph: cudaGraph_t,
@@ -29532,7 +30805,7 @@ pub struct cudaGraphAddNode_v12020_params_st {
     pub numDependencies: usize,
     pub nodeParams: *mut cudaGraphNodeParams,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphAddNode_v12030_params_st {
     pub pGraphNode: *mut cudaGraphNode_t,
@@ -29562,7 +30835,7 @@ pub struct cudaGraphClone_v10000_params_st {
     pub pGraphClone: *mut cudaGraph_t,
     pub originalGraph: cudaGraph_t,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphConditionalHandleCreate_v12030_params_st {
     pub pHandle_out: *mut cudaGraphConditionalHandle,
@@ -29570,7 +30843,7 @@ pub struct cudaGraphConditionalHandleCreate_v12030_params_st {
     pub defaultLaunchValue: ::core::ffi::c_uint,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphConditionalHandleCreate_v2_v13010_params_st {
     pub pHandle_out: *mut cudaGraphConditionalHandle,
@@ -29653,13 +30926,13 @@ pub struct cudaGraphExecExternalSemaphoresWaitNodeSetParams_v11020_params_st {
     pub hNode: cudaGraphNode_t,
     pub nodeParams: *const cudaExternalSemaphoreWaitNodeParams,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphExecGetFlags_v12000_params_st {
     pub graphExec: cudaGraphExec_t,
     pub flags: *mut ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphExecGetId_v13010_params_st {
     pub hGraphExec: cudaGraphExec_t,
@@ -29718,7 +30991,7 @@ pub struct cudaGraphExecMemsetNodeSetParams_v10020_params_st {
     pub node: cudaGraphNode_t,
     pub pNodeParams: *const cudaMemsetParams,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphExecNodeSetParams_v12020_params_st {
     pub graphExec: cudaGraphExec_t,
@@ -29733,7 +31006,7 @@ pub struct cudaGraphExecUpdate_v10020_params_st {
     pub hErrorNode_out: *mut cudaGraphNode_t,
     pub updateResult_out: *mut cudaGraphExecUpdateResult,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphExecUpdate_v10020_params_st {
     pub hGraphExec: cudaGraphExec_t,
@@ -29768,7 +31041,7 @@ pub struct cudaGraphGetEdges_v10000_params_st {
     pub to: *mut cudaGraphNode_t,
     pub numEdges: *mut usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphGetEdges_v12030_params_st {
     pub graph: cudaGraph_t,
@@ -29786,7 +31059,7 @@ pub struct cudaGraphGetEdges_v2_v12030_params_st {
     pub edgeData: *mut cudaGraphEdgeData,
     pub numEdges: *mut usize,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphGetId_v13010_params_st {
     pub hGraph: cudaGraph_t,
@@ -29820,14 +31093,14 @@ pub struct cudaGraphInstantiateWithFlags_v11040_params_st {
     pub graph: cudaGraph_t,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphInstantiateWithParams_ptsz_v12000_params_st {
     pub pGraphExec: *mut cudaGraphExec_t,
     pub graph: cudaGraph_t,
     pub instantiateParams: *mut cudaGraphInstantiateParams,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphInstantiateWithParams_v12000_params_st {
     pub pGraphExec: *mut cudaGraphExec_t,
@@ -29843,7 +31116,7 @@ pub struct cudaGraphInstantiate_v10000_params_st {
     pub pLogBuffer: *mut ::core::ffi::c_char,
     pub bufferSize: usize,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphInstantiate_v12000_params_st {
     pub pGraphExec: *mut cudaGraphExec_t,
@@ -29856,7 +31129,7 @@ pub struct cudaGraphKernelNodeCopyAttributes_v11000_params_st {
     pub hSrc: cudaGraphNode_t,
     pub hDst: cudaGraphNode_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphKernelNodeCopyAttributes_v11000_params_st {
     pub hDst: cudaGraphNode_t,
@@ -29869,7 +31142,7 @@ pub struct cudaGraphKernelNodeGetAttribute_v11000_params_st {
     pub attr: cudaKernelNodeAttrID,
     pub value_out: *mut cudaKernelNodeAttrValue,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphKernelNodeGetAttribute_v11000_params_st {
     pub hNode: cudaGraphNode_t,
@@ -29888,7 +31161,7 @@ pub struct cudaGraphKernelNodeSetAttribute_v11000_params_st {
     pub attr: cudaKernelNodeAttrID,
     pub value: *const cudaKernelNodeAttrValue,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphKernelNodeSetAttribute_v11000_params_st {
     pub hNode: cudaGraphNode_t,
@@ -29926,6 +31199,12 @@ pub struct cudaGraphMemFreeNodeGetParams_v11040_params_st {
 pub struct cudaGraphMemFreeNodeGetParams_v11040_params_st {
     pub node: cudaGraphNode_t,
     pub dptr_out: *mut *mut ::core::ffi::c_void,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+pub struct cudaGraphMemFreeNodeGetParams_v11040_params_st {
+    pub node: cudaGraphNode_t,
+    pub dptr_out: *mut ::core::ffi::c_void,
 }
 #[repr(C)]
 pub struct cudaGraphMemcpyNodeGetParams_v10000_params_st {
@@ -29979,7 +31258,7 @@ pub struct cudaGraphNodeFindInClone_v10000_params_st {
     pub originalNode: cudaGraphNode_t,
     pub clonedGraph: cudaGraph_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphNodeGetContainingGraph_v13010_params_st {
     pub hNode: cudaGraphNode_t,
@@ -29992,7 +31271,7 @@ pub struct cudaGraphNodeGetDependencies_v10000_params_st {
     pub pDependencies: *mut cudaGraphNode_t,
     pub pNumDependencies: *mut usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphNodeGetDependencies_v12030_params_st {
     pub node: cudaGraphNode_t,
@@ -30015,7 +31294,7 @@ pub struct cudaGraphNodeGetDependentNodes_v10000_params_st {
     pub pDependentNodes: *mut cudaGraphNode_t,
     pub pNumDependentNodes: *mut usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphNodeGetDependentNodes_v12030_params_st {
     pub node: cudaGraphNode_t,
@@ -30031,26 +31310,26 @@ pub struct cudaGraphNodeGetDependentNodes_v2_v12030_params_st {
     pub edgeData: *mut cudaGraphEdgeData,
     pub pNumDependentNodes: *mut usize,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphNodeGetEnabled_v11060_params_st {
     pub hGraphExec: cudaGraphExec_t,
     pub hNode: cudaGraphNode_t,
     pub isEnabled: *mut ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphNodeGetLocalId_v13010_params_st {
     pub hNode: cudaGraphNode_t,
     pub nodeId: *mut ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphNodeGetParams_v13020_params_st {
     pub node: cudaGraphNode_t,
     pub nodeParams: *mut cudaGraphNodeParams,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphNodeGetToolsId_v13010_params_st {
     pub hNode: cudaGraphNode_t,
@@ -30061,14 +31340,14 @@ pub struct cudaGraphNodeGetType_v10000_params_st {
     pub node: cudaGraphNode_t,
     pub pType: *mut cudaGraphNodeType,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphNodeSetEnabled_v11060_params_st {
     pub hGraphExec: cudaGraphExec_t,
     pub hNode: cudaGraphNode_t,
     pub isEnabled: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphNodeSetParams_v12020_params_st {
     pub node: cudaGraphNode_t,
@@ -30088,7 +31367,7 @@ pub struct cudaGraphRemoveDependencies_v10000_params_st {
     pub to: *const cudaGraphNode_t,
     pub numDependencies: usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGraphRemoveDependencies_v12030_params_st {
     pub graph: cudaGraph_t,
@@ -30162,7 +31441,7 @@ pub struct cudaGraphicsUnmapResources_v3020_params_st {
 pub struct cudaGraphicsUnregisterResource_v3020_params_st {
     pub resource: cudaGraphicsResource_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaGreenCtxCreate_v13010_params_st {
     pub phCtx: *mut cudaExecutionContext_t,
@@ -30214,7 +31493,7 @@ pub struct cudaImportExternalSemaphore_v10000_params_st {
     pub extSem_out: *mut cudaExternalSemaphore_t,
     pub semHandleDesc: *const cudaExternalSemaphoreHandleDesc,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaInitDevice_v12000_params_st {
@@ -30249,7 +31528,7 @@ pub struct cudaIpcOpenMemHandle_v4010_params_st {
     pub handle: cudaIpcMemHandle_t,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaKernelSetAttributeForDevice_v12060_params_st {
     pub kernel: cudaKernel_t,
@@ -30295,7 +31574,7 @@ pub struct cudaLaunchHostFunc_v10000_params_st {
     pub fn_: cudaHostFn_t,
     pub userData: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLaunchHostFunc_v2_ptsz_v13020_params_st {
     pub stream: cudaStream_t,
@@ -30303,7 +31582,7 @@ pub struct cudaLaunchHostFunc_v2_ptsz_v13020_params_st {
     pub userData: *mut ::core::ffi::c_void,
     pub syncMode: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLaunchHostFunc_v2_v13020_params_st {
     pub stream: cudaStream_t,
@@ -30311,7 +31590,7 @@ pub struct cudaLaunchHostFunc_v2_v13020_params_st {
     pub userData: *mut ::core::ffi::c_void,
     pub syncMode: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLaunchKernelExC_ptsz_v11060_params_st {
@@ -30319,7 +31598,7 @@ pub struct cudaLaunchKernelExC_ptsz_v11060_params_st {
     pub func: *const ::core::ffi::c_void,
     pub args: *mut *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLaunchKernelExC_v11060_params_st {
@@ -30345,14 +31624,14 @@ pub struct cudaLaunchKernel_v7000_params_st {
     pub sharedMem: usize,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLibraryEnumerateKernels_v12060_params_st {
     pub kernels: *mut cudaKernel_t,
     pub numKernels: ::core::ffi::c_uint,
     pub lib: cudaLibrary_t,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLibraryGetGlobal_v12060_params_st {
     pub dptr: *mut *mut ::core::ffi::c_void,
@@ -30360,20 +31639,20 @@ pub struct cudaLibraryGetGlobal_v12060_params_st {
     pub library: cudaLibrary_t,
     pub name: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLibraryGetKernelCount_v12060_params_st {
     pub count: *mut ::core::ffi::c_uint,
     pub lib: cudaLibrary_t,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLibraryGetKernel_v12060_params_st {
     pub pKernel: *mut cudaKernel_t,
     pub library: cudaLibrary_t,
     pub name: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLibraryGetManaged_v12060_params_st {
     pub dptr: *mut *mut ::core::ffi::c_void,
@@ -30381,14 +31660,14 @@ pub struct cudaLibraryGetManaged_v12060_params_st {
     pub library: cudaLibrary_t,
     pub name: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLibraryGetUnifiedFunction_v12060_params_st {
     pub fptr: *mut *mut ::core::ffi::c_void,
     pub library: cudaLibrary_t,
     pub symbol: *const ::core::ffi::c_char,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLibraryLoadData_v12060_params_st {
@@ -30401,7 +31680,7 @@ pub struct cudaLibraryLoadData_v12060_params_st {
     pub libraryOptionValues: *mut *mut ::core::ffi::c_void,
     pub numLibraryOptions: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLibraryLoadFromFile_v12060_params_st {
@@ -30414,19 +31693,19 @@ pub struct cudaLibraryLoadFromFile_v12060_params_st {
     pub libraryOptionValues: *mut *mut ::core::ffi::c_void,
     pub numLibraryOptions: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLibraryUnload_v12060_params_st {
     pub library: cudaLibrary_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLogsCurrent_v13000_params_st {
     pub iterator_out: *mut cudaLogIterator,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLogsDumpToFile_v13000_params_st {
@@ -30434,7 +31713,7 @@ pub struct cudaLogsDumpToFile_v13000_params_st {
     pub pathToFile: *const ::core::ffi::c_char,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLogsDumpToMemory_v13000_params_st {
@@ -30443,14 +31722,14 @@ pub struct cudaLogsDumpToMemory_v13000_params_st {
     pub size: *mut usize,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLogsRegisterCallback_v13000_params_st {
     pub callbackFunc: cudaLogsCallback_t,
     pub userData: *mut ::core::ffi::c_void,
     pub callback_out: *mut cudaLogsCallbackHandle,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaLogsUnregisterCallback_v13000_params_st {
     pub callback: cudaLogsCallbackHandle,
@@ -30537,7 +31816,7 @@ pub struct cudaMalloc_v3020_params_st {
     pub devPtr: *mut *mut ::core::ffi::c_void,
     pub size: usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemAdvise_v12020_params_st {
     pub devPtr: *const ::core::ffi::c_void,
@@ -30561,7 +31840,7 @@ pub struct cudaMemAdvise_v8000_params_st {
     pub advice: cudaMemoryAdvise,
     pub device: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemDiscardAndPrefetchBatchAsync_ptsz_v13000_params_st {
     pub dptrs: *mut *mut ::core::ffi::c_void,
@@ -30573,7 +31852,7 @@ pub struct cudaMemDiscardAndPrefetchBatchAsync_ptsz_v13000_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemDiscardAndPrefetchBatchAsync_v13000_params_st {
     pub dptrs: *mut *mut ::core::ffi::c_void,
@@ -30585,7 +31864,7 @@ pub struct cudaMemDiscardAndPrefetchBatchAsync_v13000_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemDiscardBatchAsync_ptsz_v13000_params_st {
     pub dptrs: *mut *mut ::core::ffi::c_void,
@@ -30594,7 +31873,7 @@ pub struct cudaMemDiscardBatchAsync_ptsz_v13000_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemDiscardBatchAsync_v13000_params_st {
     pub dptrs: *mut *mut ::core::ffi::c_void,
@@ -30603,7 +31882,7 @@ pub struct cudaMemDiscardBatchAsync_v13000_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemGetDefaultMemPool_v13000_params_st {
     pub memPool: *mut cudaMemPool_t,
@@ -30616,7 +31895,7 @@ pub struct cudaMemGetInfo_v3020_params_st {
     pub free: *mut usize,
     pub total: *mut usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemGetMemPool_v13000_params_st {
     pub memPool: *mut cudaMemPool_t,
@@ -30688,7 +31967,7 @@ pub struct cudaMemPoolTrimTo_v11020_params_st {
     pub memPool: cudaMemPool_t,
     pub minBytesToKeep: usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemPrefetchAsync_ptsz_v12020_params_st {
     pub devPtr: *const ::core::ffi::c_void,
@@ -30705,7 +31984,7 @@ pub struct cudaMemPrefetchAsync_ptsz_v8000_params_st {
     pub dstDevice: ::core::ffi::c_int,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemPrefetchAsync_v12020_params_st {
     pub devPtr: *const ::core::ffi::c_void,
@@ -30740,7 +32019,7 @@ pub struct cudaMemPrefetchAsync_v8000_params_st {
     pub dstDevice: ::core::ffi::c_int,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemPrefetchBatchAsync_ptsz_v13000_params_st {
     pub dptrs: *mut *mut ::core::ffi::c_void,
@@ -30752,7 +32031,7 @@ pub struct cudaMemPrefetchBatchAsync_ptsz_v13000_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemPrefetchBatchAsync_v13000_params_st {
     pub dptrs: *mut *mut ::core::ffi::c_void,
@@ -30782,7 +32061,7 @@ pub struct cudaMemRangeGetAttributes_v8000_params_st {
     pub devPtr: *const ::core::ffi::c_void,
     pub count: usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemSetMemPool_v13000_params_st {
     pub location: *mut cudaMemLocation,
@@ -30966,7 +32245,7 @@ pub struct cudaMemcpy3DBatchAsync_ptsz_v12080_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemcpy3DBatchAsync_ptsz_v13000_params_st {
     pub numOps: usize,
@@ -30983,7 +32262,7 @@ pub struct cudaMemcpy3DBatchAsync_v12080_params_st {
     pub flags: ::core::ffi::c_ulonglong,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemcpy3DBatchAsync_v13000_params_st {
     pub numOps: usize,
@@ -31011,14 +32290,14 @@ pub struct cudaMemcpy3DPeer_ptds_v7000_params_st {
 pub struct cudaMemcpy3DPeer_v4000_params_st {
     pub p: *const cudaMemcpy3DPeerParms,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemcpy3DWithAttributesAsync_ptsz_v13020_params_st {
     pub op: *mut cudaMemcpy3DBatchOp,
     pub flags: ::core::ffi::c_ulonglong,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemcpy3DWithAttributesAsync_v13020_params_st {
     pub op: *mut cudaMemcpy3DBatchOp,
@@ -31086,7 +32365,7 @@ pub struct cudaMemcpyBatchAsync_ptsz_v12080_params_st {
     pub failIdx: *mut usize,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemcpyBatchAsync_ptsz_v13000_params_st {
     pub dsts: *const *mut ::core::ffi::c_void,
@@ -31111,7 +32390,7 @@ pub struct cudaMemcpyBatchAsync_v12080_params_st {
     pub failIdx: *mut usize,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemcpyBatchAsync_v13000_params_st {
     pub dsts: *const *mut ::core::ffi::c_void,
@@ -31285,7 +32564,7 @@ pub struct cudaMemcpyToSymbol_v3020_params_st {
     pub offset: usize,
     pub kind: cudaMemcpyKind,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemcpyWithAttributesAsync_ptsz_v13020_params_st {
     pub dst: *mut ::core::ffi::c_void,
@@ -31294,7 +32573,7 @@ pub struct cudaMemcpyWithAttributesAsync_ptsz_v13020_params_st {
     pub attr: *mut cudaMemcpyAttributes,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMemcpyWithAttributesAsync_v13020_params_st {
     pub dst: *mut ::core::ffi::c_void,
@@ -31407,7 +32686,7 @@ pub struct cudaMemset_v3020_params_st {
     pub value: ::core::ffi::c_int,
     pub count: usize,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaMipmappedArrayGetMemoryRequirements_v11060_params_st {
     pub memoryRequirements: *mut cudaArrayMemoryRequirements,
@@ -31444,7 +32723,7 @@ pub struct cudaOccupancyMaxActiveBlocksPerMultiprocessor_v6050_params_st {
     pub blockSize: ::core::ffi::c_int,
     pub dynamicSMemSize: usize,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaOccupancyMaxActiveClusters_v11070_params_st {
@@ -31452,7 +32731,7 @@ pub struct cudaOccupancyMaxActiveClusters_v11070_params_st {
     pub func: *const ::core::ffi::c_void,
     pub launchConfig: *const cudaLaunchConfig_t,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaOccupancyMaxPotentialClusterSize_v11070_params_st {
@@ -31499,7 +32778,7 @@ pub struct cudaSetValidDevices_v3020_params_st {
     pub device_arr: *mut ::core::ffi::c_int,
     pub len: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaSignalExternalSemaphoresAsync_ptsz_v11020_params_st {
     pub extSemArray: *const cudaExternalSemaphore_t,
@@ -31507,7 +32786,7 @@ pub struct cudaSignalExternalSemaphoresAsync_ptsz_v11020_params_st {
     pub numExtSems: ::core::ffi::c_uint,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaSignalExternalSemaphoresAsync_v11020_params_st {
     pub extSemArray: *const cudaExternalSemaphore_t,
@@ -31559,7 +32838,7 @@ pub struct cudaStreamAttachMemAsync_v6000_params_st {
     pub length: usize,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamBeginCaptureToGraph_ptsz_v12030_params_st {
     pub stream: cudaStream_t,
@@ -31569,7 +32848,7 @@ pub struct cudaStreamBeginCaptureToGraph_ptsz_v12030_params_st {
     pub numDependencies: usize,
     pub mode: cudaStreamCaptureMode,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamBeginCaptureToGraph_v12030_params_st {
     pub stream: cudaStream_t,
@@ -31588,6 +32867,22 @@ pub struct cudaStreamBeginCapture_ptsz_v10000_params_st {
 pub struct cudaStreamBeginCapture_v10000_params_st {
     pub stream: cudaStream_t,
     pub mode: cudaStreamCaptureMode,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+pub struct cudaStreamBeginRecaptureToGraph_ptsz_v13030_params_st {
+    pub stream: cudaStream_t,
+    pub mode: cudaStreamCaptureMode,
+    pub graph: cudaGraph_t,
+    pub callbackData: *mut cudaGraphRecaptureCallbackData,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+pub struct cudaStreamBeginRecaptureToGraph_v13030_params_st {
+    pub stream: cudaStream_t,
+    pub mode: cudaStreamCaptureMode,
+    pub graph: cudaGraph_t,
+    pub callbackData: *mut cudaGraphRecaptureCallbackData,
 }
 #[repr(C)]
 pub struct cudaStreamCopyAttributes_ptsz_v11000_params_st {
@@ -31638,7 +32933,7 @@ pub struct cudaStreamGetAttribute_ptsz_v11000_params_st {
     pub attr: cudaStreamAttrID,
     pub value_out: *mut cudaStreamAttrValue,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetAttribute_ptsz_v11000_params_st {
     pub hStream: cudaStream_t,
@@ -31652,7 +32947,7 @@ pub struct cudaStreamGetAttribute_v11000_params_st {
     pub attr: cudaStreamAttrID,
     pub value: *mut cudaStreamAttrValue,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetAttribute_v11000_params_st {
     pub stream: cudaStream_t,
@@ -31673,7 +32968,7 @@ pub struct cudaStreamGetCaptureInfo_ptsz_v10010_params_st {
     pub captureStatus_out: *mut cudaStreamCaptureStatus,
     pub id_out: *mut ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetCaptureInfo_ptsz_v12030_params_st {
     pub stream: cudaStream_t,
@@ -31691,7 +32986,7 @@ pub struct cudaStreamGetCaptureInfo_v10010_params_st {
     pub captureStatus_out: *mut cudaStreamCaptureStatus,
     pub id_out: *mut ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetCaptureInfo_v12030_params_st {
     pub stream: cudaStream_t,
@@ -31744,27 +33039,27 @@ pub struct cudaStreamGetCaptureInfo_v3_v12030_params_st {
     pub edgeData_out: *mut *const cudaGraphEdgeData,
     pub numDependencies_out: *mut usize,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetDevResource_ptsz_v13010_params_st {
     pub hStream: cudaStream_t,
     pub resource: *mut cudaDevResource,
     pub type_: cudaDevResourceType,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetDevResource_v13010_params_st {
     pub hStream: cudaStream_t,
     pub resource: *mut cudaDevResource,
     pub type_: cudaDevResourceType,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetDevice_ptsz_v12080_params_st {
     pub hStream: cudaStream_t,
     pub device: *mut ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetDevice_v12080_params_st {
     pub hStream: cudaStream_t,
@@ -31780,13 +33075,13 @@ pub struct cudaStreamGetFlags_v5050_params_st {
     pub hStream: cudaStream_t,
     pub flags: *mut ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetId_ptsz_v12000_params_st {
     pub hStream: cudaStream_t,
     pub streamId: *mut ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamGetId_v12000_params_st {
     pub hStream: cudaStream_t,
@@ -31827,7 +33122,7 @@ pub struct cudaStreamSetAttribute_ptsz_v11000_params_st {
     pub attr: cudaStreamAttrID,
     pub value: *const cudaStreamAttrValue,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamSetAttribute_ptsz_v11000_params_st {
     pub hStream: cudaStream_t,
@@ -31841,7 +33136,7 @@ pub struct cudaStreamSetAttribute_v11000_params_st {
     pub attr: cudaStreamAttrID,
     pub param: *const cudaStreamAttrValue,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamSetAttribute_v11000_params_st {
     pub stream: cudaStream_t,
@@ -31864,7 +33159,7 @@ pub struct cudaStreamUpdateCaptureDependencies_ptsz_v11030_params_st {
     pub numDependencies: usize,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamUpdateCaptureDependencies_ptsz_v12030_params_st {
     pub stream: cudaStream_t,
@@ -31881,7 +33176,7 @@ pub struct cudaStreamUpdateCaptureDependencies_v11030_params_st {
     pub numDependencies: usize,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaStreamUpdateCaptureDependencies_v12030_params_st {
     pub stream: cudaStream_t,
@@ -31972,7 +33267,7 @@ pub struct cudaUserObjectRetain_v11030_params_st {
     pub object: cudaUserObject_t,
     pub count: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaWaitExternalSemaphoresAsync_ptsz_v11020_params_st {
     pub extSemArray: *const cudaExternalSemaphore_t,
@@ -31980,7 +33275,7 @@ pub struct cudaWaitExternalSemaphoresAsync_ptsz_v11020_params_st {
     pub numExtSems: ::core::ffi::c_uint,
     pub stream: cudaStream_t,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 pub struct cudaWaitExternalSemaphoresAsync_v11020_params_st {
     pub extSemArray: *const cudaExternalSemaphore_t,
@@ -32105,7 +33400,7 @@ impl CUpti_ActivityFlag {
 impl CUpti_ActivityFlag {
     pub const CUPTI_ACTIVITY_FLAG_THROTTLING_IN_CPU: CUpti_ActivityFlag = CUpti_ActivityFlag::CUPTI_ACTIVITY_FLAG_DEVICE_CONCURRENT_KERNELS;
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl CUpti_ActivityKernel10__bindgen_ty_1__bindgen_ty_1 {
     #[inline]
     pub fn requested(&self) -> u8 {
@@ -32165,8 +33460,68 @@ impl CUpti_ActivityKernel10__bindgen_ty_1__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl CUpti_ActivityKernel11__bindgen_ty_1__bindgen_ty_1 {
+    #[inline]
+    pub fn requested(&self) -> u8 {
+        unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 4u8) as u8) }
+    }
+    #[inline]
+    pub fn set_requested(&mut self, val: u8) {
+        unsafe {
+            let val: u8 = ::core::mem::transmute(val);
+            self._bitfield_1.set(0usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn requested_raw(this: *const Self) -> u8 {
+        unsafe { ::core::mem::transmute(<__BindgenBitfieldUnit<[u8; 1usize]>>::raw_get(::core::ptr::addr_of!((*this)._bitfield_1), 0usize, 4u8) as u8) }
+    }
+    #[inline]
+    pub unsafe fn set_requested_raw(this: *mut Self, val: u8) {
+        unsafe {
+            let val: u8 = ::core::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 1usize]>>::raw_set(::core::ptr::addr_of_mut!((*this)._bitfield_1), 0usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn executed(&self) -> u8 {
+        unsafe { ::core::mem::transmute(self._bitfield_1.get(4usize, 4u8) as u8) }
+    }
+    #[inline]
+    pub fn set_executed(&mut self, val: u8) {
+        unsafe {
+            let val: u8 = ::core::mem::transmute(val);
+            self._bitfield_1.set(4usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn executed_raw(this: *const Self) -> u8 {
+        unsafe { ::core::mem::transmute(<__BindgenBitfieldUnit<[u8; 1usize]>>::raw_get(::core::ptr::addr_of!((*this)._bitfield_1), 4usize, 4u8) as u8) }
+    }
+    #[inline]
+    pub unsafe fn set_executed_raw(this: *mut Self, val: u8) {
+        unsafe {
+            let val: u8 = ::core::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 1usize]>>::raw_set(::core::ptr::addr_of_mut!((*this)._bitfield_1), 4usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(requested: u8, executed: u8) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 4u8, {
+            let requested: u8 = unsafe { ::core::mem::transmute(requested) };
+            requested as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 4u8, {
+            let executed: u8 = unsafe { ::core::mem::transmute(executed) };
+            executed as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+impl CUpti_ActivityKernel12__bindgen_ty_1__bindgen_ty_1 {
     #[inline]
     pub fn requested(&self) -> u8 {
         unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 4u8) as u8) }
@@ -32520,7 +33875,7 @@ impl CUpti_ActivityKernel6__bindgen_ty_1__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl CUpti_ActivityKernel7__bindgen_ty_1__bindgen_ty_1 {
     #[inline]
     pub fn requested(&self) -> u8 {
@@ -32580,7 +33935,7 @@ impl CUpti_ActivityKernel7__bindgen_ty_1__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl CUpti_ActivityKernel8__bindgen_ty_1__bindgen_ty_1 {
     #[inline]
     pub fn requested(&self) -> u8 {
@@ -32640,7 +33995,7 @@ impl CUpti_ActivityKernel8__bindgen_ty_1__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl CUpti_ActivityKernel9__bindgen_ty_1__bindgen_ty_1 {
     #[inline]
     pub fn requested(&self) -> u8 {
@@ -32863,6 +34218,7 @@ pub union CUpti_ActivityDeviceAttribute__bindgen_ty_2 {
     pub vInt32: i32,
     pub vInt64: i64,
 }
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_ActivityEnvironment__bindgen_ty_1 {
@@ -32871,19 +34227,35 @@ pub union CUpti_ActivityEnvironment__bindgen_ty_1 {
     pub power: CUpti_ActivityEnvironment__bindgen_ty_1__bindgen_ty_3,
     pub cooling: CUpti_ActivityEnvironment__bindgen_ty_1__bindgen_ty_4,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union CUpti_ActivityEnvironment__bindgen_ty_1 {
+    pub speed: CUpti_ActivityEnvironmentSpeed,
+    pub temperature: CUpti_ActivityEnvironmentTemperature,
+    pub power: CUpti_ActivityEnvironmentPower,
+    pub cooling: CUpti_ActivityEnvironmentCooling,
+}
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_ActivityKernel10__bindgen_ty_1 {
     pub both: u8,
     pub config: CUpti_ActivityKernel10__bindgen_ty_1__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_ActivityKernel11__bindgen_ty_1 {
     pub both: u8,
     pub config: CUpti_ActivityKernel11__bindgen_ty_1__bindgen_ty_1,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union CUpti_ActivityKernel12__bindgen_ty_1 {
+    pub both: u8,
+    pub config: CUpti_ActivityKernel12__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -32915,21 +34287,21 @@ pub union CUpti_ActivityKernel6__bindgen_ty_1 {
     pub both: u8,
     pub config: CUpti_ActivityKernel6__bindgen_ty_1__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_ActivityKernel7__bindgen_ty_1 {
     pub both: u8,
     pub config: CUpti_ActivityKernel7__bindgen_ty_1__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_ActivityKernel8__bindgen_ty_1 {
     pub both: u8,
     pub config: CUpti_ActivityKernel8__bindgen_ty_1__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_ActivityKernel9__bindgen_ty_1 {
@@ -32942,14 +34314,14 @@ pub union CUpti_ActivityMemory2__bindgen_ty_1__bindgen_ty_1 {
     pub size: u64,
     pub processId: u64,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_ActivityMemory3__bindgen_ty_1__bindgen_ty_1 {
     pub size: u64,
     pub processId: u64,
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_ActivityMemory4__bindgen_ty_1__bindgen_ty_1 {
@@ -32973,7 +34345,7 @@ pub union CUpti_MetricValue {
     pub metricValueThroughput: u64,
     pub metricValueUtilizationLevel: CUpti_MetricValueUtilizationLevel,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_MetricValue {
@@ -32985,7 +34357,7 @@ pub union CUpti_MetricValue {
     pub metricValueUtilizationLevel: CUpti_MetricValueUtilizationLevel,
     pub metricValueNvtxExtendedPayload: u64,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUpti_StateData__bindgen_ty_1 {
@@ -33055,7 +34427,7 @@ pub unsafe fn cuptiActivityDisableContext(context: CUcontext, kind: CUpti_Activi
         cuptiActivityDisableContext(context, kind)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityDisable_v2(subscriber: CUpti_SubscriberHandle, kind: CUpti_ActivityKind, pActivityConfig: *mut CUpti_ActivityConfig) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33088,7 +34460,7 @@ pub unsafe fn cuptiActivityEnable(kind: CUpti_ActivityKind) -> CUptiResult {
         cuptiActivityEnable(kind)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnableAllSyncRecords(enable: u8) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33105,7 +34477,7 @@ pub unsafe fn cuptiActivityEnableAllSyncRecords(enable: u8) -> CUptiResult {
         cuptiActivityEnableAllSyncRecords(enable)
     }
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnableAllocationSource(enable: u8) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33122,7 +34494,7 @@ pub unsafe fn cuptiActivityEnableAllocationSource(enable: u8) -> CUptiResult {
         cuptiActivityEnableAllocationSource(enable)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnableAndDump(kind: CUpti_ActivityKind) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33139,7 +34511,7 @@ pub unsafe fn cuptiActivityEnableAndDump(kind: CUpti_ActivityKind) -> CUptiResul
         cuptiActivityEnableAndDump(kind)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnableAndDump_v2(subscriber: CUpti_SubscriberHandle, kind: CUpti_ActivityKind, activityConfig: *mut CUpti_ActivityConfig) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33172,7 +34544,7 @@ pub unsafe fn cuptiActivityEnableContext(context: CUcontext, kind: CUpti_Activit
         cuptiActivityEnableContext(context, kind)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnableCudaEventDeviceTimestamps(enable: u8) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33189,7 +34561,7 @@ pub unsafe fn cuptiActivityEnableCudaEventDeviceTimestamps(enable: u8) -> CUptiR
         cuptiActivityEnableCudaEventDeviceTimestamps(enable)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnableDeviceGraph(enable: u8) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33206,7 +34578,7 @@ pub unsafe fn cuptiActivityEnableDeviceGraph(enable: u8) -> CUptiResult {
         cuptiActivityEnableDeviceGraph(enable)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnableDriverApi(cbid: CUpti_CallbackId, enable: u8) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33223,7 +34595,24 @@ pub unsafe fn cuptiActivityEnableDriverApi(cbid: CUpti_CallbackId, enable: u8) -
         cuptiActivityEnableDriverApi(cbid, enable)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuptiActivityEnableDriverApi_v2(subscriber: CUpti_SubscriberHandle, cbid: CUpti_CallbackId, enable: u8) -> CUptiResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUpti_SubscriberHandle, CUpti_CallbackId, u8) -> CUptiResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuptiActivityEnableDriverApi_v2") });
+        _f(subscriber, cbid, enable)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuptiActivityEnableDriverApi_v2(subscriber: CUpti_SubscriberHandle, cbid: CUpti_CallbackId, enable: u8) -> CUptiResult;
+        }
+        cuptiActivityEnableDriverApi_v2(subscriber, cbid, enable)
+    }
+}
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnableHWTrace(enable: u8) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33272,7 +34661,7 @@ pub unsafe fn cuptiActivityEnableLaunchAttributes(enable: u8) -> CUptiResult {
         cuptiActivityEnableLaunchAttributes(enable)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnableRuntimeApi(cbid: CUpti_CallbackId, enable: u8) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33289,7 +34678,24 @@ pub unsafe fn cuptiActivityEnableRuntimeApi(cbid: CUpti_CallbackId, enable: u8) 
         cuptiActivityEnableRuntimeApi(cbid, enable)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuptiActivityEnableRuntimeApi_v2(subscriber: CUpti_SubscriberHandle, cbid: CUpti_CallbackId, enable: u8) -> CUptiResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUpti_SubscriberHandle, CUpti_CallbackId, u8) -> CUptiResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuptiActivityEnableRuntimeApi_v2") });
+        _f(subscriber, cbid, enable)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuptiActivityEnableRuntimeApi_v2(subscriber: CUpti_SubscriberHandle, cbid: CUpti_CallbackId, enable: u8) -> CUptiResult;
+        }
+        cuptiActivityEnableRuntimeApi_v2(subscriber, cbid, enable)
+    }
+}
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityEnable_v2(subscriber: CUpti_SubscriberHandle, kind: CUpti_ActivityKind, pActivityConfig: *mut CUpti_ActivityConfig) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33370,7 +34776,7 @@ pub unsafe fn cuptiActivityGetAttribute(attr: CUpti_ActivityAttribute, valueSize
         cuptiActivityGetAttribute(attr, valueSize, value)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityGetAttribute_v2(subscriber: CUpti_SubscriberHandle, attr: CUpti_ActivityAttribute, valueSize: *mut usize, value: *mut ::core::ffi::c_void) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33387,7 +34793,7 @@ pub unsafe fn cuptiActivityGetAttribute_v2(subscriber: CUpti_SubscriberHandle, a
         cuptiActivityGetAttribute_v2(subscriber, attr, valueSize, value)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityGetEnabledKinds(subscriber: CUpti_SubscriberHandle, buffer: *mut CUpti_ActivityKind, bufferSize: *mut u32, enabledKindsCount: *mut u32) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33420,6 +34826,23 @@ pub unsafe fn cuptiActivityGetNextRecord(buffer: *mut u8, validBufferSizeBytes: 
         cuptiActivityGetNextRecord(buffer, validBufferSizeBytes, record)
     }
 }
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuptiActivityGetNextRecord_v2(subscriber: CUpti_SubscriberHandle, buffer: *mut u8, validBufferSizeBytes: usize, record: *mut *mut CUpti_Activity) -> CUptiResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUpti_SubscriberHandle, *mut u8, usize, *mut *mut CUpti_Activity) -> CUptiResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuptiActivityGetNextRecord_v2") });
+        _f(subscriber, buffer, validBufferSizeBytes, record)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuptiActivityGetNextRecord_v2(subscriber: CUpti_SubscriberHandle, buffer: *mut u8, validBufferSizeBytes: usize, record: *mut *mut CUpti_Activity) -> CUptiResult;
+        }
+        cuptiActivityGetNextRecord_v2(subscriber, buffer, validBufferSizeBytes, record)
+    }
+}
 pub unsafe fn cuptiActivityGetNumDroppedRecords(context: CUcontext, streamId: u32, dropped: *mut usize) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33436,7 +34859,24 @@ pub unsafe fn cuptiActivityGetNumDroppedRecords(context: CUcontext, streamId: u3
         cuptiActivityGetNumDroppedRecords(context, streamId, dropped)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuptiActivityGetNumDroppedRecords_v2(subscriber: CUpti_SubscriberHandle, context: CUcontext, streamId: u32, dropped: *mut usize) -> CUptiResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUpti_SubscriberHandle, CUcontext, u32, *mut usize) -> CUptiResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuptiActivityGetNumDroppedRecords_v2") });
+        _f(subscriber, context, streamId, dropped)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuptiActivityGetNumDroppedRecords_v2(subscriber: CUpti_SubscriberHandle, context: CUcontext, streamId: u32, dropped: *mut usize) -> CUptiResult;
+        }
+        cuptiActivityGetNumDroppedRecords_v2(subscriber, context, streamId, dropped)
+    }
+}
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityGetStructSize(activityKind: CUpti_ActivityKind, version: u32, activityStructSize: *mut usize) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33469,6 +34909,23 @@ pub unsafe fn cuptiActivityPopExternalCorrelationId(kind: CUpti_ExternalCorrelat
         cuptiActivityPopExternalCorrelationId(kind, lastId)
     }
 }
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuptiActivityPopExternalCorrelationId_v2(subscriber: CUpti_SubscriberHandle, kind: CUpti_ExternalCorrelationKind, lastId: *mut u64) -> CUptiResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUpti_SubscriberHandle, CUpti_ExternalCorrelationKind, *mut u64) -> CUptiResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuptiActivityPopExternalCorrelationId_v2") });
+        _f(subscriber, kind, lastId)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuptiActivityPopExternalCorrelationId_v2(subscriber: CUpti_SubscriberHandle, kind: CUpti_ExternalCorrelationKind, lastId: *mut u64) -> CUptiResult;
+        }
+        cuptiActivityPopExternalCorrelationId_v2(subscriber, kind, lastId)
+    }
+}
 pub unsafe fn cuptiActivityPushExternalCorrelationId(kind: CUpti_ExternalCorrelationKind, id: u64) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33483,6 +34940,23 @@ pub unsafe fn cuptiActivityPushExternalCorrelationId(kind: CUpti_ExternalCorrela
             fn cuptiActivityPushExternalCorrelationId(kind: CUpti_ExternalCorrelationKind, id: u64) -> CUptiResult;
         }
         cuptiActivityPushExternalCorrelationId(kind, id)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuptiActivityPushExternalCorrelationId_v2(subscriber: CUpti_SubscriberHandle, kind: CUpti_ExternalCorrelationKind, id: u64) -> CUptiResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUpti_SubscriberHandle, CUpti_ExternalCorrelationKind, u64) -> CUptiResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuptiActivityPushExternalCorrelationId_v2") });
+        _f(subscriber, kind, id)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuptiActivityPushExternalCorrelationId_v2(subscriber: CUpti_SubscriberHandle, kind: CUpti_ExternalCorrelationKind, id: u64) -> CUptiResult;
+        }
+        cuptiActivityPushExternalCorrelationId_v2(subscriber, kind, id)
     }
 }
 pub unsafe fn cuptiActivityRegisterCallbacks(funcBufferRequested: CUpti_BuffersCallbackRequestFunc, funcBufferCompleted: CUpti_BuffersCallbackCompleteFunc) -> CUptiResult {
@@ -33501,7 +34975,7 @@ pub unsafe fn cuptiActivityRegisterCallbacks(funcBufferRequested: CUpti_BuffersC
         cuptiActivityRegisterCallbacks(funcBufferRequested, funcBufferCompleted)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityRegisterCallbacks_v2(subscriber: CUpti_SubscriberHandle, funcBufferRequested: CUpti_BuffersCallbackRequestFunc_v2, funcBufferCompleted: CUpti_BuffersCallbackCompleteFunc_v2) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33518,7 +34992,7 @@ pub unsafe fn cuptiActivityRegisterCallbacks_v2(subscriber: CUpti_SubscriberHand
         cuptiActivityRegisterCallbacks_v2(subscriber, funcBufferRequested, funcBufferCompleted)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivityRegisterTimestampCallback(funcTimestamp: CUpti_TimestampCallbackFunc) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -33551,7 +35025,7 @@ pub unsafe fn cuptiActivitySetAttribute(attr: CUpti_ActivityAttribute, valueSize
         cuptiActivitySetAttribute(attr, valueSize, value)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiActivitySetAttribute_v2(subscriber: CUpti_SubscriberHandle, attr: CUpti_ActivityAttribute, valueSize: *mut usize, value: *mut ::core::ffi::c_void) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -34273,7 +35747,7 @@ pub unsafe fn cuptiGetDeviceId(context: CUcontext, deviceId: *mut u32) -> CUptiR
         cuptiGetDeviceId(context, deviceId)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiGetEnabledCallbacks(subscriber: CUpti_SubscriberHandle, domain: CUpti_CallbackDomain, buffer: *mut CUpti_CallbackId, bufferSize: *mut u32, enabledCallbacksCount: *mut u32) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -34290,7 +35764,7 @@ pub unsafe fn cuptiGetEnabledCallbacks(subscriber: CUpti_SubscriberHandle, domai
         cuptiGetEnabledCallbacks(subscriber, domain, buffer, bufferSize, enabledCallbacksCount)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiGetErrorMessage(result: CUptiResult, str_: *mut *const ::core::ffi::c_char) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -34307,7 +35781,7 @@ pub unsafe fn cuptiGetErrorMessage(result: CUptiResult, str_: *mut *const ::core
         cuptiGetErrorMessage(result, str_)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiGetGraphExecId(graphExec: CUgraphExec, pId: *mut u32) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -34484,6 +35958,23 @@ pub unsafe fn cuptiGetTimestamp(timestamp: *mut u64) -> CUptiResult {
         cuptiGetTimestamp(timestamp)
     }
 }
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuptiGetTimestamp_v2(subscriber: CUpti_SubscriberHandle, timestamp: *mut u64) -> CUptiResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUpti_SubscriberHandle, *mut u64) -> CUptiResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuptiGetTimestamp_v2") });
+        _f(subscriber, timestamp)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuptiGetTimestamp_v2(subscriber: CUpti_SubscriberHandle, timestamp: *mut u64) -> CUptiResult;
+        }
+        cuptiGetTimestamp_v2(subscriber, timestamp)
+    }
+}
 pub unsafe fn cuptiGetVersion(version: *mut u32) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -34500,7 +35991,7 @@ pub unsafe fn cuptiGetVersion(version: *mut u32) -> CUptiResult {
         cuptiGetVersion(version)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiIsTracingSessionRunning(isRunning: *mut u8) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -34741,7 +36232,7 @@ pub unsafe fn cuptiSubscribe(subscriber: *mut CUpti_SubscriberHandle, callback: 
         cuptiSubscribe(subscriber, callback, userdata)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuptiSubscribe_v2(subscriber: *mut CUpti_SubscriberHandle, callback: CUpti_CallbackFunc, userdata: *mut ::core::ffi::c_void, pParams: *mut CUpti_SubscriberParams) -> CUptiResult {
     #[cfg(feature = "dynamic-loading")]
     {

--- a/src/curand/sys/mod.rs
+++ b/src/curand/sys/mod.rs
@@ -67,7 +67,7 @@ pub enum curandOrdering {
     CURAND_ORDERING_PSEUDO_LEGACY = 103,
     CURAND_ORDERING_QUASI_DEFAULT = 201,
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum curandOrdering {

--- a/src/cusolver/sys/mod.rs
+++ b/src/cusolver/sys/mod.rs
@@ -13,14 +13,8 @@ fn load<F: Copy>(name: &str) -> F {
 }
 pub use self::cudaDataType_t as cudaDataType;
 pub use self::libraryPropertyType_t as libraryPropertyType;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type FILE = _IO_FILE;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-pub type _IO_lock_t = ::core::ffi::c_void;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-pub type __off64_t = ::core::ffi::c_long;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-pub type __off_t = ::core::ffi::c_long;
 pub type csrqrInfo_t = *mut csrqrInfo;
 pub type cuComplex = cuFloatComplex;
 pub type cuDoubleComplex = double2;
@@ -31,7 +25,7 @@ pub type cudaStream_t = *mut CUstream_st;
 pub type cusolverDnHandle_t = *mut cusolverDnContext;
 pub type cusolverDnIRSInfos_t = *mut cusolverDnIRSInfos;
 pub type cusolverDnIRSParams_t = *mut cusolverDnIRSParams;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cusolverDnLoggerCallback_t = ::core::option::Option<unsafe extern "C" fn(logLevel: ::core::ffi::c_int, functionName: *const ::core::ffi::c_char, message: *const ::core::ffi::c_char)>;
 pub type cusolverDnParams_t = *mut cusolverDnParams;
 pub type cusolverRfHandle_t = *mut cusolverRfCommon;
@@ -135,7 +129,7 @@ pub enum cudaDataType_t {
     CUDA_R_8F_E4M3 = 28,
     CUDA_R_8F_E5M2 = 29,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDataType_t {
@@ -174,14 +168,14 @@ pub enum cudaDataType_t {
     CUDA_R_6F_E3M2 = 32,
     CUDA_R_4F_E2M1 = 33,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaEmulationMantissaControl_t {
     CUDA_EMULATION_MANTISSA_CONTROL_DYNAMIC = 0,
     CUDA_EMULATION_MANTISSA_CONTROL_FIXED = 1,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaEmulationSpecialValuesSupport_t {
@@ -190,7 +184,7 @@ pub enum cudaEmulationSpecialValuesSupport_t {
     CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_INFINITY = 1,
     CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NAN = 2,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaEmulationStrategy_t {
@@ -205,7 +199,7 @@ pub enum cusolverAlgMode_t {
     CUSOLVER_ALG_0 = 0,
     CUSOLVER_ALG_1 = 1,
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusolverAlgMode_t {
@@ -213,7 +207,7 @@ pub enum cusolverAlgMode_t {
     CUSOLVER_ALG_1 = 1,
     CUSOLVER_ALG_2 = 2,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusolverDeterministicMode_t {
@@ -247,7 +241,7 @@ pub enum cusolverDnFunction_t {
     CUSOLVERDN_POTRF = 1,
     CUSOLVERDN_SYEVBATCHED = 2,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusolverDnFunction_t {
@@ -256,7 +250,7 @@ pub enum cusolverDnFunction_t {
     CUSOLVERDN_SYEVBATCHED = 2,
     CUSOLVERDN_GEQRF = 3,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusolverEigComp_t {
@@ -305,7 +299,7 @@ pub enum cusolverMathMode_t {
     CUSOLVER_DEFAULT_MATH = 1,
     CUSOLVER_FP32_EMULATED_BF16X9_MATH = 2,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusolverMathMode_t {
@@ -429,57 +423,11 @@ pub enum libraryPropertyType_t {
 pub struct CUstream_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct _IO_FILE {
-    pub _flags: ::core::ffi::c_int,
-    pub _IO_read_ptr: *mut ::core::ffi::c_char,
-    pub _IO_read_end: *mut ::core::ffi::c_char,
-    pub _IO_read_base: *mut ::core::ffi::c_char,
-    pub _IO_write_base: *mut ::core::ffi::c_char,
-    pub _IO_write_ptr: *mut ::core::ffi::c_char,
-    pub _IO_write_end: *mut ::core::ffi::c_char,
-    pub _IO_buf_base: *mut ::core::ffi::c_char,
-    pub _IO_buf_end: *mut ::core::ffi::c_char,
-    pub _IO_save_base: *mut ::core::ffi::c_char,
-    pub _IO_backup_base: *mut ::core::ffi::c_char,
-    pub _IO_save_end: *mut ::core::ffi::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::core::ffi::c_int,
-    pub _flags2: ::core::ffi::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::core::ffi::c_ushort,
-    pub _vtable_offset: ::core::ffi::c_schar,
-    pub _shortbuf: [::core::ffi::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::core::ffi::c_void,
-    pub __pad5: usize,
-    pub _mode: ::core::ffi::c_int,
-    pub _unused2: [::core::ffi::c_char; 20usize],
-}
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
-}
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
-}
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
-    _unused: [u8; 0],
+    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -548,7 +496,7 @@ pub struct syevjInfo {
 impl cublasOperation_t {
     pub const CUBLAS_OP_HERMITAN: cublasOperation_t = cublasOperation_t::CUBLAS_OP_C;
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl cudaDataType_t {
     pub const CUDA_R_8F_UE4M3: cudaDataType_t = cudaDataType_t::CUDA_R_8F_E4M3;
 }
@@ -3084,7 +3032,7 @@ pub unsafe fn cusolverDnGesvd_bufferSize(handle: cusolverDnHandle_t, params: cus
         cusolverDnGesvd_bufferSize(handle, params, jobu, jobvt, m, n, dataTypeA, A, lda, dataTypeS, S, dataTypeU, U, ldu, dataTypeVT, VT, ldvt, computeType, workspaceInBytes)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnGetDeterministicMode(handle: cusolverDnHandle_t, mode: *mut cusolverDeterministicMode_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3101,7 +3049,7 @@ pub unsafe fn cusolverDnGetDeterministicMode(handle: cusolverDnHandle_t, mode: *
         cusolverDnGetDeterministicMode(handle, mode)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnGetEmulationSpecialValuesSupport(handle: cusolverDnHandle_t, mask: *mut cudaEmulationSpecialValuesSupport_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3118,7 +3066,7 @@ pub unsafe fn cusolverDnGetEmulationSpecialValuesSupport(handle: cusolverDnHandl
         cusolverDnGetEmulationSpecialValuesSupport(handle, mask)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnGetEmulationStrategy(handle: cusolverDnHandle_t, strategy: *mut cudaEmulationStrategy_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3135,7 +3083,7 @@ pub unsafe fn cusolverDnGetEmulationStrategy(handle: cusolverDnHandle_t, strateg
         cusolverDnGetEmulationStrategy(handle, strategy)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnGetFixedPointEmulationMantissaBitOffset(handle: cusolverDnHandle_t, mantissaBitOffset: *mut ::core::ffi::c_int) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3152,7 +3100,7 @@ pub unsafe fn cusolverDnGetFixedPointEmulationMantissaBitOffset(handle: cusolver
         cusolverDnGetFixedPointEmulationMantissaBitOffset(handle, mantissaBitOffset)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnGetFixedPointEmulationMantissaControl(handle: cusolverDnHandle_t, control: *mut cudaEmulationMantissaControl_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3169,7 +3117,7 @@ pub unsafe fn cusolverDnGetFixedPointEmulationMantissaControl(handle: cusolverDn
         cusolverDnGetFixedPointEmulationMantissaControl(handle, control)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnGetFixedPointEmulationMaxMantissaBitCount(handle: cusolverDnHandle_t, mantissaBitCount: *mut ::core::ffi::c_int) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3186,7 +3134,7 @@ pub unsafe fn cusolverDnGetFixedPointEmulationMaxMantissaBitCount(handle: cusolv
         cusolverDnGetFixedPointEmulationMaxMantissaBitCount(handle, mantissaBitCount)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnGetMathMode(handle: cusolverDnHandle_t, mode: *mut cusolverMathMode_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3977,7 +3925,7 @@ pub unsafe fn cusolverDnSetAdvOptions(params: cusolverDnParams_t, function: cuso
         cusolverDnSetAdvOptions(params, function, algo)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnSetDeterministicMode(handle: cusolverDnHandle_t, mode: cusolverDeterministicMode_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3994,7 +3942,7 @@ pub unsafe fn cusolverDnSetDeterministicMode(handle: cusolverDnHandle_t, mode: c
         cusolverDnSetDeterministicMode(handle, mode)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnSetEmulationSpecialValuesSupport(handle: cusolverDnHandle_t, mask: cudaEmulationSpecialValuesSupport_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4011,7 +3959,7 @@ pub unsafe fn cusolverDnSetEmulationSpecialValuesSupport(handle: cusolverDnHandl
         cusolverDnSetEmulationSpecialValuesSupport(handle, mask)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnSetEmulationStrategy(handle: cusolverDnHandle_t, strategy: cudaEmulationStrategy_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4028,7 +3976,7 @@ pub unsafe fn cusolverDnSetEmulationStrategy(handle: cusolverDnHandle_t, strateg
         cusolverDnSetEmulationStrategy(handle, strategy)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnSetFixedPointEmulationMantissaBitOffset(handle: cusolverDnHandle_t, mantissaBitOffset: ::core::ffi::c_int) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4045,7 +3993,7 @@ pub unsafe fn cusolverDnSetFixedPointEmulationMantissaBitOffset(handle: cusolver
         cusolverDnSetFixedPointEmulationMantissaBitOffset(handle, mantissaBitOffset)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnSetFixedPointEmulationMantissaControl(handle: cusolverDnHandle_t, control: cudaEmulationMantissaControl_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4062,7 +4010,7 @@ pub unsafe fn cusolverDnSetFixedPointEmulationMantissaControl(handle: cusolverDn
         cusolverDnSetFixedPointEmulationMantissaControl(handle, control)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnSetFixedPointEmulationMaxMantissaBitCount(handle: cusolverDnHandle_t, mantissaBitCount: ::core::ffi::c_int) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4079,7 +4027,7 @@ pub unsafe fn cusolverDnSetFixedPointEmulationMaxMantissaBitCount(handle: cusolv
         cusolverDnSetFixedPointEmulationMaxMantissaBitCount(handle, mantissaBitCount)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnSetMathMode(handle: cusolverDnHandle_t, mode: cusolverMathMode_t) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5060,7 +5008,7 @@ pub unsafe fn cusolverDnSyevdx_bufferSize(handle: cusolverDnHandle_t, params: cu
         cusolverDnSyevdx_bufferSize(handle, params, jobz, range, uplo, n, dataTypeA, A, lda, vl, vu, il, iu, h_meig, dataTypeW, W, computeType, workspaceInBytes)
     }
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXgeev(handle: cusolverDnHandle_t, params: cusolverDnParams_t, jobvl: cusolverEigMode_t, jobvr: cusolverEigMode_t, n: i64, dataTypeA: cudaDataType, A: *mut ::core::ffi::c_void, lda: i64, dataTypeW: cudaDataType, W: *mut ::core::ffi::c_void, dataTypeVL: cudaDataType, VL: *mut ::core::ffi::c_void, ldvl: i64, dataTypeVR: cudaDataType, VR: *mut ::core::ffi::c_void, ldvr: i64, computeType: cudaDataType, bufferOnDevice: *mut ::core::ffi::c_void, workspaceInBytesOnDevice: usize, bufferOnHost: *mut ::core::ffi::c_void, workspaceInBytesOnHost: usize, info: *mut ::core::ffi::c_int) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5077,7 +5025,7 @@ pub unsafe fn cusolverDnXgeev(handle: cusolverDnHandle_t, params: cusolverDnPara
         cusolverDnXgeev(handle, params, jobvl, jobvr, n, dataTypeA, A, lda, dataTypeW, W, dataTypeVL, VL, ldvl, dataTypeVR, VR, ldvr, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
     }
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXgeev_bufferSize(handle: cusolverDnHandle_t, params: cusolverDnParams_t, jobvl: cusolverEigMode_t, jobvr: cusolverEigMode_t, n: i64, dataTypeA: cudaDataType, A: *const ::core::ffi::c_void, lda: i64, dataTypeW: cudaDataType, W: *const ::core::ffi::c_void, dataTypeVL: cudaDataType, VL: *const ::core::ffi::c_void, ldvl: i64, dataTypeVR: cudaDataType, VR: *const ::core::ffi::c_void, ldvr: i64, computeType: cudaDataType, workspaceInBytesOnDevice: *mut usize, workspaceInBytesOnHost: *mut usize) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5367,7 +5315,7 @@ pub unsafe fn cusolverDnXlarft(handle: cusolverDnHandle_t, params: cusolverDnPar
         cusolverDnXlarft(handle, params, direct, storev, N, K, dataTypeV, d_V, ldv, dataTypeTau, d_tau, dataTypeT, d_T, ldt, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXlarft(handle: cusolverDnHandle_t, params: cusolverDnParams_t, direct: cusolverDirectMode_t, storev: cusolverStorevMode_t, n: i64, k: i64, dataTypeV: cudaDataType, V: *const ::core::ffi::c_void, ldv: i64, dataTypeTau: cudaDataType, tau: *const ::core::ffi::c_void, dataTypeT: cudaDataType, T: *mut ::core::ffi::c_void, ldt: i64, computeType: cudaDataType, bufferOnDevice: *mut ::core::ffi::c_void, workspaceInBytesOnDevice: usize, bufferOnHost: *mut ::core::ffi::c_void, workspaceInBytesOnHost: usize) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5401,7 +5349,7 @@ pub unsafe fn cusolverDnXlarft_bufferSize(handle: cusolverDnHandle_t, params: cu
         cusolverDnXlarft_bufferSize(handle, params, direct, storev, N, K, dataTypeV, d_V, ldv, dataTypeTau, d_tau, dataTypeT, d_T, ldt, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXlarft_bufferSize(handle: cusolverDnHandle_t, params: cusolverDnParams_t, direct: cusolverDirectMode_t, storev: cusolverStorevMode_t, n: i64, k: i64, dataTypeV: cudaDataType, V: *const ::core::ffi::c_void, ldv: i64, dataTypeTau: cudaDataType, tau: *const ::core::ffi::c_void, dataTypeT: cudaDataType, T: *mut ::core::ffi::c_void, ldt: i64, computeType: cudaDataType, workspaceInBytesOnDevice: *mut usize, workspaceInBytesOnHost: *mut usize) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5418,7 +5366,7 @@ pub unsafe fn cusolverDnXlarft_bufferSize(handle: cusolverDnHandle_t, params: cu
         cusolverDnXlarft_bufferSize(handle, params, direct, storev, n, k, dataTypeV, V, ldv, dataTypeTau, tau, dataTypeT, T, ldt, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXpolar(handle: cusolverDnHandle_t, params: cusolverDnParams_t, uplo: cublasFillMode_t, M: i64, N: i64, dataTypeA: cudaDataType, A: *mut ::core::ffi::c_void, lda: i64, dataTypeH: cudaDataType, H: *mut ::core::ffi::c_void, ldh: i64, computeType: cudaDataType, bufferOnDevice: *mut ::core::ffi::c_void, workspaceInBytesOnDevice: usize, bufferOnHost: *mut ::core::ffi::c_void, workspaceInBytesOnHost: usize, d_res_nrm: *mut f64, d_A_nrmF: *mut f64, d_rcond: *mut f64, d_info: *mut ::core::ffi::c_int) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5435,7 +5383,7 @@ pub unsafe fn cusolverDnXpolar(handle: cusolverDnHandle_t, params: cusolverDnPar
         cusolverDnXpolar(handle, params, uplo, M, N, dataTypeA, A, lda, dataTypeH, H, ldh, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_res_nrm, d_A_nrmF, d_rcond, d_info)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXpolar_bufferSize(handle: cusolverDnHandle_t, params: cusolverDnParams_t, uplo: cublasFillMode_t, M: i64, N: i64, dataTypeA: cudaDataType, A: *const ::core::ffi::c_void, lda: i64, dataTypeH: cudaDataType, H: *const ::core::ffi::c_void, ldh: i64, computeType: cudaDataType, workspaceInBytesOnDevice: *mut usize, workspaceInBytesOnHost: *mut usize) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5500,7 +5448,7 @@ pub unsafe fn cusolverDnXpotrs(handle: cusolverDnHandle_t, params: cusolverDnPar
         cusolverDnXpotrs(handle, params, uplo, n, nrhs, dataTypeA, A, lda, dataTypeB, B, ldb, info)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXstedc(handle: cusolverDnHandle_t, params: cusolverDnParams_t, compz: cusolverEigComp_t, n: i64, dataTypeDE: cudaDataType, D: *mut ::core::ffi::c_void, E: *mut ::core::ffi::c_void, dataTypeZ: cudaDataType, Z: *mut ::core::ffi::c_void, ldz: i64, computeType: cudaDataType, bufferOnDevice: *mut ::core::ffi::c_void, workspaceInBytesOnDevice: usize, bufferOnHost: *mut ::core::ffi::c_void, workspaceInBytesOnHost: usize, info: *mut ::core::ffi::c_int) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5517,7 +5465,7 @@ pub unsafe fn cusolverDnXstedc(handle: cusolverDnHandle_t, params: cusolverDnPar
         cusolverDnXstedc(handle, params, compz, n, dataTypeDE, D, E, dataTypeZ, Z, ldz, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXstedc_bufferSize(handle: cusolverDnHandle_t, params: cusolverDnParams_t, compz: cusolverEigComp_t, n: i64, dataTypeDE: cudaDataType, D: *const ::core::ffi::c_void, E: *const ::core::ffi::c_void, dataTypeZ: cudaDataType, Z: *const ::core::ffi::c_void, ldz: i64, computeType: cudaDataType, workspaceInBytesOnDevice: *mut usize, workspaceInBytesOnHost: *mut usize) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5534,7 +5482,7 @@ pub unsafe fn cusolverDnXstedc_bufferSize(handle: cusolverDnHandle_t, params: cu
         cusolverDnXstedc_bufferSize(handle, params, compz, n, dataTypeDE, D, E, dataTypeZ, Z, ldz, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
     }
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXsyevBatched(handle: cusolverDnHandle_t, params: cusolverDnParams_t, jobz: cusolverEigMode_t, uplo: cublasFillMode_t, n: i64, dataTypeA: cudaDataType, A: *mut ::core::ffi::c_void, lda: i64, dataTypeW: cudaDataType, W: *mut ::core::ffi::c_void, computeType: cudaDataType, bufferOnDevice: *mut ::core::ffi::c_void, workspaceInBytesOnDevice: usize, bufferOnHost: *mut ::core::ffi::c_void, workspaceInBytesOnHost: usize, info: *mut ::core::ffi::c_int, batchSize: i64) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5551,7 +5499,7 @@ pub unsafe fn cusolverDnXsyevBatched(handle: cusolverDnHandle_t, params: cusolve
         cusolverDnXsyevBatched(handle, params, jobz, uplo, n, dataTypeA, A, lda, dataTypeW, W, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, info, batchSize)
     }
 }
-#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXsyevBatched_bufferSize(handle: cusolverDnHandle_t, params: cusolverDnParams_t, jobz: cusolverEigMode_t, uplo: cublasFillMode_t, n: i64, dataTypeA: cudaDataType, A: *const ::core::ffi::c_void, lda: i64, dataTypeW: cudaDataType, W: *const ::core::ffi::c_void, computeType: cudaDataType, workspaceInBytesOnDevice: *mut usize, workspaceInBytesOnHost: *mut usize, batchSize: i64) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5712,7 +5660,7 @@ pub unsafe fn cusolverDnXsyevjSetTolerance(info: syevjInfo_t, tolerance: f64) ->
         cusolverDnXsyevjSetTolerance(info, tolerance)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXsygvd(handle: cusolverDnHandle_t, params: cusolverDnParams_t, itype: cusolverEigType_t, jobz: cusolverEigMode_t, uplo: cublasFillMode_t, n: i64, dataTypeA: cudaDataType, d_A: *mut ::core::ffi::c_void, lda: i64, dataTypeB: cudaDataType, d_B: *mut ::core::ffi::c_void, ldb: i64, dataTypeW: cudaDataType, d_W: *mut ::core::ffi::c_void, computeType: cudaDataType, bufferOnDevice: *mut ::core::ffi::c_void, workspaceInBytesOnDevice: usize, bufferOnHost: *mut ::core::ffi::c_void, workspaceInBytesOnHost: usize, d_info: *mut ::core::ffi::c_int) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5729,7 +5677,7 @@ pub unsafe fn cusolverDnXsygvd(handle: cusolverDnHandle_t, params: cusolverDnPar
         cusolverDnXsygvd(handle, params, itype, jobz, uplo, n, dataTypeA, d_A, lda, dataTypeB, d_B, ldb, dataTypeW, d_W, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_info)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXsygvd_bufferSize(handle: cusolverDnHandle_t, params: cusolverDnParams_t, itype: cusolverEigType_t, jobz: cusolverEigMode_t, uplo: cublasFillMode_t, n: i64, dataTypeA: cudaDataType, d_A: *const ::core::ffi::c_void, lda: i64, dataTypeB: cudaDataType, d_B: *const ::core::ffi::c_void, ldb: i64, dataTypeW: cudaDataType, d_W: *const ::core::ffi::c_void, computeType: cudaDataType, workspaceInBytesOnDevice: *mut usize, workspaceInBytesOnHost: *mut usize) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5746,7 +5694,7 @@ pub unsafe fn cusolverDnXsygvd_bufferSize(handle: cusolverDnHandle_t, params: cu
         cusolverDnXsygvd_bufferSize(handle, params, itype, jobz, uplo, n, dataTypeA, d_A, lda, dataTypeB, d_B, ldb, dataTypeW, d_W, computeType, workspaceInBytesOnDevice, workspaceInBytesOnHost)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXsygvdx(handle: cusolverDnHandle_t, params: cusolverDnParams_t, itype: cusolverEigType_t, jobz: cusolverEigMode_t, range: cusolverEigRange_t, uplo: cublasFillMode_t, n: i64, dataTypeA: cudaDataType, d_A: *mut ::core::ffi::c_void, lda: i64, dataTypeB: cudaDataType, d_B: *mut ::core::ffi::c_void, ldb: i64, vl: *mut ::core::ffi::c_void, vu: *mut ::core::ffi::c_void, il: i64, iu: i64, meig: *mut i64, dataTypeW: cudaDataType, d_W: *mut ::core::ffi::c_void, computeType: cudaDataType, bufferOnDevice: *mut ::core::ffi::c_void, workspaceInBytesOnDevice: usize, bufferOnHost: *mut ::core::ffi::c_void, workspaceInBytesOnHost: usize, d_info: *mut ::core::ffi::c_int) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5763,7 +5711,7 @@ pub unsafe fn cusolverDnXsygvdx(handle: cusolverDnHandle_t, params: cusolverDnPa
         cusolverDnXsygvdx(handle, params, itype, jobz, range, uplo, n, dataTypeA, d_A, lda, dataTypeB, d_B, ldb, vl, vu, il, iu, meig, dataTypeW, d_W, computeType, bufferOnDevice, workspaceInBytesOnDevice, bufferOnHost, workspaceInBytesOnHost, d_info)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusolverDnXsygvdx_bufferSize(handle: cusolverDnHandle_t, params: cusolverDnParams_t, itype: cusolverEigType_t, jobz: cusolverEigMode_t, uplo: cublasFillMode_t, n: i64, dataTypeA: cudaDataType, d_A: *const ::core::ffi::c_void, lda: i64, dataTypeB: cudaDataType, d_B: *const ::core::ffi::c_void, ldb: i64, vl: *mut ::core::ffi::c_void, vu: *mut ::core::ffi::c_void, il: i64, iu: i64, meig: *mut i64, dataTypeW: cudaDataType, d_W: *const ::core::ffi::c_void, computeType: cudaDataType, workspaceInBytesOnDevice: *mut usize, workspaceInBytesOnHost: *mut usize) -> cusolverStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {

--- a/src/cusolvermg/sys/mod.rs
+++ b/src/cusolvermg/sys/mod.rs
@@ -98,7 +98,7 @@ pub enum cudaDataType_t {
     CUDA_R_8F_E4M3 = 28,
     CUDA_R_8F_E5M2 = 29,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDataType_t {
@@ -186,7 +186,7 @@ pub struct cusolverMgContext {
 impl cublasOperation_t {
     pub const CUBLAS_OP_HERMITAN: cublasOperation_t = cublasOperation_t::CUBLAS_OP_C;
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl cudaDataType_t {
     pub const CUDA_R_8F_UE4M3: cudaDataType_t = cudaDataType_t::CUDA_R_8F_E4M3;
 }

--- a/src/cusparse/sys/mod.rs
+++ b/src/cusparse/sys/mod.rs
@@ -13,14 +13,8 @@ fn load<F: Copy>(name: &str) -> F {
 }
 pub use self::cudaDataType_t as cudaDataType;
 pub use self::libraryPropertyType_t as libraryPropertyType;
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type FILE = _IO_FILE;
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-pub type _IO_lock_t = ::core::ffi::c_void;
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-pub type __off64_t = ::core::ffi::c_long;
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-pub type __off_t = ::core::ffi::c_long;
 pub type bsric02Info_t = *mut bsric02Info;
 pub type bsrilu02Info_t = *mut bsrilu02Info;
 pub type bsrsm2Info_t = *mut bsrsm2Info;
@@ -39,22 +33,24 @@ pub type cuDoubleComplex = double2;
 pub type cuFloatComplex = float2;
 pub type cudaStream_t = *mut CUstream_st;
 pub type cusparseColorInfo_t = *mut cusparseColorInfo;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cusparseConstDnMatDescr_t = *const cusparseDnMatDescr;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cusparseConstDnVecDescr_t = *const cusparseDnVecDescr;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cusparseConstSpMatDescr_t = *const cusparseSpMatDescr;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cusparseConstSpVecDescr_t = *const cusparseSpVecDescr;
 pub type cusparseDnMatDescr_t = *mut cusparseDnMatDescr;
 pub type cusparseDnVecDescr_t = *mut cusparseDnVecDescr;
 pub type cusparseHandle_t = *mut cusparseContext;
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cusparseLoggerCallback_t = ::core::option::Option<unsafe extern "C" fn(logLevel: ::core::ffi::c_int, functionName: *const ::core::ffi::c_char, message: *const ::core::ffi::c_char)>;
 pub type cusparseMatDescr_t = *mut cusparseMatDescr;
+#[cfg(any(feature = "cuda-13030"))]
+pub type cusparseSpGEAMDescr_t = *mut cusparseSpGEAMDescr;
 pub type cusparseSpGEMMDescr_t = *mut cusparseSpGEMMDescr;
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cusparseSpMMOpPlan_t = *mut cusparseSpMMOpPlan;
 pub type cusparseSpMatDescr_t = *mut cusparseSpMatDescr;
 pub type cusparseSpSMDescr_t = *mut cusparseSpSMDescr;
@@ -129,7 +125,7 @@ pub enum cudaDataType_t {
     CUDA_R_8F_E4M3 = 28,
     CUDA_R_8F_E5M2 = 29,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDataType_t {
@@ -193,7 +189,7 @@ pub enum cusparseCsr2CscAlg_t {
     CUSPARSE_CSR2CSC_ALG1 = 1,
     CUSPARSE_CSR2CSC_ALG2 = 2,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusparseCsr2CscAlg_t {
@@ -241,7 +237,7 @@ pub enum cusparseFormat_t {
     CUSPARSE_FORMAT_COO = 3,
     CUSPARSE_FORMAT_BLOCKED_ELL = 5,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusparseFormat_t {
@@ -310,6 +306,13 @@ pub enum cusparseSolvePolicy_t {
     CUSPARSE_SOLVE_POLICY_NO_LEVEL = 0,
     CUSPARSE_SOLVE_POLICY_USE_LEVEL = 1,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cusparseSpGEAMAlg_t {
+    CUSPARSE_SPGEAM_ALG_DEFAULT = 0,
+    CUSPARSE_SPGEAM_ALG1 = 1,
+}
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -318,7 +321,7 @@ pub enum cusparseSpGEMMAlg_t {
     CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC = 1,
     CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC = 2,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusparseSpGEMMAlg_t {
@@ -357,7 +360,7 @@ pub enum cusparseSpMMAlg_t {
     CUSPARSE_SPMM_CSR_ALG3 = 12,
     CUSPARSE_SPMM_BLOCKED_ELL_ALG1 = 13,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusparseSpMMAlg_t {
@@ -372,7 +375,7 @@ pub enum cusparseSpMMAlg_t {
     CUSPARSE_SPMM_BLOCKED_ELL_ALG1 = 13,
     CUSPARSE_SPMM_BSR_ALG1 = 14,
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusparseSpMMOpAlg_t {
@@ -409,7 +412,7 @@ pub enum cusparseSpMVAlg_t {
     CUSPARSE_SPMV_COO_ALG2 = 4,
     CUSPARSE_SPMV_SELL_ALG1 = 5,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusparseSpMVAlg_t {
@@ -432,7 +435,7 @@ pub enum cusparseSpMatAttribute_t {
 pub enum cusparseSpSMAlg_t {
     CUSPARSE_SPSM_ALG_DEFAULT = 0,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusparseSpSMUpdate_t {
@@ -444,7 +447,7 @@ pub enum cusparseSpSMUpdate_t {
 pub enum cusparseSpSVAlg_t {
     CUSPARSE_SPSV_ALG_DEFAULT = 0,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cusparseSpSVUpdate_t {
@@ -484,57 +487,11 @@ pub enum libraryPropertyType_t {
 pub struct CUstream_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct _IO_FILE {
-    pub _flags: ::core::ffi::c_int,
-    pub _IO_read_ptr: *mut ::core::ffi::c_char,
-    pub _IO_read_end: *mut ::core::ffi::c_char,
-    pub _IO_read_base: *mut ::core::ffi::c_char,
-    pub _IO_write_base: *mut ::core::ffi::c_char,
-    pub _IO_write_ptr: *mut ::core::ffi::c_char,
-    pub _IO_write_end: *mut ::core::ffi::c_char,
-    pub _IO_buf_base: *mut ::core::ffi::c_char,
-    pub _IO_buf_end: *mut ::core::ffi::c_char,
-    pub _IO_save_base: *mut ::core::ffi::c_char,
-    pub _IO_backup_base: *mut ::core::ffi::c_char,
-    pub _IO_save_end: *mut ::core::ffi::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::core::ffi::c_int,
-    pub _flags2: ::core::ffi::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::core::ffi::c_ushort,
-    pub _vtable_offset: ::core::ffi::c_schar,
-    pub _shortbuf: [::core::ffi::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::core::ffi::c_void,
-    pub __pad5: usize,
-    pub _mode: ::core::ffi::c_int,
-    pub _unused2: [::core::ffi::c_char; 20usize],
-}
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
-}
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
-}
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
-    _unused: [u8; 0],
+    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -614,12 +571,18 @@ pub struct cusparseDnVecDescr {
 pub struct cusparseMatDescr {
     _unused: [u8; 0],
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct cusparseSpGEAMDescr {
+    _unused: [u8; 0],
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cusparseSpGEMMDescr {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cusparseSpMMOpPlan {
@@ -664,11 +627,11 @@ pub struct float2 {
 pub struct pruneInfo {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl cudaDataType_t {
     pub const CUDA_R_8F_UE4M3: cudaDataType_t = cudaDataType_t::CUDA_R_8F_E4M3;
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl cusparseCsr2CscAlg_t {
     pub const CUSPARSE_CSR2CSC_ALG1: cusparseCsr2CscAlg_t = cusparseCsr2CscAlg_t::CUSPARSE_CSR2CSC_ALG_DEFAULT;
 }
@@ -725,7 +688,7 @@ pub unsafe fn cusparseAxpby(handle: cusparseHandle_t, alpha: *const ::core::ffi:
         cusparseAxpby(handle, alpha, vecX, beta, vecY)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseAxpby(handle: cusparseHandle_t, alpha: *const ::core::ffi::c_void, vecX: cusparseConstSpVecDescr_t, beta: *const ::core::ffi::c_void, vecY: cusparseDnVecDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -775,7 +738,7 @@ pub unsafe fn cusparseBsrSetStridedBatch(spMatDescr: cusparseSpMatDescr_t, batch
         cusparseBsrSetStridedBatch(spMatDescr, batchCount, offsetsBatchStride, columnsValuesBatchStride, ValuesBatchStride)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseBsrSetStridedBatch(spMatDescr: cusparseSpMatDescr_t, batchCount: ::core::ffi::c_int, offsetsBatchStride: i64, columnsBatchStride: i64, ValuesBatchStride: i64) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1929,7 +1892,7 @@ pub unsafe fn cusparseCnnz_compress(handle: cusparseHandle_t, m: ::core::ffi::c_
         cusparseCnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstBlockedEllGet(spMatDescr: cusparseConstSpMatDescr_t, rows: *mut i64, cols: *mut i64, ellBlockSize: *mut i64, ellCols: *mut i64, ellColInd: *mut *const ::core::ffi::c_void, ellValue: *mut *const ::core::ffi::c_void, ellIdxType: *mut cusparseIndexType_t, idxBase: *mut cusparseIndexBase_t, valueType: *mut cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1946,7 +1909,7 @@ pub unsafe fn cusparseConstBlockedEllGet(spMatDescr: cusparseConstSpMatDescr_t, 
         cusparseConstBlockedEllGet(spMatDescr, rows, cols, ellBlockSize, ellCols, ellColInd, ellValue, ellIdxType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstCooGet(spMatDescr: cusparseConstSpMatDescr_t, rows: *mut i64, cols: *mut i64, nnz: *mut i64, cooRowInd: *mut *const ::core::ffi::c_void, cooColInd: *mut *const ::core::ffi::c_void, cooValues: *mut *const ::core::ffi::c_void, idxType: *mut cusparseIndexType_t, idxBase: *mut cusparseIndexBase_t, valueType: *mut cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1963,7 +1926,7 @@ pub unsafe fn cusparseConstCooGet(spMatDescr: cusparseConstSpMatDescr_t, rows: *
         cusparseConstCooGet(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues, idxType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstCscGet(spMatDescr: cusparseConstSpMatDescr_t, rows: *mut i64, cols: *mut i64, nnz: *mut i64, cscColOffsets: *mut *const ::core::ffi::c_void, cscRowInd: *mut *const ::core::ffi::c_void, cscValues: *mut *const ::core::ffi::c_void, cscColOffsetsType: *mut cusparseIndexType_t, cscRowIndType: *mut cusparseIndexType_t, idxBase: *mut cusparseIndexBase_t, valueType: *mut cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1980,7 +1943,7 @@ pub unsafe fn cusparseConstCscGet(spMatDescr: cusparseConstSpMatDescr_t, rows: *
         cusparseConstCscGet(spMatDescr, rows, cols, nnz, cscColOffsets, cscRowInd, cscValues, cscColOffsetsType, cscRowIndType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstCsrGet(spMatDescr: cusparseConstSpMatDescr_t, rows: *mut i64, cols: *mut i64, nnz: *mut i64, csrRowOffsets: *mut *const ::core::ffi::c_void, csrColInd: *mut *const ::core::ffi::c_void, csrValues: *mut *const ::core::ffi::c_void, csrRowOffsetsType: *mut cusparseIndexType_t, csrColIndType: *mut cusparseIndexType_t, idxBase: *mut cusparseIndexBase_t, valueType: *mut cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -1997,7 +1960,7 @@ pub unsafe fn cusparseConstCsrGet(spMatDescr: cusparseConstSpMatDescr_t, rows: *
         cusparseConstCsrGet(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd, csrValues, csrRowOffsetsType, csrColIndType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstDnMatGet(dnMatDescr: cusparseConstDnMatDescr_t, rows: *mut i64, cols: *mut i64, ld: *mut i64, values: *mut *const ::core::ffi::c_void, type_: *mut cudaDataType, order: *mut cusparseOrder_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2014,7 +1977,7 @@ pub unsafe fn cusparseConstDnMatGet(dnMatDescr: cusparseConstDnMatDescr_t, rows:
         cusparseConstDnMatGet(dnMatDescr, rows, cols, ld, values, type_, order)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstDnMatGetValues(dnMatDescr: cusparseConstDnMatDescr_t, values: *mut *const ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2031,7 +1994,7 @@ pub unsafe fn cusparseConstDnMatGetValues(dnMatDescr: cusparseConstDnMatDescr_t,
         cusparseConstDnMatGetValues(dnMatDescr, values)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstDnVecGet(dnVecDescr: cusparseConstDnVecDescr_t, size: *mut i64, values: *mut *const ::core::ffi::c_void, valueType: *mut cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2048,7 +2011,7 @@ pub unsafe fn cusparseConstDnVecGet(dnVecDescr: cusparseConstDnVecDescr_t, size:
         cusparseConstDnVecGet(dnVecDescr, size, values, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstDnVecGetValues(dnVecDescr: cusparseConstDnVecDescr_t, values: *mut *const ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2065,7 +2028,7 @@ pub unsafe fn cusparseConstDnVecGetValues(dnVecDescr: cusparseConstDnVecDescr_t,
         cusparseConstDnVecGetValues(dnVecDescr, values)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstSpMatGetValues(spMatDescr: cusparseConstSpMatDescr_t, values: *mut *const ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2082,7 +2045,7 @@ pub unsafe fn cusparseConstSpMatGetValues(spMatDescr: cusparseConstSpMatDescr_t,
         cusparseConstSpMatGetValues(spMatDescr, values)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstSpVecGet(spVecDescr: cusparseConstSpVecDescr_t, size: *mut i64, nnz: *mut i64, indices: *mut *const ::core::ffi::c_void, values: *mut *const ::core::ffi::c_void, idxType: *mut cusparseIndexType_t, idxBase: *mut cusparseIndexBase_t, valueType: *mut cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2099,7 +2062,7 @@ pub unsafe fn cusparseConstSpVecGet(spVecDescr: cusparseConstSpVecDescr_t, size:
         cusparseConstSpVecGet(spVecDescr, size, nnz, indices, values, idxType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseConstSpVecGetValues(spVecDescr: cusparseConstSpVecDescr_t, values: *mut *const ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2281,7 +2244,7 @@ pub unsafe fn cusparseCreateBsr(spMatDescr: *mut cusparseSpMatDescr_t, brows: i6
         cusparseCreateBsr(spMatDescr, brows, bcols, bnnz, rowBlockDim, colBlockDim, bsrRowOffsets, bsrColInd, bsrValues, bsrRowOffsetsType, bsrColIndType, idxBase, valueType, order)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateBsr(spMatDescr: *mut cusparseSpMatDescr_t, brows: i64, bcols: i64, bnnz: i64, rowBlockSize: i64, colBlockSize: i64, bsrRowOffsets: *mut ::core::ffi::c_void, bsrColInd: *mut ::core::ffi::c_void, bsrValues: *mut ::core::ffi::c_void, bsrRowOffsetsType: cusparseIndexType_t, bsrColIndType: cusparseIndexType_t, idxBase: cusparseIndexBase_t, valueType: cudaDataType, order: cusparseOrder_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2378,7 +2341,7 @@ pub unsafe fn cusparseCreateColorInfo(info: *mut cusparseColorInfo_t) -> cuspars
         cusparseCreateColorInfo(info)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateConstBlockedEll(spMatDescr: *mut cusparseConstSpMatDescr_t, rows: i64, cols: i64, ellBlockSize: i64, ellCols: i64, ellColInd: *const ::core::ffi::c_void, ellValue: *const ::core::ffi::c_void, ellIdxType: cusparseIndexType_t, idxBase: cusparseIndexBase_t, valueType: cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2395,7 +2358,7 @@ pub unsafe fn cusparseCreateConstBlockedEll(spMatDescr: *mut cusparseConstSpMatD
         cusparseCreateConstBlockedEll(spMatDescr, rows, cols, ellBlockSize, ellCols, ellColInd, ellValue, ellIdxType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateConstBsr(spMatDescr: *mut cusparseConstSpMatDescr_t, brows: i64, bcols: i64, bnnz: i64, rowBlockDim: i64, colBlockDim: i64, bsrRowOffsets: *const ::core::ffi::c_void, bsrColInd: *const ::core::ffi::c_void, bsrValues: *const ::core::ffi::c_void, bsrRowOffsetsType: cusparseIndexType_t, bsrColIndType: cusparseIndexType_t, idxBase: cusparseIndexBase_t, valueType: cudaDataType, order: cusparseOrder_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2412,7 +2375,7 @@ pub unsafe fn cusparseCreateConstBsr(spMatDescr: *mut cusparseConstSpMatDescr_t,
         cusparseCreateConstBsr(spMatDescr, brows, bcols, bnnz, rowBlockDim, colBlockDim, bsrRowOffsets, bsrColInd, bsrValues, bsrRowOffsetsType, bsrColIndType, idxBase, valueType, order)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateConstCoo(spMatDescr: *mut cusparseConstSpMatDescr_t, rows: i64, cols: i64, nnz: i64, cooRowInd: *const ::core::ffi::c_void, cooColInd: *const ::core::ffi::c_void, cooValues: *const ::core::ffi::c_void, cooIdxType: cusparseIndexType_t, idxBase: cusparseIndexBase_t, valueType: cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2429,7 +2392,7 @@ pub unsafe fn cusparseCreateConstCoo(spMatDescr: *mut cusparseConstSpMatDescr_t,
         cusparseCreateConstCoo(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues, cooIdxType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateConstCsc(spMatDescr: *mut cusparseConstSpMatDescr_t, rows: i64, cols: i64, nnz: i64, cscColOffsets: *const ::core::ffi::c_void, cscRowInd: *const ::core::ffi::c_void, cscValues: *const ::core::ffi::c_void, cscColOffsetsType: cusparseIndexType_t, cscRowIndType: cusparseIndexType_t, idxBase: cusparseIndexBase_t, valueType: cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2446,7 +2409,7 @@ pub unsafe fn cusparseCreateConstCsc(spMatDescr: *mut cusparseConstSpMatDescr_t,
         cusparseCreateConstCsc(spMatDescr, rows, cols, nnz, cscColOffsets, cscRowInd, cscValues, cscColOffsetsType, cscRowIndType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateConstCsr(spMatDescr: *mut cusparseConstSpMatDescr_t, rows: i64, cols: i64, nnz: i64, csrRowOffsets: *const ::core::ffi::c_void, csrColInd: *const ::core::ffi::c_void, csrValues: *const ::core::ffi::c_void, csrRowOffsetsType: cusparseIndexType_t, csrColIndType: cusparseIndexType_t, idxBase: cusparseIndexBase_t, valueType: cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2463,7 +2426,7 @@ pub unsafe fn cusparseCreateConstCsr(spMatDescr: *mut cusparseConstSpMatDescr_t,
         cusparseCreateConstCsr(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd, csrValues, csrRowOffsetsType, csrColIndType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateConstDnMat(dnMatDescr: *mut cusparseConstDnMatDescr_t, rows: i64, cols: i64, ld: i64, values: *const ::core::ffi::c_void, valueType: cudaDataType, order: cusparseOrder_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2480,7 +2443,7 @@ pub unsafe fn cusparseCreateConstDnMat(dnMatDescr: *mut cusparseConstDnMatDescr_
         cusparseCreateConstDnMat(dnMatDescr, rows, cols, ld, values, valueType, order)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateConstDnVec(dnVecDescr: *mut cusparseConstDnVecDescr_t, size: i64, values: *const ::core::ffi::c_void, valueType: cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2497,7 +2460,7 @@ pub unsafe fn cusparseCreateConstDnVec(dnVecDescr: *mut cusparseConstDnVecDescr_
         cusparseCreateConstDnVec(dnVecDescr, size, values, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateConstSlicedEll(spMatDescr: *mut cusparseConstSpMatDescr_t, rows: i64, cols: i64, nnz: i64, sellValuesSize: i64, sliceSize: i64, sellSliceOffsets: *const ::core::ffi::c_void, sellColInd: *const ::core::ffi::c_void, sellValues: *const ::core::ffi::c_void, sellSliceOffsetsType: cusparseIndexType_t, sellColIndType: cusparseIndexType_t, idxBase: cusparseIndexBase_t, valueType: cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2514,7 +2477,7 @@ pub unsafe fn cusparseCreateConstSlicedEll(spMatDescr: *mut cusparseConstSpMatDe
         cusparseCreateConstSlicedEll(spMatDescr, rows, cols, nnz, sellValuesSize, sliceSize, sellSliceOffsets, sellColInd, sellValues, sellSliceOffsetsType, sellColIndType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateConstSpVec(spVecDescr: *mut cusparseConstSpVecDescr_t, size: i64, nnz: i64, indices: *const ::core::ffi::c_void, values: *const ::core::ffi::c_void, idxType: cusparseIndexType_t, idxBase: cusparseIndexBase_t, valueType: cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2775,7 +2738,7 @@ pub unsafe fn cusparseCreatePruneInfo(info: *mut pruneInfo_t) -> cusparseStatus_
         cusparseCreatePruneInfo(info)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCreateSlicedEll(spMatDescr: *mut cusparseSpMatDescr_t, rows: i64, cols: i64, nnz: i64, sellValuesSize: i64, sliceSize: i64, sellSliceOffsets: *mut ::core::ffi::c_void, sellColInd: *mut ::core::ffi::c_void, sellValues: *mut ::core::ffi::c_void, sellSliceOffsetsType: cusparseIndexType_t, sellColIndType: cusparseIndexType_t, idxBase: cusparseIndexBase_t, valueType: cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -2808,7 +2771,7 @@ pub unsafe fn cusparseCreateSpVec(spVecDescr: *mut cusparseSpVecDescr_t, size: i
         cusparseCreateSpVec(spVecDescr, size, nnz, indices, values, idxType, idxBase, valueType)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseCscGet(spMatDescr: cusparseSpMatDescr_t, rows: *mut i64, cols: *mut i64, nnz: *mut i64, cscColOffsets: *mut *mut ::core::ffi::c_void, cscRowInd: *mut *mut ::core::ffi::c_void, cscValues: *mut *mut ::core::ffi::c_void, cscColOffsetsType: *mut cusparseIndexType_t, cscRowIndType: *mut cusparseIndexType_t, idxBase: *mut cusparseIndexBase_t, valueType: *mut cudaDataType) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3788,7 +3751,7 @@ pub unsafe fn cusparseDenseToSparse_analysis(handle: cusparseHandle_t, matA: cus
         cusparseDenseToSparse_analysis(handle, matA, matB, alg, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseDenseToSparse_analysis(handle: cusparseHandle_t, matA: cusparseConstDnMatDescr_t, matB: cusparseSpMatDescr_t, alg: cusparseDenseToSparseAlg_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3822,7 +3785,7 @@ pub unsafe fn cusparseDenseToSparse_bufferSize(handle: cusparseHandle_t, matA: c
         cusparseDenseToSparse_bufferSize(handle, matA, matB, alg, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseDenseToSparse_bufferSize(handle: cusparseHandle_t, matA: cusparseConstDnMatDescr_t, matB: cusparseSpMatDescr_t, alg: cusparseDenseToSparseAlg_t, bufferSize: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -3873,7 +3836,7 @@ pub unsafe fn cusparseDenseToSparse_convert(handle: cusparseHandle_t, matA: cusp
         cusparseDenseToSparse_convert(handle, matA, matB, alg, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseDenseToSparse_convert(handle: cusparseHandle_t, matA: cusparseConstDnMatDescr_t, matB: cusparseSpMatDescr_t, alg: cusparseDenseToSparseAlg_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4102,7 +4065,7 @@ pub unsafe fn cusparseDestroyDnMat(dnMatDescr: cusparseDnMatDescr_t) -> cusparse
         cusparseDestroyDnMat(dnMatDescr)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseDestroyDnMat(dnMatDescr: cusparseConstDnMatDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4136,7 +4099,7 @@ pub unsafe fn cusparseDestroyDnVec(dnVecDescr: cusparseDnVecDescr_t) -> cusparse
         cusparseDestroyDnVec(dnVecDescr)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseDestroyDnVec(dnVecDescr: cusparseConstDnVecDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4202,7 +4165,7 @@ pub unsafe fn cusparseDestroySpMat(spMatDescr: cusparseSpMatDescr_t) -> cusparse
         cusparseDestroySpMat(spMatDescr)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseDestroySpMat(spMatDescr: cusparseConstSpMatDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4236,7 +4199,7 @@ pub unsafe fn cusparseDestroySpVec(spVecDescr: cusparseSpVecDescr_t) -> cusparse
         cusparseDestroySpVec(spVecDescr)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseDestroySpVec(spVecDescr: cusparseConstSpVecDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4609,7 +4572,7 @@ pub unsafe fn cusparseDnMatGetStridedBatch(dnMatDescr: cusparseDnMatDescr_t, bat
         cusparseDnMatGetStridedBatch(dnMatDescr, batchCount, batchStride)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseDnMatGetStridedBatch(dnMatDescr: cusparseConstDnMatDescr_t, batchCount: *mut ::core::ffi::c_int, batchStride: *mut i64) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -4997,7 +4960,7 @@ pub unsafe fn cusparseGather(handle: cusparseHandle_t, vecY: cusparseDnVecDescr_
         cusparseGather(handle, vecY, vecX)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseGather(handle: cusparseHandle_t, vecY: cusparseConstDnVecDescr_t, vecX: cusparseSpVecDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5191,7 +5154,7 @@ pub unsafe fn cusparseGetVersion(handle: cusparseHandle_t, version: *mut ::core:
         cusparseGetVersion(handle, version)
     }
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseLoggerForceDisable() -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5208,7 +5171,7 @@ pub unsafe fn cusparseLoggerForceDisable() -> cusparseStatus_t {
         cusparseLoggerForceDisable()
     }
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseLoggerOpenFile(logFile: *const ::core::ffi::c_char) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5225,7 +5188,7 @@ pub unsafe fn cusparseLoggerOpenFile(logFile: *const ::core::ffi::c_char) -> cus
         cusparseLoggerOpenFile(logFile)
     }
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseLoggerSetCallback(callback: cusparseLoggerCallback_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5242,7 +5205,7 @@ pub unsafe fn cusparseLoggerSetCallback(callback: cusparseLoggerCallback_t) -> c
         cusparseLoggerSetCallback(callback)
     }
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseLoggerSetFile(file: *mut FILE) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5259,7 +5222,7 @@ pub unsafe fn cusparseLoggerSetFile(file: *mut FILE) -> cusparseStatus_t {
         cusparseLoggerSetFile(file)
     }
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseLoggerSetLevel(level: ::core::ffi::c_int) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5276,7 +5239,7 @@ pub unsafe fn cusparseLoggerSetLevel(level: ::core::ffi::c_int) -> cusparseStatu
         cusparseLoggerSetLevel(level)
     }
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseLoggerSetMask(mask: ::core::ffi::c_int) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5326,7 +5289,7 @@ pub unsafe fn cusparseSDDMM(handle: cusparseHandle_t, opA: cusparseOperation_t, 
         cusparseSDDMM(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSDDMM(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstDnMatDescr_t, matB: cusparseConstDnMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSDDMMAlg_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5360,7 +5323,7 @@ pub unsafe fn cusparseSDDMM_bufferSize(handle: cusparseHandle_t, opA: cusparseOp
         cusparseSDDMM_bufferSize(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSDDMM_bufferSize(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstDnMatDescr_t, matB: cusparseConstDnMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSDDMMAlg_t, bufferSize: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5394,7 +5357,7 @@ pub unsafe fn cusparseSDDMM_preprocess(handle: cusparseHandle_t, opA: cusparseOp
         cusparseSDDMM_preprocess(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSDDMM_preprocess(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstDnMatDescr_t, matB: cusparseConstDnMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSDDMMAlg_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -5717,7 +5680,7 @@ pub unsafe fn cusparseScatter(handle: cusparseHandle_t, vecX: cusparseSpVecDescr
         cusparseScatter(handle, vecX, vecY)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseScatter(handle: cusparseHandle_t, vecX: cusparseConstSpVecDescr_t, vecY: cusparseDnVecDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6695,6 +6658,91 @@ pub unsafe fn cusparseSnnz_compress(handle: cusparseHandle_t, m: ::core::ffi::c_
         cusparseSnnz_compress(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol)
     }
 }
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cusparseSpGEAM(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseSpMatDescr_t, beta: *const ::core::ffi::c_void, matB: cusparseSpMatDescr_t, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEAMAlg_t, spgeamDescr: cusparseSpGEAMDescr_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, *const ::core::ffi::c_void, cusparseSpMatDescr_t, *const ::core::ffi::c_void, cusparseSpMatDescr_t, cusparseSpMatDescr_t, cudaDataType, cusparseSpGEAMAlg_t, cusparseSpGEAMDescr_t, *mut ::core::ffi::c_void) -> cusparseStatus_t;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cusparseSpGEAM") });
+        _f(handle, opA, opB, alpha, matA, beta, matB, matC, computeType, alg, spgeamDescr, externalBuffer)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cusparseSpGEAM(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseSpMatDescr_t, beta: *const ::core::ffi::c_void, matB: cusparseSpMatDescr_t, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEAMAlg_t, spgeamDescr: cusparseSpGEAMDescr_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t;
+        }
+        cusparseSpGEAM(handle, opA, opB, alpha, matA, beta, matB, matC, computeType, alg, spgeamDescr, externalBuffer)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cusparseSpGEAM_bufferSize(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseSpMatDescr_t, beta: *const ::core::ffi::c_void, matB: cusparseSpMatDescr_t, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEAMAlg_t, spgeamDescr: cusparseSpGEAMDescr_t, bufferSize: *mut usize) -> cusparseStatus_t {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, *const ::core::ffi::c_void, cusparseSpMatDescr_t, *const ::core::ffi::c_void, cusparseSpMatDescr_t, cusparseSpMatDescr_t, cudaDataType, cusparseSpGEAMAlg_t, cusparseSpGEAMDescr_t, *mut usize) -> cusparseStatus_t;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cusparseSpGEAM_bufferSize") });
+        _f(handle, opA, opB, alpha, matA, beta, matB, matC, computeType, alg, spgeamDescr, bufferSize)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cusparseSpGEAM_bufferSize(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseSpMatDescr_t, beta: *const ::core::ffi::c_void, matB: cusparseSpMatDescr_t, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEAMAlg_t, spgeamDescr: cusparseSpGEAMDescr_t, bufferSize: *mut usize) -> cusparseStatus_t;
+        }
+        cusparseSpGEAM_bufferSize(handle, opA, opB, alpha, matA, beta, matB, matC, computeType, alg, spgeamDescr, bufferSize)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cusparseSpGEAM_createDescr(descr: *mut cusparseSpGEAMDescr_t) -> cusparseStatus_t {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(*mut cusparseSpGEAMDescr_t) -> cusparseStatus_t;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cusparseSpGEAM_createDescr") });
+        _f(descr)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cusparseSpGEAM_createDescr(descr: *mut cusparseSpGEAMDescr_t) -> cusparseStatus_t;
+        }
+        cusparseSpGEAM_createDescr(descr)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cusparseSpGEAM_destroyDescr(descr: cusparseSpGEAMDescr_t) -> cusparseStatus_t {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(cusparseSpGEAMDescr_t) -> cusparseStatus_t;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cusparseSpGEAM_destroyDescr") });
+        _f(descr)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cusparseSpGEAM_destroyDescr(descr: cusparseSpGEAMDescr_t) -> cusparseStatus_t;
+        }
+        cusparseSpGEAM_destroyDescr(descr)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cusparseSpGEAM_nnz(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseSpMatDescr_t, beta: *const ::core::ffi::c_void, matB: cusparseSpMatDescr_t, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEAMAlg_t, spgeamDescr: cusparseSpGEAMDescr_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, *const ::core::ffi::c_void, cusparseSpMatDescr_t, *const ::core::ffi::c_void, cusparseSpMatDescr_t, cusparseSpMatDescr_t, cudaDataType, cusparseSpGEAMAlg_t, cusparseSpGEAMDescr_t, *mut ::core::ffi::c_void) -> cusparseStatus_t;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cusparseSpGEAM_nnz") });
+        _f(handle, opA, opB, alpha, matA, beta, matB, matC, computeType, alg, spgeamDescr, externalBuffer)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cusparseSpGEAM_nnz(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseSpMatDescr_t, beta: *const ::core::ffi::c_void, matB: cusparseSpMatDescr_t, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEAMAlg_t, spgeamDescr: cusparseSpGEAMDescr_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t;
+        }
+        cusparseSpGEAM_nnz(handle, opA, opB, alpha, matA, beta, matB, matC, computeType, alg, spgeamDescr, externalBuffer)
+    }
+}
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080"))]
 pub unsafe fn cusparseSpGEMM_compute(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseSpMatDescr_t, matB: cusparseSpMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEMMAlg_t, spgemmDescr: cusparseSpGEMMDescr_t, bufferSize2: *mut usize, externalBuffer2: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
@@ -6712,7 +6760,7 @@ pub unsafe fn cusparseSpGEMM_compute(handle: cusparseHandle_t, opA: cusparseOper
         cusparseSpGEMM_compute(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, spgemmDescr, bufferSize2, externalBuffer2)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpGEMM_compute(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstSpMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEMMAlg_t, spgemmDescr: cusparseSpGEMMDescr_t, bufferSize2: *mut usize, externalBuffer2: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6746,7 +6794,7 @@ pub unsafe fn cusparseSpGEMM_copy(handle: cusparseHandle_t, opA: cusparseOperati
         cusparseSpGEMM_copy(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, spgemmDescr)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpGEMM_copy(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstSpMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEMMAlg_t, spgemmDescr: cusparseSpGEMMDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6795,7 +6843,7 @@ pub unsafe fn cusparseSpGEMM_destroyDescr(descr: cusparseSpGEMMDescr_t) -> cuspa
         cusparseSpGEMM_destroyDescr(descr)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpGEMM_estimateMemory(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstSpMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEMMAlg_t, spgemmDescr: cusparseSpGEMMDescr_t, chunk_fraction: f32, bufferSize3: *mut usize, externalBuffer3: *mut ::core::ffi::c_void, bufferSize2: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6812,7 +6860,7 @@ pub unsafe fn cusparseSpGEMM_estimateMemory(handle: cusparseHandle_t, opA: cuspa
         cusparseSpGEMM_estimateMemory(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, spgemmDescr, chunk_fraction, bufferSize3, externalBuffer3, bufferSize2)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpGEMM_getNumProducts(spgemmDescr: cusparseSpGEMMDescr_t, num_prods: *mut i64) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6846,7 +6894,7 @@ pub unsafe fn cusparseSpGEMM_workEstimation(handle: cusparseHandle_t, opA: cuspa
         cusparseSpGEMM_workEstimation(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, spgemmDescr, bufferSize1, externalBuffer1)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpGEMM_workEstimation(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstSpMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEMMAlg_t, spgemmDescr: cusparseSpGEMMDescr_t, bufferSize1: *mut usize, externalBuffer1: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6880,7 +6928,7 @@ pub unsafe fn cusparseSpGEMMreuse_compute(handle: cusparseHandle_t, opA: cuspars
         cusparseSpGEMMreuse_compute(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, spgemmDescr)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpGEMMreuse_compute(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstSpMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseSpMatDescr_t, computeType: cudaDataType, alg: cusparseSpGEMMAlg_t, spgemmDescr: cusparseSpGEMMDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6914,7 +6962,7 @@ pub unsafe fn cusparseSpGEMMreuse_copy(handle: cusparseHandle_t, opA: cusparseOp
         cusparseSpGEMMreuse_copy(handle, opA, opB, matA, matB, matC, alg, spgemmDescr, bufferSize5, externalBuffer5)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpGEMMreuse_copy(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, matA: cusparseConstSpMatDescr_t, matB: cusparseConstSpMatDescr_t, matC: cusparseSpMatDescr_t, alg: cusparseSpGEMMAlg_t, spgemmDescr: cusparseSpGEMMDescr_t, bufferSize5: *mut usize, externalBuffer5: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6948,7 +6996,7 @@ pub unsafe fn cusparseSpGEMMreuse_nnz(handle: cusparseHandle_t, opA: cusparseOpe
         cusparseSpGEMMreuse_nnz(handle, opA, opB, matA, matB, matC, alg, spgemmDescr, bufferSize2, externalBuffer2, bufferSize3, externalBuffer3, bufferSize4, externalBuffer4)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpGEMMreuse_nnz(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, matA: cusparseConstSpMatDescr_t, matB: cusparseConstSpMatDescr_t, matC: cusparseSpMatDescr_t, alg: cusparseSpGEMMAlg_t, spgemmDescr: cusparseSpGEMMDescr_t, bufferSize2: *mut usize, externalBuffer2: *mut ::core::ffi::c_void, bufferSize3: *mut usize, externalBuffer3: *mut ::core::ffi::c_void, bufferSize4: *mut usize, externalBuffer4: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6982,7 +7030,7 @@ pub unsafe fn cusparseSpGEMMreuse_workEstimation(handle: cusparseHandle_t, opA: 
         cusparseSpGEMMreuse_workEstimation(handle, opA, opB, matA, matB, matC, alg, spgemmDescr, bufferSize1, externalBuffer1)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpGEMMreuse_workEstimation(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, matA: cusparseConstSpMatDescr_t, matB: cusparseConstSpMatDescr_t, matC: cusparseSpMatDescr_t, alg: cusparseSpGEMMAlg_t, spgemmDescr: cusparseSpGEMMDescr_t, bufferSize1: *mut usize, externalBuffer1: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7016,7 +7064,7 @@ pub unsafe fn cusparseSpMM(handle: cusparseHandle_t, opA: cusparseOperation_t, o
         cusparseSpMM(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMM(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstDnMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseDnMatDescr_t, computeType: cudaDataType, alg: cusparseSpMMAlg_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7033,7 +7081,7 @@ pub unsafe fn cusparseSpMM(handle: cusparseHandle_t, opA: cusparseOperation_t, o
         cusparseSpMM(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMMOp(plan: cusparseSpMMOpPlan_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7084,7 +7132,7 @@ pub unsafe fn cusparseSpMMOp_createPlan(handle: cusparseHandle_t, plan: *mut cus
         cusparseSpMMOp_createPlan(handle, plan, opA, opB, matA, matB, matC, computeType, alg, addOperationNvvmBuffer, addOperationBufferSize, mulOperationNvvmBuffer, mulOperationBufferSize, epilogueNvvmBuffer, epilogueBufferSize, SpMMWorkspaceSize)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMMOp_createPlan(handle: cusparseHandle_t, plan: *mut cusparseSpMMOpPlan_t, opA: cusparseOperation_t, opB: cusparseOperation_t, matA: cusparseConstSpMatDescr_t, matB: cusparseConstDnMatDescr_t, matC: cusparseDnMatDescr_t, computeType: cudaDataType, alg: cusparseSpMMOpAlg_t, addOperationLtoirBuffer: *const ::core::ffi::c_void, addOperationBufferSize: usize, mulOperationLtoirBuffer: *const ::core::ffi::c_void, mulOperationBufferSize: usize, epilogueLtoirBuffer: *const ::core::ffi::c_void, epilogueBufferSize: usize, SpMMWorkspaceSize: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7101,7 +7149,7 @@ pub unsafe fn cusparseSpMMOp_createPlan(handle: cusparseHandle_t, plan: *mut cus
         cusparseSpMMOp_createPlan(handle, plan, opA, opB, matA, matB, matC, computeType, alg, addOperationLtoirBuffer, addOperationBufferSize, mulOperationLtoirBuffer, mulOperationBufferSize, epilogueLtoirBuffer, epilogueBufferSize, SpMMWorkspaceSize)
     }
 }
-#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMMOp_destroyPlan(plan: cusparseSpMMOpPlan_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7135,7 +7183,7 @@ pub unsafe fn cusparseSpMM_bufferSize(handle: cusparseHandle_t, opA: cusparseOpe
         cusparseSpMM_bufferSize(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMM_bufferSize(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstDnMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseDnMatDescr_t, computeType: cudaDataType, alg: cusparseSpMMAlg_t, bufferSize: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7169,7 +7217,7 @@ pub unsafe fn cusparseSpMM_preprocess(handle: cusparseHandle_t, opA: cusparseOpe
         cusparseSpMM_preprocess(handle, opA, opB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMM_preprocess(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstDnMatDescr_t, beta: *const ::core::ffi::c_void, matC: cusparseDnMatDescr_t, computeType: cudaDataType, alg: cusparseSpMMAlg_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7203,7 +7251,7 @@ pub unsafe fn cusparseSpMV(handle: cusparseHandle_t, opA: cusparseOperation_t, a
         cusparseSpMV(handle, opA, alpha, matA, vecX, beta, vecY, computeType, alg, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMV(handle: cusparseHandle_t, opA: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, vecX: cusparseConstDnVecDescr_t, beta: *const ::core::ffi::c_void, vecY: cusparseDnVecDescr_t, computeType: cudaDataType, alg: cusparseSpMVAlg_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7237,7 +7285,7 @@ pub unsafe fn cusparseSpMV_bufferSize(handle: cusparseHandle_t, opA: cusparseOpe
         cusparseSpMV_bufferSize(handle, opA, alpha, matA, vecX, beta, vecY, computeType, alg, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMV_bufferSize(handle: cusparseHandle_t, opA: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, vecX: cusparseConstDnVecDescr_t, beta: *const ::core::ffi::c_void, vecY: cusparseDnVecDescr_t, computeType: cudaDataType, alg: cusparseSpMVAlg_t, bufferSize: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7254,7 +7302,7 @@ pub unsafe fn cusparseSpMV_bufferSize(handle: cusparseHandle_t, opA: cusparseOpe
         cusparseSpMV_bufferSize(handle, opA, alpha, matA, vecX, beta, vecY, computeType, alg, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMV_preprocess(handle: cusparseHandle_t, opA: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, vecX: cusparseConstDnVecDescr_t, beta: *const ::core::ffi::c_void, vecY: cusparseDnVecDescr_t, computeType: cudaDataType, alg: cusparseSpMVAlg_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7288,7 +7336,7 @@ pub unsafe fn cusparseSpMatGetAttribute(spMatDescr: cusparseSpMatDescr_t, attrib
         cusparseSpMatGetAttribute(spMatDescr, attribute, data, dataSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMatGetAttribute(spMatDescr: cusparseConstSpMatDescr_t, attribute: cusparseSpMatAttribute_t, data: *mut ::core::ffi::c_void, dataSize: usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7322,7 +7370,7 @@ pub unsafe fn cusparseSpMatGetFormat(spMatDescr: cusparseSpMatDescr_t, format: *
         cusparseSpMatGetFormat(spMatDescr, format)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMatGetFormat(spMatDescr: cusparseConstSpMatDescr_t, format: *mut cusparseFormat_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7356,7 +7404,7 @@ pub unsafe fn cusparseSpMatGetIndexBase(spMatDescr: cusparseSpMatDescr_t, idxBas
         cusparseSpMatGetIndexBase(spMatDescr, idxBase)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMatGetIndexBase(spMatDescr: cusparseConstSpMatDescr_t, idxBase: *mut cusparseIndexBase_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7390,7 +7438,7 @@ pub unsafe fn cusparseSpMatGetSize(spMatDescr: cusparseSpMatDescr_t, rows: *mut 
         cusparseSpMatGetSize(spMatDescr, rows, cols, nnz)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMatGetSize(spMatDescr: cusparseConstSpMatDescr_t, rows: *mut i64, cols: *mut i64, nnz: *mut i64) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7424,7 +7472,7 @@ pub unsafe fn cusparseSpMatGetStridedBatch(spMatDescr: cusparseSpMatDescr_t, bat
         cusparseSpMatGetStridedBatch(spMatDescr, batchCount)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpMatGetStridedBatch(spMatDescr: cusparseConstSpMatDescr_t, batchCount: *mut ::core::ffi::c_int) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7523,7 +7571,7 @@ pub unsafe fn cusparseSpSM_analysis(handle: cusparseHandle_t, opA: cusparseOpera
         cusparseSpSM_analysis(handle, opA, opB, alpha, matA, matB, matC, computeType, alg, spsmDescr, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpSM_analysis(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstDnMatDescr_t, matC: cusparseDnMatDescr_t, computeType: cudaDataType, alg: cusparseSpSMAlg_t, spsmDescr: cusparseSpSMDescr_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7557,7 +7605,7 @@ pub unsafe fn cusparseSpSM_bufferSize(handle: cusparseHandle_t, opA: cusparseOpe
         cusparseSpSM_bufferSize(handle, opA, opB, alpha, matA, matB, matC, computeType, alg, spsmDescr, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpSM_bufferSize(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstDnMatDescr_t, matC: cusparseDnMatDescr_t, computeType: cudaDataType, alg: cusparseSpSMAlg_t, spsmDescr: cusparseSpSMDescr_t, bufferSize: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7623,7 +7671,7 @@ pub unsafe fn cusparseSpSM_solve(handle: cusparseHandle_t, opA: cusparseOperatio
         cusparseSpSM_solve(handle, opA, opB, alpha, matA, matB, matC, computeType, alg, spsmDescr)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpSM_solve(handle: cusparseHandle_t, opA: cusparseOperation_t, opB: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, matB: cusparseConstDnMatDescr_t, matC: cusparseDnMatDescr_t, computeType: cudaDataType, alg: cusparseSpSMAlg_t, spsmDescr: cusparseSpSMDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7640,7 +7688,7 @@ pub unsafe fn cusparseSpSM_solve(handle: cusparseHandle_t, opA: cusparseOperatio
         cusparseSpSM_solve(handle, opA, opB, alpha, matA, matB, matC, computeType, alg, spsmDescr)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpSM_updateMatrix(handle: cusparseHandle_t, spsmDescr: cusparseSpSMDescr_t, newValues: *mut ::core::ffi::c_void, updatePart: cusparseSpSMUpdate_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7674,7 +7722,7 @@ pub unsafe fn cusparseSpSV_analysis(handle: cusparseHandle_t, opA: cusparseOpera
         cusparseSpSV_analysis(handle, opA, alpha, matA, vecX, vecY, computeType, alg, spsvDescr, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpSV_analysis(handle: cusparseHandle_t, opA: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, vecX: cusparseConstDnVecDescr_t, vecY: cusparseDnVecDescr_t, computeType: cudaDataType, alg: cusparseSpSVAlg_t, spsvDescr: cusparseSpSVDescr_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7708,7 +7756,7 @@ pub unsafe fn cusparseSpSV_bufferSize(handle: cusparseHandle_t, opA: cusparseOpe
         cusparseSpSV_bufferSize(handle, opA, alpha, matA, vecX, vecY, computeType, alg, spsvDescr, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpSV_bufferSize(handle: cusparseHandle_t, opA: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, vecX: cusparseConstDnVecDescr_t, vecY: cusparseDnVecDescr_t, computeType: cudaDataType, alg: cusparseSpSVAlg_t, spsvDescr: cusparseSpSVDescr_t, bufferSize: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7774,7 +7822,7 @@ pub unsafe fn cusparseSpSV_solve(handle: cusparseHandle_t, opA: cusparseOperatio
         cusparseSpSV_solve(handle, opA, alpha, matA, vecX, vecY, computeType, alg, spsvDescr)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpSV_solve(handle: cusparseHandle_t, opA: cusparseOperation_t, alpha: *const ::core::ffi::c_void, matA: cusparseConstSpMatDescr_t, vecX: cusparseConstDnVecDescr_t, vecY: cusparseDnVecDescr_t, computeType: cudaDataType, alg: cusparseSpSVAlg_t, spsvDescr: cusparseSpSVDescr_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7791,7 +7839,7 @@ pub unsafe fn cusparseSpSV_solve(handle: cusparseHandle_t, opA: cusparseOperatio
         cusparseSpSV_solve(handle, opA, alpha, matA, vecX, vecY, computeType, alg, spsvDescr)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpSV_updateMatrix(handle: cusparseHandle_t, spsvDescr: cusparseSpSVDescr_t, newValues: *mut ::core::ffi::c_void, updatePart: cusparseSpSVUpdate_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7825,7 +7873,7 @@ pub unsafe fn cusparseSpVV(handle: cusparseHandle_t, opX: cusparseOperation_t, v
         cusparseSpVV(handle, opX, vecX, vecY, result, computeType, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpVV(handle: cusparseHandle_t, opX: cusparseOperation_t, vecX: cusparseConstSpVecDescr_t, vecY: cusparseConstDnVecDescr_t, result: *mut ::core::ffi::c_void, computeType: cudaDataType, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7859,7 +7907,7 @@ pub unsafe fn cusparseSpVV_bufferSize(handle: cusparseHandle_t, opX: cusparseOpe
         cusparseSpVV_bufferSize(handle, opX, vecX, vecY, result, computeType, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpVV_bufferSize(handle: cusparseHandle_t, opX: cusparseOperation_t, vecX: cusparseConstSpVecDescr_t, vecY: cusparseConstDnVecDescr_t, result: *const ::core::ffi::c_void, computeType: cudaDataType, bufferSize: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7909,7 +7957,7 @@ pub unsafe fn cusparseSpVecGetIndexBase(spVecDescr: cusparseSpVecDescr_t, idxBas
         cusparseSpVecGetIndexBase(spVecDescr, idxBase)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSpVecGetIndexBase(spVecDescr: cusparseConstSpVecDescr_t, idxBase: *mut cusparseIndexBase_t) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7992,7 +8040,7 @@ pub unsafe fn cusparseSparseToDense(handle: cusparseHandle_t, matA: cusparseSpMa
         cusparseSparseToDense(handle, matA, matB, alg, externalBuffer)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSparseToDense(handle: cusparseHandle_t, matA: cusparseConstSpMatDescr_t, matB: cusparseDnMatDescr_t, alg: cusparseSparseToDenseAlg_t, externalBuffer: *mut ::core::ffi::c_void) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8026,7 +8074,7 @@ pub unsafe fn cusparseSparseToDense_bufferSize(handle: cusparseHandle_t, matA: c
         cusparseSparseToDense_bufferSize(handle, matA, matB, alg, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cusparseSparseToDense_bufferSize(handle: cusparseHandle_t, matA: cusparseConstSpMatDescr_t, matB: cusparseDnMatDescr_t, alg: cusparseSparseToDenseAlg_t, bufferSize: *mut usize) -> cusparseStatus_t {
     #[cfg(feature = "dynamic-loading")]
     {

--- a/src/cutensor/sys/mod.rs
+++ b/src/cutensor/sys/mod.rs
@@ -13,9 +13,6 @@ fn load<F: Copy>(name: &str) -> F {
 }
 pub use self::cudaDataType_t as cutensorDataType_t;
 pub type FILE = _IO_FILE;
-pub type _IO_lock_t = ::core::ffi::c_void;
-pub type __off64_t = ::core::ffi::c_long;
-pub type __off_t = ::core::ffi::c_long;
 pub type cudaStream_t = *mut CUstream_st;
 pub type cutensorBlockSparseTensorDescriptor_t = *mut cutensorBlockSparseTensorDescriptor;
 pub type cutensorComputeDescriptor_t = *mut cutensorComputeDescriptor;
@@ -200,50 +197,7 @@ pub struct CUstream_st {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct _IO_FILE {
-    pub _flags: ::core::ffi::c_int,
-    pub _IO_read_ptr: *mut ::core::ffi::c_char,
-    pub _IO_read_end: *mut ::core::ffi::c_char,
-    pub _IO_read_base: *mut ::core::ffi::c_char,
-    pub _IO_write_base: *mut ::core::ffi::c_char,
-    pub _IO_write_ptr: *mut ::core::ffi::c_char,
-    pub _IO_write_end: *mut ::core::ffi::c_char,
-    pub _IO_buf_base: *mut ::core::ffi::c_char,
-    pub _IO_buf_end: *mut ::core::ffi::c_char,
-    pub _IO_save_base: *mut ::core::ffi::c_char,
-    pub _IO_backup_base: *mut ::core::ffi::c_char,
-    pub _IO_save_end: *mut ::core::ffi::c_char,
-    pub _markers: *mut _IO_marker,
-    pub _chain: *mut _IO_FILE,
-    pub _fileno: ::core::ffi::c_int,
-    pub _flags2: ::core::ffi::c_int,
-    pub _old_offset: __off_t,
-    pub _cur_column: ::core::ffi::c_ushort,
-    pub _vtable_offset: ::core::ffi::c_schar,
-    pub _shortbuf: [::core::ffi::c_char; 1usize],
-    pub _lock: *mut _IO_lock_t,
-    pub _offset: __off64_t,
-    pub _codecvt: *mut _IO_codecvt,
-    pub _wide_data: *mut _IO_wide_data,
-    pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut ::core::ffi::c_void,
-    pub __pad5: usize,
-    pub _mode: ::core::ffi::c_int,
-    pub _unused2: [::core::ffi::c_char; 20usize],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_codecvt {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_marker {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _IO_wide_data {
-    _unused: [u8; 0],
+    pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/driver/result.rs
+++ b/src/driver/result.rs
@@ -171,10 +171,16 @@ pub mod device {
             #[cfg(not(any(
                 feature = "cuda-13000",
                 feature = "cuda-13010",
-                feature = "cuda-13020"
+                feature = "cuda-13020",
+                feature = "cuda-13030"
             )))]
             sys::cuDeviceGetUuid(uuid.as_mut_ptr(), dev).result()?;
-            #[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+            #[cfg(any(
+                feature = "cuda-13000",
+                feature = "cuda-13010",
+                feature = "cuda-13020",
+                feature = "cuda-13030"
+            ))]
             sys::cuDeviceGetUuid_v2(uuid.as_mut_ptr(), dev).result()?;
             id = uuid.assume_init();
         }
@@ -1246,10 +1252,16 @@ pub mod event {
             #[cfg(not(any(
                 feature = "cuda-13000",
                 feature = "cuda-13010",
-                feature = "cuda-13020"
+                feature = "cuda-13020",
+                feature = "cuda-13030"
             )))]
             sys::cuEventElapsedTime((&mut ms) as *mut _, start, end).result()?;
-            #[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+            #[cfg(any(
+                feature = "cuda-13000",
+                feature = "cuda-13010",
+                feature = "cuda-13020",
+                feature = "cuda-13030"
+            ))]
             sys::cuEventElapsedTime_v2((&mut ms) as *mut _, start, end).result()?;
         }
         Ok(ms)

--- a/src/driver/safe/unified_memory.rs
+++ b/src/driver/safe/unified_memory.rs
@@ -185,9 +185,9 @@ impl<T> UnifiedSlice<T> {
                 }
                 sys::CUmemLocation {
                     type_: sys::CUmemLocationType::CU_MEM_LOCATION_TYPE_DEVICE,
-                    #[cfg(not(feature = "cuda-13020"))]
+                    #[cfg(not(any(feature = "cuda-13020", feature = "cuda-13030")))]
                     id: self.stream.ctx.ordinal as i32,
-                    #[cfg(feature = "cuda-13020")]
+                    #[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
                     __bindgen_anon_1: sys::CUmemLocation_st__bindgen_ty_1 {
                         id: self.stream.ctx.ordinal as i32,
                     },
@@ -197,9 +197,9 @@ impl<T> UnifiedSlice<T> {
                 // > Specifying CU_MEM_LOCATION_TYPE_HOST as CUmemLocation::type will prefetch data to host memory. Applications can request prefetching memory to a specific host NUMA node by specifying CU_MEM_LOCATION_TYPE_HOST_NUMA for CUmemLocation::type and a valid host NUMA node id in CUmemLocation::id Users can also request prefetching memory to the host NUMA node closest to the current thread's CPU by specifying CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT for CUmemLocation::type.
                 sys::CUmemLocation {
                     type_: sys::CUmemLocationType::CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT,
-                    #[cfg(not(feature = "cuda-13020"))]
+                    #[cfg(not(any(feature = "cuda-13020", feature = "cuda-13030")))]
                     id: 0, // NOTE: ignored
-                    #[cfg(feature = "cuda-13020")]
+                    #[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
                     __bindgen_anon_1: sys::CUmemLocation_st__bindgen_ty_1 { id: 0 },
                 }
             }

--- a/src/driver/sys/mod.rs
+++ b/src/driver/sys/mod.rs
@@ -19,30 +19,30 @@ pub use self::CUaddress_mode_enum as CUaddress_mode;
 pub use self::CUarraySparseSubresourceType_enum as CUarraySparseSubresourceType;
 pub use self::CUarray_cubemap_face_enum as CUarray_cubemap_face;
 pub use self::CUarray_format_enum as CUarray_format;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUasyncNotificationType_enum as CUasyncNotificationType;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUatomicOperationCapability_enum as CUatomicOperationCapability;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUatomicOperation_enum as CUatomicOperation;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUcigDataType_enum as CUcigDataType;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUclusterSchedulingPolicy_enum as CUclusterSchedulingPolicy;
 pub use self::CUcomputemode_enum as CUcomputemode;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUcoredumpSettings_enum as CUcoredumpSettings;
 pub use self::CUctx_flags_enum as CUctx_flags;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUdeviceNumaConfig_enum as CUdeviceNumaConfig;
 pub use self::CUdevice_P2PAttribute_enum as CUdevice_P2PAttribute;
 pub use self::CUdevice_attribute_enum as CUdevice_attribute;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUdriverProcAddressQueryResult_enum as CUdriverProcAddressQueryResult;
 pub use self::CUdriverProcAddress_flags_enum as CUdriverProcAddress_flags;
 pub use self::CUevent_flags_enum as CUevent_flags;
 pub use self::CUevent_record_flags_enum as CUevent_record_flags;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUevent_sched_flags_enum as CUevent_sched_flags;
 pub use self::CUevent_wait_flags_enum as CUevent_wait_flags;
 pub use self::CUexecAffinityType_enum as CUexecAffinityType;
@@ -53,25 +53,27 @@ pub use self::CUflushGPUDirectRDMAWritesOptions_enum as CUflushGPUDirectRDMAWrit
 pub use self::CUflushGPUDirectRDMAWritesScope_enum as CUflushGPUDirectRDMAWritesScope;
 pub use self::CUflushGPUDirectRDMAWritesTarget_enum as CUflushGPUDirectRDMAWritesTarget;
 pub use self::CUfunc_cache_enum as CUfunc_cache;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUfunctionLoadingState_enum as CUfunctionLoadingState;
 pub use self::CUfunction_attribute_enum as CUfunction_attribute;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUgraphChildGraphNodeOwnership_enum as CUgraphChildGraphNodeOwnership;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUgraphConditionalNodeType_enum as CUgraphConditionalNodeType;
 pub use self::CUgraphDebugDot_flags_enum as CUgraphDebugDot_flags;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUgraphDependencyType_enum as CUgraphDependencyType;
 pub use self::CUgraphExecUpdateResult_enum as CUgraphExecUpdateResult;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUgraphInstantiateResult_enum as CUgraphInstantiateResult;
 pub use self::CUgraphInstantiate_flags_enum as CUgraphInstantiate_flags;
 pub use self::CUgraphMem_attribute_enum as CUgraphMem_attribute;
 pub use self::CUgraphNodeType_enum as CUgraphNodeType;
+#[cfg(any(feature = "cuda-13030"))]
+pub use self::CUgraphRecaptureStatus_enum as CUgraphRecaptureStatus;
 pub use self::CUgraphicsMapResourceFlags_enum as CUgraphicsMapResourceFlags;
 pub use self::CUgraphicsRegisterFlags_enum as CUgraphicsRegisterFlags;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUhostTaskSyncMode_enum as CUhostTaskSyncMode;
 pub use self::CUipcMem_flags_enum as CUipcMem_flags;
 pub use self::CUjitInputType_enum as CUjitInputType;
@@ -81,104 +83,110 @@ pub use self::CUjit_option_enum as CUjit_option;
 pub use self::CUjit_target_enum as CUjit_target;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070"))]
 pub use self::CUkernelNodeAttrID_enum as CUkernelNodeAttrID;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUlaunchAttributeID as CUkernelNodeAttrID;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUlaunchAttributeID as CUstreamAttrID;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUlaunchAttributeID_enum as CUlaunchAttributeID;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUlaunchAttributePortableClusterMode_enum as CUlaunchAttributePortableClusterMode;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUlaunchMemSyncDomain_enum as CUlaunchMemSyncDomain;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUlibraryOption_enum as CUlibraryOption;
 pub use self::CUlimit_enum as CUlimit;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUlogLevel_enum as CUlogLevel;
+#[cfg(any(feature = "cuda-13030"))]
+pub use self::CUlogicalEndpointFlag_enum as CUlogicalEndpointFlag;
+#[cfg(any(feature = "cuda-13030"))]
+pub use self::CUlogicalEndpointIpcHandleType_enum as CUlogicalEndpointIpcHandleType;
+#[cfg(any(feature = "cuda-13030"))]
+pub use self::CUlogicalEndpointType_enum as CUlogicalEndpointType;
 pub use self::CUmemAccess_flags_enum as CUmemAccess_flags;
 pub use self::CUmemAllocationCompType_enum as CUmemAllocationCompType;
 pub use self::CUmemAllocationGranularity_flags_enum as CUmemAllocationGranularity_flags;
 pub use self::CUmemAllocationHandleType_enum as CUmemAllocationHandleType;
 pub use self::CUmemAllocationType_enum as CUmemAllocationType;
 pub use self::CUmemAttach_flags_enum as CUmemAttach_flags;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUmemDecompressAlgorithm_enum as CUmemDecompressAlgorithm;
 pub use self::CUmemHandleType_enum as CUmemHandleType;
 pub use self::CUmemLocationType_enum as CUmemLocationType;
 pub use self::CUmemOperationType_enum as CUmemOperationType;
 pub use self::CUmemPool_attribute_enum as CUmemPool_attribute;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUmemRangeFlags_enum as CUmemRangeFlags;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUmemRangeHandleType_enum as CUmemRangeHandleType;
 pub use self::CUmem_advise_enum as CUmem_advise;
 pub use self::CUmem_range_attribute_enum as CUmem_range_attribute;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUmemcpy3DOperandType_enum as CUmemcpy3DOperandType;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUmemcpyFlags_enum as CUmemcpyFlags;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUmemcpySrcAccessOrder_enum as CUmemcpySrcAccessOrder;
 pub use self::CUmemorytype_enum as CUmemorytype;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUmoduleLoadingMode_enum as CUmoduleLoadingMode;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUmulticastGranularity_flags_enum as CUmulticastGranularity_flags;
 pub use self::CUoccupancy_flags_enum as CUoccupancy_flags;
 pub use self::CUoutput_mode_enum as CUoutput_mode;
 pub use self::CUpointer_attribute_enum as CUpointer_attribute;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUprocessState_enum as CUprocessState;
 pub use self::CUresourceViewFormat_enum as CUresourceViewFormat;
 pub use self::CUresourcetype_enum as CUresourcetype;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUsharedMemoryMode_enum as CUsharedMemoryMode;
 pub use self::CUshared_carveout_enum as CUshared_carveout;
 pub use self::CUsharedconfig_enum as CUsharedconfig;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUstreamAtomicReductionDataType_enum as CUstreamAtomicReductionDataType;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUstreamAtomicReductionOpType_enum as CUstreamAtomicReductionOpType;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070"))]
 pub use self::CUstreamAttrID_enum as CUstreamAttrID;
 pub use self::CUstreamBatchMemOpType_enum as CUstreamBatchMemOpType;
 pub use self::CUstreamCaptureMode_enum as CUstreamCaptureMode;
 pub use self::CUstreamCaptureStatus_enum as CUstreamCaptureStatus;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUstreamCigDataType_enum as CUstreamCigDataType;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUstreamMemoryBarrier_flags_enum as CUstreamMemoryBarrier_flags;
 pub use self::CUstreamUpdateCaptureDependencies_flags_enum as CUstreamUpdateCaptureDependencies_flags;
 pub use self::CUstreamWaitValue_flags_enum as CUstreamWaitValue_flags;
 pub use self::CUstreamWriteValue_flags_enum as CUstreamWriteValue_flags;
 pub use self::CUstream_flags_enum as CUstream_flags;
 pub use self::CUsynchronizationPolicy_enum as CUsynchronizationPolicy;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUtensorMapDataType_enum as CUtensorMapDataType;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUtensorMapFloatOOBfill_enum as CUtensorMapFloatOOBfill;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUtensorMapIm2ColWideMode_enum as CUtensorMapIm2ColWideMode;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUtensorMapInterleave_enum as CUtensorMapInterleave;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUtensorMapL2promotion_enum as CUtensorMapL2promotion;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUtensorMapSwizzle_enum as CUtensorMapSwizzle;
 pub use self::CUuserObjectRetain_flags_enum as CUuserObjectRetain_flags;
 pub use self::CUuserObject_flags_enum as CUuserObject_flags;
 pub const CUDA_ARRAY3D_2DARRAY: u32 = 1;
 pub const CUDA_ARRAY3D_COLOR_ATTACHMENT: u32 = 32;
 pub const CUDA_ARRAY3D_CUBEMAP: u32 = 4;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CUDA_ARRAY3D_DEFERRED_MAPPING: u32 = 128;
 pub const CUDA_ARRAY3D_DEPTH_TEXTURE: u32 = 16;
 pub const CUDA_ARRAY3D_LAYERED: u32 = 1;
 pub const CUDA_ARRAY3D_SPARSE: u32 = 64;
 pub const CUDA_ARRAY3D_SURFACE_LDST: u32 = 2;
 pub const CUDA_ARRAY3D_TEXTURE_GATHER: u32 = 8;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CUDA_ARRAY3D_VIDEO_ENCODE_DECODE: u32 = 256;
 pub const CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC: u32 = 2;
 pub const CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC: u32 = 1;
@@ -221,27 +229,29 @@ pub const CUDA_VERSION: u32 = 13000;
 pub const CUDA_VERSION: u32 = 13010;
 #[cfg(any(feature = "cuda-13020"))]
 pub const CUDA_VERSION: u32 = 13020;
+#[cfg(any(feature = "cuda-13030"))]
+pub const CUDA_VERSION: u32 = 13030;
 pub const CU_ARRAY_SPARSE_PROPERTIES_SINGLE_MIPTAIL: u32 = 1;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_COMPUTE_ACCELERATED_TARGET_BASE: u32 = 65536;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_COMPUTE_FAMILY_TARGET_BASE: u32 = 131072;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_GRAPH_COND_ASSIGN_DEFAULT: u32 = 1;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_GRAPH_KERNEL_NODE_PORT_DEFAULT: u32 = 0;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_GRAPH_KERNEL_NODE_PORT_LAUNCH_ORDER: u32 = 2;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_GRAPH_KERNEL_NODE_PORT_PROGRAMMATIC: u32 = 1;
 pub const CU_IPC_HANDLE_SIZE: u32 = 64;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_LAUNCH_KERNEL_REQUIRED_BLOCK_DIM: u32 = 1;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_LAUNCH_PARAM_BUFFER_POINTER_AS_INT: u32 = 1;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_LAUNCH_PARAM_BUFFER_SIZE_AS_INT: u32 = 2;
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_LAUNCH_PARAM_END_AS_INT: u32 = 0;
 pub const CU_MEMHOSTALLOC_DEVICEMAP: u32 = 2;
 pub const CU_MEMHOSTALLOC_PORTABLE: u32 = 1;
@@ -250,44 +260,44 @@ pub const CU_MEMHOSTREGISTER_DEVICEMAP: u32 = 2;
 pub const CU_MEMHOSTREGISTER_IOMEMORY: u32 = 4;
 pub const CU_MEMHOSTREGISTER_PORTABLE: u32 = 1;
 pub const CU_MEMHOSTREGISTER_READ_ONLY: u32 = 8;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_MEM_CREATE_USAGE_HW_DECOMPRESS: u32 = 2;
 pub const CU_MEM_CREATE_USAGE_TILE_POOL: u32 = 1;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_MEM_POOL_CREATE_USAGE_HW_DECOMPRESS: u32 = 2;
 pub const CU_PARAM_TR_DEFAULT: i32 = -1;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_TENSOR_MAP_NUM_QWORDS: u32 = 16;
 pub const CU_TRSA_OVERRIDE_FORMAT: u32 = 1;
 pub const CU_TRSF_DISABLE_TRILINEAR_OPTIMIZATION: u32 = 32;
 pub const CU_TRSF_NORMALIZED_COORDINATES: u32 = 2;
 pub const CU_TRSF_READ_AS_INTEGER: u32 = 1;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const CU_TRSF_SEAMLESS_CUBEMAP: u32 = 64;
 pub const CU_TRSF_SRGB: u32 = 16;
 pub type CUDA_ARRAY3D_DESCRIPTOR = CUDA_ARRAY3D_DESCRIPTOR_v2;
 pub type CUDA_ARRAY3D_DESCRIPTOR_v2 = CUDA_ARRAY3D_DESCRIPTOR_st;
 pub type CUDA_ARRAY_DESCRIPTOR = CUDA_ARRAY_DESCRIPTOR_v2;
 pub type CUDA_ARRAY_DESCRIPTOR_v2 = CUDA_ARRAY_DESCRIPTOR_st;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_ARRAY_MEMORY_REQUIREMENTS = CUDA_ARRAY_MEMORY_REQUIREMENTS_v1;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_ARRAY_MEMORY_REQUIREMENTS_v1 = CUDA_ARRAY_MEMORY_REQUIREMENTS_st;
 pub type CUDA_ARRAY_SPARSE_PROPERTIES = CUDA_ARRAY_SPARSE_PROPERTIES_v1;
 pub type CUDA_ARRAY_SPARSE_PROPERTIES_v1 = CUDA_ARRAY_SPARSE_PROPERTIES_st;
 #[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010"))]
 pub type CUDA_BATCH_MEM_OP_NODE_PARAMS = CUDA_BATCH_MEM_OP_NODE_PARAMS_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_BATCH_MEM_OP_NODE_PARAMS = CUDA_BATCH_MEM_OP_NODE_PARAMS_v1;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_BATCH_MEM_OP_NODE_PARAMS_v1 = CUDA_BATCH_MEM_OP_NODE_PARAMS_v1_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_BATCH_MEM_OP_NODE_PARAMS_v2 = CUDA_BATCH_MEM_OP_NODE_PARAMS_v2_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_CHILD_GRAPH_NODE_PARAMS = CUDA_CHILD_GRAPH_NODE_PARAMS_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_EVENT_RECORD_NODE_PARAMS = CUDA_EVENT_RECORD_NODE_PARAMS_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_EVENT_WAIT_NODE_PARAMS = CUDA_EVENT_WAIT_NODE_PARAMS_st;
 pub type CUDA_EXTERNAL_MEMORY_BUFFER_DESC = CUDA_EXTERNAL_MEMORY_BUFFER_DESC_v1;
 pub type CUDA_EXTERNAL_MEMORY_BUFFER_DESC_v1 = CUDA_EXTERNAL_MEMORY_BUFFER_DESC_st;
@@ -303,54 +313,54 @@ pub type CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS = CUDA_EXTERNAL_SEMAPHORE_WAIT_PARA
 pub type CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_v1 = CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st;
 pub type CUDA_EXT_SEM_SIGNAL_NODE_PARAMS = CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v1;
 pub type CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v1 = CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v2 = CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v2_st;
 pub type CUDA_EXT_SEM_WAIT_NODE_PARAMS = CUDA_EXT_SEM_WAIT_NODE_PARAMS_v1;
 pub type CUDA_EXT_SEM_WAIT_NODE_PARAMS_v1 = CUDA_EXT_SEM_WAIT_NODE_PARAMS_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2 = CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_GRAPH_INSTANTIATE_PARAMS = CUDA_GRAPH_INSTANTIATE_PARAMS_st;
 pub type CUDA_HOST_NODE_PARAMS = CUDA_HOST_NODE_PARAMS_v1;
 pub type CUDA_HOST_NODE_PARAMS_v1 = CUDA_HOST_NODE_PARAMS_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_HOST_NODE_PARAMS_v2 = CUDA_HOST_NODE_PARAMS_v2_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080"))]
 pub type CUDA_KERNEL_NODE_PARAMS = CUDA_KERNEL_NODE_PARAMS_v1;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_KERNEL_NODE_PARAMS = CUDA_KERNEL_NODE_PARAMS_v2;
 pub type CUDA_KERNEL_NODE_PARAMS_v1 = CUDA_KERNEL_NODE_PARAMS_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_KERNEL_NODE_PARAMS_v2 = CUDA_KERNEL_NODE_PARAMS_v2_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_KERNEL_NODE_PARAMS_v3 = CUDA_KERNEL_NODE_PARAMS_v3_st;
 pub type CUDA_LAUNCH_PARAMS = CUDA_LAUNCH_PARAMS_v1;
 pub type CUDA_LAUNCH_PARAMS_v1 = CUDA_LAUNCH_PARAMS_st;
 pub type CUDA_MEMCPY2D = CUDA_MEMCPY2D_v2;
 pub type CUDA_MEMCPY2D_v2 = CUDA_MEMCPY2D_st;
 pub type CUDA_MEMCPY3D = CUDA_MEMCPY3D_v2;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_MEMCPY3D_BATCH_OP = CUDA_MEMCPY3D_BATCH_OP_v1;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_MEMCPY3D_BATCH_OP_v1 = CUDA_MEMCPY3D_BATCH_OP_st;
 pub type CUDA_MEMCPY3D_PEER = CUDA_MEMCPY3D_PEER_v1;
 pub type CUDA_MEMCPY3D_PEER_v1 = CUDA_MEMCPY3D_PEER_st;
 pub type CUDA_MEMCPY3D_v2 = CUDA_MEMCPY3D_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_MEMCPY_NODE_PARAMS = CUDA_MEMCPY_NODE_PARAMS_st;
 pub type CUDA_MEMSET_NODE_PARAMS = CUDA_MEMSET_NODE_PARAMS_v1;
 pub type CUDA_MEMSET_NODE_PARAMS_v1 = CUDA_MEMSET_NODE_PARAMS_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_MEMSET_NODE_PARAMS_v2 = CUDA_MEMSET_NODE_PARAMS_v2_st;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010"))]
 pub type CUDA_MEM_ALLOC_NODE_PARAMS = CUDA_MEM_ALLOC_NODE_PARAMS_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_MEM_ALLOC_NODE_PARAMS = CUDA_MEM_ALLOC_NODE_PARAMS_v1;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_MEM_ALLOC_NODE_PARAMS_v1 = CUDA_MEM_ALLOC_NODE_PARAMS_v1_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_MEM_ALLOC_NODE_PARAMS_v2 = CUDA_MEM_ALLOC_NODE_PARAMS_v2_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUDA_MEM_FREE_NODE_PARAMS = CUDA_MEM_FREE_NODE_PARAMS_st;
 pub type CUDA_POINTER_ATTRIBUTE_P2P_TOKENS = CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_v1;
 pub type CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_v1 = CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st;
@@ -360,49 +370,49 @@ pub type CUDA_RESOURCE_VIEW_DESC = CUDA_RESOURCE_VIEW_DESC_v1;
 pub type CUDA_RESOURCE_VIEW_DESC_v1 = CUDA_RESOURCE_VIEW_DESC_st;
 pub type CUDA_TEXTURE_DESC = CUDA_TEXTURE_DESC_v1;
 pub type CUDA_TEXTURE_DESC_v1 = CUDA_TEXTURE_DESC_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CU_DEV_SM_RESOURCE_GROUP_PARAMS = CU_DEV_SM_RESOURCE_GROUP_PARAMS_st;
 pub type CUaccessPolicyWindow = CUaccessPolicyWindow_v1;
 pub type CUaccessPolicyWindow_v1 = CUaccessPolicyWindow_st;
 pub type CUarray = *mut CUarray_st;
 pub type CUarrayMapInfo = CUarrayMapInfo_v1;
 pub type CUarrayMapInfo_v1 = CUarrayMapInfo_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUasyncCallback = ::core::option::Option<unsafe extern "C" fn(info: *mut CUasyncNotificationInfo, userData: *mut ::core::ffi::c_void, callback: CUasyncCallbackHandle)>;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUasyncCallbackHandle = *mut CUasyncCallbackEntry_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUasyncNotificationInfo = CUasyncNotificationInfo_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUcheckpointCheckpointArgs = CUcheckpointCheckpointArgs_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUcheckpointGpuPair = CUcheckpointGpuPair_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUcheckpointLockArgs = CUcheckpointLockArgs_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUcheckpointRestoreArgs = CUcheckpointRestoreArgs_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUcheckpointUnlockArgs = CUcheckpointUnlockArgs_st;
 pub type CUcontext = *mut CUctx_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUcoredumpCallbackHandle = *mut CUcoredumpCallbackEntry_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUcoredumpStatusCallback = ::core::option::Option<unsafe extern "C" fn(userData: *mut ::core::ffi::c_void, pid: ::core::ffi::c_int, dev: CUdevice)>;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUctxCigParam = CUctxCigParam_st;
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUctxCreateParams = CUctxCreateParams_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUdevResource = CUdevResource_v1;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUdevResourceDesc = *mut CUdevResourceDesc_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUdevResource_v1 = CUdevResource_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUdevSmResource = CUdevSmResource_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUdevWorkqueueConfigResource = CUdevWorkqueueConfigResource_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUdevWorkqueueResource = CUdevWorkqueueResource_st;
 pub type CUdevice = CUdevice_v1;
 pub type CUdevice_v1 = ::core::ffi::c_int;
@@ -415,71 +425,79 @@ pub type CUexecAffinityParam = CUexecAffinityParam_v1;
 pub type CUexecAffinityParam_v1 = CUexecAffinityParam_st;
 pub type CUexecAffinitySmCount = CUexecAffinitySmCount_v1;
 pub type CUexecAffinitySmCount_v1 = CUexecAffinitySmCount_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUextent3D = CUextent3D_v1;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUextent3D_v1 = CUextent3D_st;
 pub type CUexternalMemory = *mut CUextMemory_st;
 pub type CUexternalSemaphore = *mut CUextSemaphore_st;
 pub type CUfunction = *mut CUfunc_st;
 pub type CUgraph = *mut CUgraph_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUgraphConditionalHandle = cuuint64_t;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUgraphDeviceNode = *mut CUgraphDeviceUpdatableNode_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUgraphEdgeData = CUgraphEdgeData_st;
 pub type CUgraphExec = *mut CUgraphExec_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUgraphExecUpdateResultInfo = CUgraphExecUpdateResultInfo_v1;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUgraphExecUpdateResultInfo_v1 = CUgraphExecUpdateResultInfo_st;
 pub type CUgraphNode = *mut CUgraphNode_st;
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUgraphNodeParams = CUgraphNodeParams_st;
+#[cfg(any(feature = "cuda-13030"))]
+pub type CUgraphRecaptureCallback = ::core::option::Option<unsafe extern "C" fn(data: *mut ::core::ffi::c_void, node: CUgraphNode, originalParams: *const CUgraphNodeParams, recaptureParams: *const CUgraphNodeParams, status: CUgraphRecaptureStatus) -> CUresult>;
 pub type CUgraphicsResource = *mut CUgraphicsResource_st;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUgreenCtx = *mut CUgreenCtx_st;
 pub type CUhostFn = ::core::option::Option<unsafe extern "C" fn(userData: *mut ::core::ffi::c_void)>;
 pub type CUipcEventHandle = CUipcEventHandle_v1;
 pub type CUipcEventHandle_v1 = CUipcEventHandle_st;
 pub type CUipcMemHandle = CUipcMemHandle_v1;
 pub type CUipcMemHandle_v1 = CUipcMemHandle_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUkernel = *mut CUkern_st;
 pub type CUkernelNodeAttrValue = CUkernelNodeAttrValue_v1;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070"))]
 pub type CUkernelNodeAttrValue_v1 = CUkernelNodeAttrValue_union;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUkernelNodeAttrValue_v1 = CUlaunchAttributeValue;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUlaunchAttribute = CUlaunchAttribute_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUlaunchAttributeValue = CUlaunchAttributeValue_union;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUlaunchConfig = CUlaunchConfig_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUlaunchMemSyncDomainMap = CUlaunchMemSyncDomainMap_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUlibrary = *mut CUlib_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUlibraryHostUniversalFunctionAndDataTable = CUlibraryHostUniversalFunctionAndDataTable_st;
 pub type CUlinkState = *mut CUlinkState_st;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUlogIterator = ::core::ffi::c_uint;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+pub type CUlogicalEndpointFabricHandle = CUlogicalEndpointFabricHandle_st;
+#[cfg(any(feature = "cuda-13030"))]
+pub type CUlogicalEndpointId = cuuint32_t;
+#[cfg(any(feature = "cuda-13030"))]
+pub type CUlogicalEndpointProp = CUlogicalEndpointProp_struct;
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUlogsCallback = ::core::option::Option<unsafe extern "C" fn(data: *mut ::core::ffi::c_void, logLevel: CUlogLevel, message: *mut ::core::ffi::c_char, length: usize)>;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUlogsCallbackHandle = *mut CUlogsCallbackEntry_st;
 pub type CUmemAccessDesc = CUmemAccessDesc_v1;
 pub type CUmemAccessDesc_v1 = CUmemAccessDesc_st;
 pub type CUmemAllocationProp = CUmemAllocationProp_v1;
 pub type CUmemAllocationProp_v1 = CUmemAllocationProp_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUmemDecompressParams = CUmemDecompressParams_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUmemFabricHandle = CUmemFabricHandle_v1;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUmemFabricHandle_v1 = CUmemFabricHandle_st;
 pub type CUmemGenericAllocationHandle = CUmemGenericAllocationHandle_v1;
 pub type CUmemGenericAllocationHandle_v1 = ::core::ffi::c_ulonglong;
@@ -489,43 +507,43 @@ pub type CUmemPoolProps = CUmemPoolProps_v1;
 pub type CUmemPoolProps_v1 = CUmemPoolProps_st;
 pub type CUmemPoolPtrExportData = CUmemPoolPtrExportData_v1;
 pub type CUmemPoolPtrExportData_v1 = CUmemPoolPtrExportData_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUmemcpy3DOperand = CUmemcpy3DOperand_v1;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUmemcpy3DOperand_v1 = CUmemcpy3DOperand_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUmemcpyAttributes = CUmemcpyAttributes_v1;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUmemcpyAttributes_v1 = CUmemcpyAttributes_st;
 pub type CUmemoryPool = *mut CUmemPoolHandle_st;
 pub type CUmipmappedArray = *mut CUmipmappedArray_st;
 pub type CUmodule = *mut CUmod_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUmulticastObjectProp = CUmulticastObjectProp_v1;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUmulticastObjectProp_v1 = CUmulticastObjectProp_st;
 pub type CUoccupancyB2DSize = ::core::option::Option<unsafe extern "C" fn(blockSize: ::core::ffi::c_int) -> usize>;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUoffset3D = CUoffset3D_v1;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUoffset3D_v1 = CUoffset3D_st;
 pub type CUstream = *mut CUstream_st;
 pub type CUstreamAttrValue = CUstreamAttrValue_v1;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070"))]
 pub type CUstreamAttrValue_v1 = CUstreamAttrValue_union;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUstreamAttrValue_v1 = CUlaunchAttributeValue;
 pub type CUstreamBatchMemOpParams = CUstreamBatchMemOpParams_v1;
 pub type CUstreamBatchMemOpParams_v1 = CUstreamBatchMemOpParams_union;
 pub type CUstreamCallback = ::core::option::Option<unsafe extern "C" fn(hStream: CUstream, status: CUresult, userData: *mut ::core::ffi::c_void)>;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUstreamCigCaptureParams = CUstreamCigCaptureParams_st;
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUstreamCigParam = CUstreamCigParam_st;
 pub type CUsurfObject = CUsurfObject_v1;
 pub type CUsurfObject_v1 = ::core::ffi::c_ulonglong;
 pub type CUsurfref = *mut CUsurfref_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type CUtensorMap = CUtensorMap_st;
 pub type CUtexObject = CUtexObject_v1;
 pub type CUtexObject_v1 = ::core::ffi::c_ulonglong;
@@ -571,6 +589,23 @@ pub enum CUCoredumpGenerationFlags {
     CU_COREDUMP_SKIP_ABORT = 16,
     CU_COREDUMP_SKIP_CONSTBANK_MEMORY = 32,
     CU_COREDUMP_GZIP_COMPRESS = 64,
+    CU_COREDUMP_LIGHTWEIGHT_FLAGS = 47,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUCoredumpGenerationFlags {
+    CU_COREDUMP_DEFAULT_FLAGS = 0,
+    CU_COREDUMP_SKIP_NONRELOCATED_ELF_IMAGES = 1,
+    CU_COREDUMP_SKIP_GLOBAL_MEMORY = 2,
+    CU_COREDUMP_SKIP_SHARED_MEMORY = 4,
+    CU_COREDUMP_SKIP_LOCAL_MEMORY = 8,
+    CU_COREDUMP_SKIP_ABORT = 16,
+    CU_COREDUMP_SKIP_CONSTBANK_MEMORY = 32,
+    CU_COREDUMP_GZIP_COMPRESS = 64,
+    CU_COREDUMP_FAULTED_CONTEXTS_ONLY = 128,
+    CU_COREDUMP_NO_ERRBAR_AT_EXIT = 1073741824,
+    CU_COREDUMP_LOG_ONLY = -2147483648,
     CU_COREDUMP_LIGHTWEIGHT_FLAGS = 47,
 }
 #[repr(u32)]
@@ -783,7 +818,7 @@ pub enum CUarray_format_enum {
     CU_AD_FORMAT_UNORM_INT_101010_2 = 80,
     CU_AD_FORMAT_MAX = 2147483647,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUarray_format_enum {
@@ -854,13 +889,13 @@ pub enum CUarray_format_enum {
     CU_AD_FORMAT_UINT16_PLANAR_444 = 94,
     CU_AD_FORMAT_MAX = 2147483647,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUasyncNotificationType_enum {
     CU_ASYNC_NOTIFICATION_TYPE_OVER_BUDGET = 1,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUatomicOperationCapability_enum {
@@ -872,7 +907,7 @@ pub enum CUatomicOperationCapability_enum {
     CU_ATOMIC_CAPABILITY_SCALAR_128 = 32,
     CU_ATOMIC_CAPABILITY_VECTOR_32x4 = 64,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUatomicOperation_enum {
@@ -897,14 +932,14 @@ pub enum CUatomicOperation_enum {
 pub enum CUcigDataType_enum {
     CIG_DATA_TYPE_D3D12_COMMAND_QUEUE = 1,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUcigDataType_enum {
     CIG_DATA_TYPE_D3D12_COMMAND_QUEUE = 1,
     CIG_DATA_TYPE_NV_BLOB = 2,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUclusterSchedulingPolicy_enum {
@@ -931,7 +966,7 @@ pub enum CUcoredumpSettings_enum {
     CU_COREDUMP_PIPE = 6,
     CU_COREDUMP_MAX = 7,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUcoredumpSettings_enum {
@@ -957,7 +992,7 @@ pub enum CUctx_flags_enum {
     CU_CTX_LMEM_RESIZE_TO_MAX = 16,
     CU_CTX_FLAGS_MASK = 31,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUctx_flags_enum {
@@ -980,7 +1015,7 @@ pub enum CUdevResourceType {
     CU_DEV_RESOURCE_TYPE_INVALID = 0,
     CU_DEV_RESOURCE_TYPE_SM = 1,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUdevResourceType {
@@ -989,14 +1024,14 @@ pub enum CUdevResourceType {
     CU_DEV_RESOURCE_TYPE_WORKQUEUE_CONFIG = 1000,
     CU_DEV_RESOURCE_TYPE_WORKQUEUE = 10000,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUdevSmResourceGroup_flags {
     CU_DEV_SM_RESOURCE_GROUP_DEFAULT = 0,
     CU_DEV_SM_RESOURCE_GROUP_BACKFILL = 1,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUdevSmResourceSplitByCount_flags {
@@ -1010,14 +1045,14 @@ pub enum CUdevSmResourceSplit_flags {
     CU_DEV_SM_RESOURCE_SPLIT_IGNORE_SM_COSCHEDULING = 1,
     CU_DEV_SM_RESOURCE_SPLIT_MAX_POTENTIAL_CLUSTER_SIZE = 2,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUdevWorkqueueConfigScope {
     CU_WORKQUEUE_SCOPE_DEVICE_CTX = 0,
     CU_WORKQUEUE_SCOPE_GREEN_CTX_BALANCED = 1,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUdeviceNumaConfig_enum {
@@ -1033,7 +1068,7 @@ pub enum CUdevice_P2PAttribute_enum {
     CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED = 3,
     CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED = 4,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUdevice_P2PAttribute_enum {
@@ -2843,7 +2878,167 @@ pub enum CUdevice_attribute_enum {
     CU_DEVICE_ATTRIBUTE_ATOMIC_REDUCTION_SUPPORTED = 148,
     CU_DEVICE_ATTRIBUTE_MAX = 149,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUdevice_attribute_enum {
+    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1,
+    CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 2,
+    CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y = 3,
+    CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z = 4,
+    CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X = 5,
+    CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y = 6,
+    CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z = 7,
+    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8,
+    CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY = 9,
+    CU_DEVICE_ATTRIBUTE_WARP_SIZE = 10,
+    CU_DEVICE_ATTRIBUTE_MAX_PITCH = 11,
+    CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK = 12,
+    CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13,
+    CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT = 14,
+    CU_DEVICE_ATTRIBUTE_GPU_OVERLAP = 15,
+    CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 16,
+    CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT = 17,
+    CU_DEVICE_ATTRIBUTE_INTEGRATED = 18,
+    CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY = 19,
+    CU_DEVICE_ATTRIBUTE_COMPUTE_MODE = 20,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH = 21,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH = 22,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT = 23,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH = 24,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT = 25,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH = 26,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH = 27,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT = 28,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS = 29,
+    CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT = 30,
+    CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS = 31,
+    CU_DEVICE_ATTRIBUTE_ECC_ENABLED = 32,
+    CU_DEVICE_ATTRIBUTE_PCI_BUS_ID = 33,
+    CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID = 34,
+    CU_DEVICE_ATTRIBUTE_TCC_DRIVER = 35,
+    CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36,
+    CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH = 37,
+    CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38,
+    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39,
+    CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT = 40,
+    CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING = 41,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH = 42,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS = 43,
+    CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER = 44,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH = 45,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT = 46,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE = 47,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE = 48,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE = 49,
+    CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID = 50,
+    CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT = 51,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH = 52,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH = 53,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS = 54,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH = 55,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH = 56,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT = 57,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH = 58,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT = 59,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH = 60,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH = 61,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS = 62,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH = 63,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT = 64,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS = 65,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH = 66,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH = 67,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS = 68,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH = 69,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH = 70,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT = 71,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH = 72,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH = 73,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT = 74,
+    CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR = 75,
+    CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR = 76,
+    CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH = 77,
+    CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED = 78,
+    CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED = 79,
+    CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED = 80,
+    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR = 81,
+    CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR = 82,
+    CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY = 83,
+    CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD = 84,
+    CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID = 85,
+    CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED = 86,
+    CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO = 87,
+    CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS = 88,
+    CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS = 89,
+    CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED = 90,
+    CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM = 91,
+    CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS_V1 = 92,
+    CU_DEVICE_ATTRIBUTE_CAN_USE_64_BIT_STREAM_MEM_OPS_V1 = 93,
+    CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR_V1 = 94,
+    CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH = 95,
+    CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH = 96,
+    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN = 97,
+    CU_DEVICE_ATTRIBUTE_CAN_FLUSH_REMOTE_WRITES = 98,
+    CU_DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED = 99,
+    CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES = 100,
+    CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST = 101,
+    CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED = 102,
+    CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR_SUPPORTED = 103,
+    CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_HANDLE_SUPPORTED = 104,
+    CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_KMT_HANDLE_SUPPORTED = 105,
+    CU_DEVICE_ATTRIBUTE_MAX_BLOCKS_PER_MULTIPROCESSOR = 106,
+    CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED = 107,
+    CU_DEVICE_ATTRIBUTE_MAX_PERSISTING_L2_CACHE_SIZE = 108,
+    CU_DEVICE_ATTRIBUTE_MAX_ACCESS_POLICY_WINDOW_SIZE = 109,
+    CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED = 110,
+    CU_DEVICE_ATTRIBUTE_RESERVED_SHARED_MEMORY_PER_BLOCK = 111,
+    CU_DEVICE_ATTRIBUTE_SPARSE_CUDA_ARRAY_SUPPORTED = 112,
+    CU_DEVICE_ATTRIBUTE_READ_ONLY_HOST_REGISTER_SUPPORTED = 113,
+    CU_DEVICE_ATTRIBUTE_TIMELINE_SEMAPHORE_INTEROP_SUPPORTED = 114,
+    CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED = 115,
+    CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED = 116,
+    CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_FLUSH_WRITES_OPTIONS = 117,
+    CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WRITES_ORDERING = 118,
+    CU_DEVICE_ATTRIBUTE_MEMPOOL_SUPPORTED_HANDLE_TYPES = 119,
+    CU_DEVICE_ATTRIBUTE_CLUSTER_LAUNCH = 120,
+    CU_DEVICE_ATTRIBUTE_DEFERRED_MAPPING_CUDA_ARRAY_SUPPORTED = 121,
+    CU_DEVICE_ATTRIBUTE_CAN_USE_64_BIT_STREAM_MEM_OPS = 122,
+    CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR = 123,
+    CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED = 124,
+    CU_DEVICE_ATTRIBUTE_IPC_EVENT_SUPPORTED = 125,
+    CU_DEVICE_ATTRIBUTE_MEM_SYNC_DOMAIN_COUNT = 126,
+    CU_DEVICE_ATTRIBUTE_TENSOR_MAP_ACCESS_SUPPORTED = 127,
+    CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED = 128,
+    CU_DEVICE_ATTRIBUTE_UNIFIED_FUNCTION_POINTERS = 129,
+    CU_DEVICE_ATTRIBUTE_NUMA_CONFIG = 130,
+    CU_DEVICE_ATTRIBUTE_NUMA_ID = 131,
+    CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED = 132,
+    CU_DEVICE_ATTRIBUTE_MPS_ENABLED = 133,
+    CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID = 134,
+    CU_DEVICE_ATTRIBUTE_D3D12_CIG_SUPPORTED = 135,
+    CU_DEVICE_ATTRIBUTE_MEM_DECOMPRESS_ALGORITHM_MASK = 136,
+    CU_DEVICE_ATTRIBUTE_MEM_DECOMPRESS_MAXIMUM_LENGTH = 137,
+    CU_DEVICE_ATTRIBUTE_VULKAN_CIG_SUPPORTED = 138,
+    CU_DEVICE_ATTRIBUTE_GPU_PCI_DEVICE_ID = 139,
+    CU_DEVICE_ATTRIBUTE_GPU_PCI_SUBSYSTEM_ID = 140,
+    CU_DEVICE_ATTRIBUTE_HOST_NUMA_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED = 141,
+    CU_DEVICE_ATTRIBUTE_HOST_NUMA_MEMORY_POOLS_SUPPORTED = 142,
+    CU_DEVICE_ATTRIBUTE_HOST_NUMA_MULTINODE_IPC_SUPPORTED = 143,
+    CU_DEVICE_ATTRIBUTE_HOST_MEMORY_POOLS_SUPPORTED = 144,
+    CU_DEVICE_ATTRIBUTE_HOST_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED = 145,
+    CU_DEVICE_ATTRIBUTE_HOST_ALLOC_DMA_BUF_SUPPORTED = 146,
+    CU_DEVICE_ATTRIBUTE_ONLY_PARTIAL_HOST_NATIVE_ATOMIC_SUPPORTED = 147,
+    CU_DEVICE_ATTRIBUTE_ATOMIC_REDUCTION_SUPPORTED = 148,
+    CU_DEVICE_ATTRIBUTE_D3D12_CIG_STREAMS_SUPPORTED = 151,
+    CU_DEVICE_ATTRIBUTE_DMA_BUF_MMAP_SUPPORTED = 152,
+    CU_DEVICE_ATTRIBUTE_LOGICAL_ENDPOINT_UNICAST_SUPPORTED = 153,
+    CU_DEVICE_ATTRIBUTE_LOGICAL_ENDPOINT_MULTICAST_SUPPORTED = 154,
+    CU_DEVICE_ATTRIBUTE_LOGICAL_ENDPOINT_COUNTED_OPS_SUPPORTED = 155,
+    CU_DEVICE_ATTRIBUTE_LOGICAL_ENDPOINT_UNICAST_ACCESS_ON_OWNER_DEVICE_SUPPORTED = 156,
+    CU_DEVICE_ATTRIBUTE_MAX = 157,
+}
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUdriverProcAddressQueryResult_enum {
@@ -2872,7 +3067,7 @@ pub enum CUevent_record_flags_enum {
     CU_EVENT_RECORD_DEFAULT = 0,
     CU_EVENT_RECORD_EXTERNAL = 1,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUevent_sched_flags_enum {
@@ -2906,7 +3101,7 @@ pub enum CUexternalMemoryHandleType_enum {
     CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE_KMT = 7,
     CU_EXTERNAL_MEMORY_HANDLE_TYPE_NVSCIBUF = 8,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUexternalMemoryHandleType_enum {
@@ -2965,7 +3160,7 @@ pub enum CUfunc_cache_enum {
     CU_FUNC_CACHE_PREFER_L1 = 2,
     CU_FUNC_CACHE_PREFER_EQUAL = 3,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUfunctionLoadingState_enum {
@@ -3011,6 +3206,29 @@ pub enum CUfunction_attribute_enum {
     CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE = 15,
     CU_FUNC_ATTRIBUTE_MAX = 16,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUfunction_attribute_enum {
+    CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 0,
+    CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES = 1,
+    CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES = 2,
+    CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES = 3,
+    CU_FUNC_ATTRIBUTE_NUM_REGS = 4,
+    CU_FUNC_ATTRIBUTE_PTX_VERSION = 5,
+    CU_FUNC_ATTRIBUTE_BINARY_VERSION = 6,
+    CU_FUNC_ATTRIBUTE_CACHE_MODE_CA = 7,
+    CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES = 8,
+    CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT = 9,
+    CU_FUNC_ATTRIBUTE_CLUSTER_SIZE_MUST_BE_SET = 10,
+    CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_WIDTH = 11,
+    CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_HEIGHT = 12,
+    CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_DEPTH = 13,
+    CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED = 14,
+    CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE = 15,
+    CU_FUNC_ATTRIBUTE_DEVICE_NODE_UPDATE_SUPPORTED = 16,
+    CU_FUNC_ATTRIBUTE_MAX = 17,
+}
 #[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -3018,7 +3236,7 @@ pub enum CUgraphChildGraphNodeOwnership_enum {
     CU_GRAPH_CHILD_GRAPH_OWNERSHIP_CLONE = 0,
     CU_GRAPH_CHILD_GRAPH_OWNERSHIP_MOVE = 1,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUgraphChildGraphNodeOwnership_enum {
@@ -3033,7 +3251,7 @@ pub enum CUgraphConditionalNodeType_enum {
     CU_GRAPH_COND_TYPE_IF = 0,
     CU_GRAPH_COND_TYPE_WHILE = 1,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUgraphConditionalNodeType_enum {
@@ -3098,7 +3316,7 @@ pub enum CUgraphDebugDot_flags_enum {
     CU_GRAPH_DEBUG_DOT_FLAGS_BATCH_MEM_OP_NODE_PARAMS = 8192,
     CU_GRAPH_DEBUG_DOT_FLAGS_EXTRA_TOPO_INFO = 16384,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUgraphDebugDot_flags_enum {
@@ -3119,7 +3337,7 @@ pub enum CUgraphDebugDot_flags_enum {
     CU_GRAPH_DEBUG_DOT_FLAGS_EXTRA_TOPO_INFO = 16384,
     CU_GRAPH_DEBUG_DOT_FLAGS_CONDITIONAL_NODE_PARAMS = 32768,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUgraphDependencyType_enum {
@@ -3139,7 +3357,7 @@ pub enum CUgraphExecUpdateResult_enum {
     CU_GRAPH_EXEC_UPDATE_ERROR_NOT_SUPPORTED = 6,
     CU_GRAPH_EXEC_UPDATE_ERROR_UNSUPPORTED_FUNCTION_CHANGE = 7,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUgraphExecUpdateResult_enum {
@@ -3163,7 +3381,7 @@ pub enum CUgraphInstantiateResult_enum {
     CUDA_GRAPH_INSTANTIATE_NODE_OPERATION_NOT_SUPPORTED = 3,
     CUDA_GRAPH_INSTANTIATE_MULTIPLE_CTXS_NOT_SUPPORTED = 4,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUgraphInstantiateResult_enum {
@@ -3187,7 +3405,7 @@ pub enum CUgraphInstantiate_flags_enum {
     CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH = 1,
     CUDA_GRAPH_INSTANTIATE_FLAG_USE_NODE_PRIORITY = 8,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUgraphInstantiate_flags_enum {
@@ -3258,6 +3476,34 @@ pub enum CUgraphNodeType_enum {
     CU_GRAPH_NODE_TYPE_BATCH_MEM_OP = 12,
     CU_GRAPH_NODE_TYPE_CONDITIONAL = 13,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUgraphNodeType_enum {
+    CU_GRAPH_NODE_TYPE_KERNEL = 0,
+    CU_GRAPH_NODE_TYPE_MEMCPY = 1,
+    CU_GRAPH_NODE_TYPE_MEMSET = 2,
+    CU_GRAPH_NODE_TYPE_HOST = 3,
+    CU_GRAPH_NODE_TYPE_GRAPH = 4,
+    CU_GRAPH_NODE_TYPE_EMPTY = 5,
+    CU_GRAPH_NODE_TYPE_WAIT_EVENT = 6,
+    CU_GRAPH_NODE_TYPE_EVENT_RECORD = 7,
+    CU_GRAPH_NODE_TYPE_EXT_SEMAS_SIGNAL = 8,
+    CU_GRAPH_NODE_TYPE_EXT_SEMAS_WAIT = 9,
+    CU_GRAPH_NODE_TYPE_MEM_ALLOC = 10,
+    CU_GRAPH_NODE_TYPE_MEM_FREE = 11,
+    CU_GRAPH_NODE_TYPE_BATCH_MEM_OP = 12,
+    CU_GRAPH_NODE_TYPE_CONDITIONAL = 13,
+    CU_GRAPH_NODE_TYPE_RESERVED_16 = 16,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUgraphRecaptureStatus_enum {
+    CU_GRAPH_RECAPTURE_ELIGIBLE_FOR_UPDATE = 0,
+    CU_GRAPH_RECAPTURE_INELIGIBLE_FOR_UPDATE = 1,
+    CU_GRAPH_RECAPTURE_ERROR = 2,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUgraphicsMapResourceFlags_enum {
@@ -3280,7 +3526,14 @@ pub enum CUgraphicsRegisterFlags_enum {
 pub enum CUgreenCtxCreate_flags {
     CU_GREEN_CTX_DEFAULT_STREAM = 1,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUgreenCtxCreate_flags {
+    CU_GREEN_CTX_NONE = 0,
+    CU_GREEN_CTX_DEFAULT_STREAM = 1,
+}
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUhostTaskSyncMode_enum {
@@ -3539,7 +3792,7 @@ pub enum CUjit_option_enum {
     CU_JIT_SPLIT_COMPILE = 34,
     CU_JIT_NUM_OPTIONS = 35,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUjit_option_enum {
@@ -3744,7 +3997,7 @@ pub enum CUjit_target_enum {
     CU_TARGET_COMPUTE_120F = 131192,
     CU_TARGET_COMPUTE_121F = 131193,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUjit_target_enum {
@@ -3923,7 +4176,7 @@ pub enum CUlaunchAttributeID_enum {
     CU_LAUNCH_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT = 14,
     CU_LAUNCH_ATTRIBUTE_NVLINK_UTIL_CENTRIC_SCHEDULING = 16,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUlaunchAttributeID_enum {
@@ -3946,7 +4199,7 @@ pub enum CUlaunchAttributeID_enum {
     CU_LAUNCH_ATTRIBUTE_PORTABLE_CLUSTER_SIZE_MODE = 17,
     CU_LAUNCH_ATTRIBUTE_SHARED_MEMORY_MODE = 18,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUlaunchAttributePortableClusterMode_enum {
@@ -3954,14 +4207,14 @@ pub enum CUlaunchAttributePortableClusterMode_enum {
     CU_LAUNCH_PORTABLE_CLUSTER_MODE_REQUIRE_PORTABLE = 1,
     CU_LAUNCH_PORTABLE_CLUSTER_MODE_ALLOW_NON_PORTABLE = 2,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUlaunchMemSyncDomain_enum {
     CU_LAUNCH_MEM_SYNC_DOMAIN_DEFAULT = 0,
     CU_LAUNCH_MEM_SYNC_DOMAIN_REMOTE = 1,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUlibraryOption_enum {
@@ -3982,7 +4235,7 @@ pub enum CUlimit_enum {
     CU_LIMIT_PERSISTING_L2_CACHE_SIZE = 6,
     CU_LIMIT_MAX = 7,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUlimit_enum {
@@ -3998,12 +4251,34 @@ pub enum CUlimit_enum {
     CU_LIMIT_CIG_SHMEM_FALLBACK_ENABLED = 9,
     CU_LIMIT_MAX = 10,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUlogLevel_enum {
     CU_LOG_LEVEL_ERROR = 0,
     CU_LOG_LEVEL_WARNING = 1,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUlogicalEndpointFlag_enum {
+    CU_LOGICAL_ENDPOINT_FLAG_NONE = 0,
+    CU_LOGICAL_ENDPOINT_FLAG_COUNTED_OPS = 1,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUlogicalEndpointIpcHandleType_enum {
+    CU_LOGICAL_ENDPOINT_IPC_HANDLE_TYPE_NONE = 0,
+    CU_LOGICAL_ENDPOINT_IPC_HANDLE_TYPE_FABRIC = 1,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum CUlogicalEndpointType_enum {
+    CU_LOGICAL_ENDPOINT_TYPE_INVALID = 0,
+    CU_LOGICAL_ENDPOINT_TYPE_UNICAST = 1,
+    CU_LOGICAL_ENDPOINT_TYPE_MULTICAST = 2,
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -4033,7 +4308,7 @@ pub enum CUmemAllocationType_enum {
     CU_MEM_ALLOCATION_TYPE_PINNED = 1,
     CU_MEM_ALLOCATION_TYPE_MAX = 2147483647,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmemAllocationType_enum {
@@ -4057,7 +4332,7 @@ pub enum CUmemDecompressAlgorithm_enum {
     CU_MEM_DECOMPRESS_ALGORITHM_DEFLATE = 1,
     CU_MEM_DECOMPRESS_ALGORITHM_SNAPPY = 2,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmemDecompressAlgorithm_enum {
@@ -4090,7 +4365,7 @@ pub enum CUmemLocationType_enum {
     CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT = 4,
     CU_MEM_LOCATION_TYPE_MAX = 2147483647,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmemLocationType_enum {
@@ -4121,7 +4396,7 @@ pub enum CUmemPool_attribute_enum {
     CU_MEMPOOL_ATTR_USED_MEM_CURRENT = 7,
     CU_MEMPOOL_ATTR_USED_MEM_HIGH = 8,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmemPool_attribute_enum {
@@ -4140,13 +4415,13 @@ pub enum CUmemPool_attribute_enum {
     CU_MEMPOOL_ATTR_MAX_POOL_SIZE = 13,
     CU_MEMPOOL_ATTR_HW_DECOMPRESS_ENABLED = 14,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmemRangeFlags_enum {
     CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE = 1,
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmemRangeHandleType_enum {
@@ -4172,7 +4447,7 @@ pub enum CUmem_range_attribute_enum {
     CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY = 3,
     CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION = 4,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmem_range_attribute_enum {
@@ -4185,7 +4460,7 @@ pub enum CUmem_range_attribute_enum {
     CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION_TYPE = 7,
     CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION_ID = 8,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmemcpy3DOperandType_enum {
@@ -4193,14 +4468,14 @@ pub enum CUmemcpy3DOperandType_enum {
     CU_MEMCPY_OPERAND_TYPE_ARRAY = 2,
     CU_MEMCPY_OPERAND_TYPE_MAX = 2147483647,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmemcpyFlags_enum {
     CU_MEMCPY_FLAG_DEFAULT = 0,
     CU_MEMCPY_FLAG_PREFER_OVERLAP_WITH_COMPUTE = 1,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmemcpySrcAccessOrder_enum {
@@ -4218,14 +4493,14 @@ pub enum CUmemorytype_enum {
     CU_MEMORYTYPE_ARRAY = 3,
     CU_MEMORYTYPE_UNIFIED = 4,
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmoduleLoadingMode_enum {
     CU_MODULE_EAGER_LOADING = 1,
     CU_MODULE_LAZY_LOADING = 2,
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUmulticastGranularity_flags_enum {
@@ -4291,7 +4566,7 @@ pub enum CUpointer_attribute_enum {
     CU_POINTER_ATTRIBUTE_MAPPING_BASE_ADDR = 19,
     CU_POINTER_ATTRIBUTE_MEMORY_BLOCK_ID = 20,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUpointer_attribute_enum {
@@ -4317,7 +4592,7 @@ pub enum CUpointer_attribute_enum {
     CU_POINTER_ATTRIBUTE_MEMORY_BLOCK_ID = 20,
     CU_POINTER_ATTRIBUTE_IS_HW_DECOMPRESS_CAPABLE = 21,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUprocessState_enum {
@@ -4373,7 +4648,7 @@ pub enum CUresourcetype_enum {
     CU_RESOURCE_TYPE_LINEAR = 2,
     CU_RESOURCE_TYPE_PITCH2D = 3,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUsharedMemoryMode_enum {
@@ -4395,14 +4670,14 @@ pub enum CUsharedconfig_enum {
     CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE = 1,
     CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE = 2,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUstreamAtomicReductionDataType_enum {
     CU_STREAM_ATOMIC_REDUCTION_UNSIGNED_32 = 14,
     CU_STREAM_ATOMIC_REDUCTION_UNSIGNED_64 = 22,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUstreamAtomicReductionOpType_enum {
@@ -4438,7 +4713,7 @@ pub enum CUstreamBatchMemOpType_enum {
     CU_STREAM_MEM_OP_BARRIER = 6,
     CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES = 3,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUstreamBatchMemOpType_enum {
@@ -4464,13 +4739,13 @@ pub enum CUstreamCaptureStatus_enum {
     CU_STREAM_CAPTURE_STATUS_ACTIVE = 1,
     CU_STREAM_CAPTURE_STATUS_INVALIDATED = 2,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUstreamCigDataType_enum {
     STREAM_CIG_DATA_TYPE_D3D12_COMMAND_LIST = 1,
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUstreamMemoryBarrier_flags_enum {
@@ -4530,7 +4805,7 @@ pub enum CUtensorMapDataType_enum {
     CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 = 11,
     CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ = 12,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUtensorMapDataType_enum {
@@ -4551,21 +4826,21 @@ pub enum CUtensorMapDataType_enum {
     CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B = 14,
     CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B = 15,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUtensorMapFloatOOBfill_enum {
     CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE = 0,
     CU_TENSOR_MAP_FLOAT_OOB_FILL_NAN_REQUEST_ZERO_FMA = 1,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUtensorMapIm2ColWideMode_enum {
     CU_TENSOR_MAP_IM2COL_WIDE_MODE_W = 0,
     CU_TENSOR_MAP_IM2COL_WIDE_MODE_W128 = 1,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUtensorMapInterleave_enum {
@@ -4573,7 +4848,7 @@ pub enum CUtensorMapInterleave_enum {
     CU_TENSOR_MAP_INTERLEAVE_16B = 1,
     CU_TENSOR_MAP_INTERLEAVE_32B = 2,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUtensorMapL2promotion_enum {
@@ -4591,7 +4866,7 @@ pub enum CUtensorMapSwizzle_enum {
     CU_TENSOR_MAP_SWIZZLE_64B = 2,
     CU_TENSOR_MAP_SWIZZLE_128B = 3,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUtensorMapSwizzle_enum {
@@ -5607,6 +5882,114 @@ pub enum cudaError_enum {
     CUDA_ERROR_STREAM_DETACHED = 917,
     CUDA_ERROR_UNKNOWN = 999,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cudaError_enum {
+    CUDA_SUCCESS = 0,
+    CUDA_ERROR_INVALID_VALUE = 1,
+    CUDA_ERROR_OUT_OF_MEMORY = 2,
+    CUDA_ERROR_NOT_INITIALIZED = 3,
+    CUDA_ERROR_DEINITIALIZED = 4,
+    CUDA_ERROR_PROFILER_DISABLED = 5,
+    CUDA_ERROR_PROFILER_NOT_INITIALIZED = 6,
+    CUDA_ERROR_PROFILER_ALREADY_STARTED = 7,
+    CUDA_ERROR_PROFILER_ALREADY_STOPPED = 8,
+    CUDA_ERROR_STUB_LIBRARY = 34,
+    CUDA_ERROR_CALL_REQUIRES_NEWER_DRIVER = 36,
+    CUDA_ERROR_DEVICE_UNAVAILABLE = 46,
+    CUDA_ERROR_NO_DEVICE = 100,
+    CUDA_ERROR_INVALID_DEVICE = 101,
+    CUDA_ERROR_DEVICE_NOT_LICENSED = 102,
+    CUDA_ERROR_INVALID_IMAGE = 200,
+    CUDA_ERROR_INVALID_CONTEXT = 201,
+    CUDA_ERROR_CONTEXT_ALREADY_CURRENT = 202,
+    CUDA_ERROR_MAP_FAILED = 205,
+    CUDA_ERROR_UNMAP_FAILED = 206,
+    CUDA_ERROR_ARRAY_IS_MAPPED = 207,
+    CUDA_ERROR_ALREADY_MAPPED = 208,
+    CUDA_ERROR_NO_BINARY_FOR_GPU = 209,
+    CUDA_ERROR_ALREADY_ACQUIRED = 210,
+    CUDA_ERROR_NOT_MAPPED = 211,
+    CUDA_ERROR_NOT_MAPPED_AS_ARRAY = 212,
+    CUDA_ERROR_NOT_MAPPED_AS_POINTER = 213,
+    CUDA_ERROR_ECC_UNCORRECTABLE = 214,
+    CUDA_ERROR_UNSUPPORTED_LIMIT = 215,
+    CUDA_ERROR_CONTEXT_ALREADY_IN_USE = 216,
+    CUDA_ERROR_PEER_ACCESS_UNSUPPORTED = 217,
+    CUDA_ERROR_INVALID_PTX = 218,
+    CUDA_ERROR_INVALID_GRAPHICS_CONTEXT = 219,
+    CUDA_ERROR_NVLINK_UNCORRECTABLE = 220,
+    CUDA_ERROR_JIT_COMPILER_NOT_FOUND = 221,
+    CUDA_ERROR_UNSUPPORTED_PTX_VERSION = 222,
+    CUDA_ERROR_JIT_COMPILATION_DISABLED = 223,
+    CUDA_ERROR_UNSUPPORTED_EXEC_AFFINITY = 224,
+    CUDA_ERROR_UNSUPPORTED_DEVSIDE_SYNC = 225,
+    CUDA_ERROR_CONTAINED = 226,
+    CUDA_ERROR_INVALID_SOURCE = 300,
+    CUDA_ERROR_FILE_NOT_FOUND = 301,
+    CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND = 302,
+    CUDA_ERROR_SHARED_OBJECT_INIT_FAILED = 303,
+    CUDA_ERROR_OPERATING_SYSTEM = 304,
+    CUDA_ERROR_INVALID_HANDLE = 400,
+    CUDA_ERROR_ILLEGAL_STATE = 401,
+    CUDA_ERROR_LOSSY_QUERY = 402,
+    CUDA_ERROR_NOT_FOUND = 500,
+    CUDA_ERROR_NOT_READY = 600,
+    CUDA_ERROR_ILLEGAL_ADDRESS = 700,
+    CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES = 701,
+    CUDA_ERROR_LAUNCH_TIMEOUT = 702,
+    CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING = 703,
+    CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED = 704,
+    CUDA_ERROR_PEER_ACCESS_NOT_ENABLED = 705,
+    CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE = 708,
+    CUDA_ERROR_CONTEXT_IS_DESTROYED = 709,
+    CUDA_ERROR_ASSERT = 710,
+    CUDA_ERROR_TOO_MANY_PEERS = 711,
+    CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED = 712,
+    CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED = 713,
+    CUDA_ERROR_HARDWARE_STACK_ERROR = 714,
+    CUDA_ERROR_ILLEGAL_INSTRUCTION = 715,
+    CUDA_ERROR_MISALIGNED_ADDRESS = 716,
+    CUDA_ERROR_INVALID_ADDRESS_SPACE = 717,
+    CUDA_ERROR_INVALID_PC = 718,
+    CUDA_ERROR_LAUNCH_FAILED = 719,
+    CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE = 720,
+    CUDA_ERROR_TENSOR_MEMORY_LEAK = 721,
+    CUDA_ERROR_NOT_PERMITTED = 800,
+    CUDA_ERROR_NOT_SUPPORTED = 801,
+    CUDA_ERROR_SYSTEM_NOT_READY = 802,
+    CUDA_ERROR_SYSTEM_DRIVER_MISMATCH = 803,
+    CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE = 804,
+    CUDA_ERROR_MPS_CONNECTION_FAILED = 805,
+    CUDA_ERROR_MPS_RPC_FAILURE = 806,
+    CUDA_ERROR_MPS_SERVER_NOT_READY = 807,
+    CUDA_ERROR_MPS_MAX_CLIENTS_REACHED = 808,
+    CUDA_ERROR_MPS_MAX_CONNECTIONS_REACHED = 809,
+    CUDA_ERROR_MPS_CLIENT_TERMINATED = 810,
+    CUDA_ERROR_CDP_NOT_SUPPORTED = 811,
+    CUDA_ERROR_CDP_VERSION_MISMATCH = 812,
+    CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED = 900,
+    CUDA_ERROR_STREAM_CAPTURE_INVALIDATED = 901,
+    CUDA_ERROR_STREAM_CAPTURE_MERGE = 902,
+    CUDA_ERROR_STREAM_CAPTURE_UNMATCHED = 903,
+    CUDA_ERROR_STREAM_CAPTURE_UNJOINED = 904,
+    CUDA_ERROR_STREAM_CAPTURE_ISOLATION = 905,
+    CUDA_ERROR_STREAM_CAPTURE_IMPLICIT = 906,
+    CUDA_ERROR_CAPTURED_EVENT = 907,
+    CUDA_ERROR_STREAM_CAPTURE_WRONG_THREAD = 908,
+    CUDA_ERROR_TIMEOUT = 909,
+    CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE = 910,
+    CUDA_ERROR_EXTERNAL_DEVICE = 911,
+    CUDA_ERROR_INVALID_CLUSTER_SIZE = 912,
+    CUDA_ERROR_FUNCTION_NOT_LOADED = 913,
+    CUDA_ERROR_INVALID_RESOURCE_TYPE = 914,
+    CUDA_ERROR_INVALID_RESOURCE_CONFIGURATION = 915,
+    CUDA_ERROR_KEY_ROTATION = 916,
+    CUDA_ERROR_STREAM_DETACHED = 917,
+    CUDA_ERROR_GRAPH_RECAPTURE_FAILURE = 918,
+    CUDA_ERROR_UNKNOWN = 999,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_ARRAY3D_DESCRIPTOR_st {
@@ -5625,7 +6008,7 @@ pub struct CUDA_ARRAY_DESCRIPTOR_st {
     pub Format: CUarray_format,
     pub NumChannels: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_ARRAY_MEMORY_REQUIREMENTS_st {
@@ -5658,7 +6041,7 @@ pub struct CUDA_BATCH_MEM_OP_NODE_PARAMS_st {
     pub paramArray: *mut CUstreamBatchMemOpParams,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_BATCH_MEM_OP_NODE_PARAMS_v1_st {
@@ -5667,7 +6050,7 @@ pub struct CUDA_BATCH_MEM_OP_NODE_PARAMS_v1_st {
     pub paramArray: *mut CUstreamBatchMemOpParams,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_BATCH_MEM_OP_NODE_PARAMS_v2_st {
@@ -5682,14 +6065,14 @@ pub struct CUDA_BATCH_MEM_OP_NODE_PARAMS_v2_st {
 pub struct CUDA_CHILD_GRAPH_NODE_PARAMS_st {
     pub graph: CUgraph,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_CHILD_GRAPH_NODE_PARAMS_st {
     pub graph: CUgraph,
     pub ownership: CUgraphChildGraphNodeOwnership,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_CONDITIONAL_NODE_PARAMS {
@@ -5699,13 +6082,13 @@ pub struct CUDA_CONDITIONAL_NODE_PARAMS {
     pub phGraph_out: *mut CUgraph,
     pub ctx: CUcontext,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_EVENT_RECORD_NODE_PARAMS_st {
     pub event: CUevent,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_EVENT_WAIT_NODE_PARAMS_st {
@@ -5814,7 +6197,7 @@ pub struct CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_st {
     pub paramsArray: *const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS,
     pub numExtSems: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v2_st {
@@ -5829,7 +6212,7 @@ pub struct CUDA_EXT_SEM_WAIT_NODE_PARAMS_st {
     pub paramsArray: *const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS,
     pub numExtSems: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2_st {
@@ -5837,7 +6220,7 @@ pub struct CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2_st {
     pub paramsArray: *const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS,
     pub numExtSems: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_GRAPH_INSTANTIATE_PARAMS_st {
@@ -5859,7 +6242,7 @@ pub struct CUDA_HOST_NODE_PARAMS_v2_st {
     pub fn_: CUhostFn,
     pub userData: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_HOST_NODE_PARAMS_v2_st {
@@ -5881,7 +6264,7 @@ pub struct CUDA_KERNEL_NODE_PARAMS_st {
     pub kernelParams: *mut *mut ::core::ffi::c_void,
     pub extra: *mut *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_KERNEL_NODE_PARAMS_v2_st {
@@ -5898,7 +6281,7 @@ pub struct CUDA_KERNEL_NODE_PARAMS_v2_st {
     pub kern: CUkernel,
     pub ctx: CUcontext,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_KERNEL_NODE_PARAMS_v3_st {
@@ -5949,7 +6332,7 @@ pub struct CUDA_MEMCPY2D_st {
     pub WidthInBytes: usize,
     pub Height: usize,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUDA_MEMCPY3D_BATCH_OP_st {
@@ -6017,7 +6400,7 @@ pub struct CUDA_MEMCPY3D_st {
     pub Height: usize,
     pub Depth: usize,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_MEMCPY_NODE_PARAMS_st {
@@ -6036,7 +6419,7 @@ pub struct CUDA_MEMSET_NODE_PARAMS_st {
     pub width: usize,
     pub height: usize,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_MEMSET_NODE_PARAMS_v2_st {
@@ -6068,7 +6451,7 @@ pub struct CUDA_MEM_ALLOC_NODE_PARAMS_v1_st {
     pub bytesize: usize,
     pub dptr: CUdeviceptr,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUDA_MEM_ALLOC_NODE_PARAMS_v1_st {
@@ -6088,7 +6471,7 @@ pub struct CUDA_MEM_ALLOC_NODE_PARAMS_v2_st {
     pub bytesize: usize,
     pub dptr: CUdeviceptr,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUDA_MEM_ALLOC_NODE_PARAMS_v2_st {
@@ -6098,7 +6481,7 @@ pub struct CUDA_MEM_ALLOC_NODE_PARAMS_v2_st {
     pub bytesize: usize,
     pub dptr: CUdeviceptr,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUDA_MEM_FREE_NODE_PARAMS_st {
@@ -6177,7 +6560,7 @@ pub struct CUDA_TEXTURE_DESC_st {
     pub borderColor: [f32; 4usize],
     pub reserved: [::core::ffi::c_int; 12usize],
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CU_DEV_SM_RESOURCE_GROUP_PARAMS_st {
@@ -6235,39 +6618,39 @@ pub struct CUarrayMapInfo_st__bindgen_ty_2__bindgen_ty_2 {
 pub struct CUarray_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUasyncCallbackEntry_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUasyncNotificationInfo_st {
     pub type_: CUasyncNotificationType,
     pub info: CUasyncNotificationInfo_st__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUasyncNotificationInfo_st__bindgen_ty_1__bindgen_ty_1 {
     pub bytesOverBudget: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUcheckpointCheckpointArgs_st {
     pub reserved: [cuuint64_t; 8usize],
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUcheckpointGpuPair_st {
     pub oldUuid: CUuuid,
     pub newUuid: CUuuid,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUcheckpointLockArgs_st {
@@ -6290,26 +6673,34 @@ pub struct CUcheckpointRestoreArgs_st {
     pub reserved: [::core::ffi::c_char; 44usize],
     pub reserved1: cuuint64_t,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUcheckpointRestoreArgs_st {
+    pub gpuPairs: *mut CUcheckpointGpuPair,
+    pub gpuPairsCount: ::core::ffi::c_uint,
+    pub reserved: [::core::ffi::c_char; 52usize],
+}
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUcheckpointUnlockArgs_st {
     pub reserved: [cuuint64_t; 8usize],
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUcoredumpCallbackEntry_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUctxCigParam_st {
     pub sharedDataType: CUcigDataType,
     pub sharedData: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUctxCreateParams_st {
@@ -6322,7 +6713,7 @@ pub struct CUctxCreateParams_st {
 pub struct CUctx_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUdevResourceDesc_st {
@@ -6336,7 +6727,7 @@ pub struct CUdevResource_st {
     pub _internal_padding: [::core::ffi::c_uchar; 92usize],
     pub __bindgen_anon_1: CUdevResource_st__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUdevResource_st {
@@ -6359,7 +6750,7 @@ pub struct CUdevSmResource_st {
     pub minSmPartitionSize: ::core::ffi::c_uint,
     pub smCoscheduledAlignment: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUdevSmResource_st {
@@ -6368,7 +6759,7 @@ pub struct CUdevSmResource_st {
     pub smCoscheduledAlignment: ::core::ffi::c_uint,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUdevWorkqueueConfigResource_st {
@@ -6376,7 +6767,7 @@ pub struct CUdevWorkqueueConfigResource_st {
     pub wqConcurrencyLimit: ::core::ffi::c_uint,
     pub sharingScope: CUdevWorkqueueConfigScope,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUdevWorkqueueResource_st {
@@ -6422,7 +6813,7 @@ pub struct CUextMemory_st {
 pub struct CUextSemaphore_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUextent3D_st {
@@ -6435,13 +6826,13 @@ pub struct CUextent3D_st {
 pub struct CUfunc_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUgraphDeviceUpdatableNode_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUgraphEdgeData_st {
@@ -6450,7 +6841,7 @@ pub struct CUgraphEdgeData_st {
     pub type_: ::core::ffi::c_uchar,
     pub reserved: [::core::ffi::c_uchar; 5usize],
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUgraphExecUpdateResultInfo_st {
@@ -6463,7 +6854,7 @@ pub struct CUgraphExecUpdateResultInfo_st {
 pub struct CUgraphExec_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUgraphNodeParams_st {
@@ -6487,7 +6878,7 @@ pub struct CUgraph_st {
 pub struct CUgraphicsResource_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUgreenCtx_st {
@@ -6503,13 +6894,13 @@ pub struct CUipcEventHandle_st {
 pub struct CUipcMemHandle_st {
     pub reserved: [::core::ffi::c_char; 64usize],
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUkern_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUlaunchAttributeValue_union__bindgen_ty_1 {
@@ -6517,7 +6908,7 @@ pub struct CUlaunchAttributeValue_union__bindgen_ty_1 {
     pub y: ::core::ffi::c_uint,
     pub z: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUlaunchAttributeValue_union__bindgen_ty_2 {
@@ -6525,7 +6916,7 @@ pub struct CUlaunchAttributeValue_union__bindgen_ty_2 {
     pub flags: ::core::ffi::c_int,
     pub triggerAtBlockStart: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUlaunchAttributeValue_union__bindgen_ty_3 {
@@ -6539,7 +6930,7 @@ pub struct CUlaunchAttributeValue_union__bindgen_ty_4 {
     pub deviceUpdatable: ::core::ffi::c_int,
     pub devNode: CUgraphDeviceNode,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUlaunchAttributeValue_union__bindgen_ty_4 {
@@ -6547,14 +6938,14 @@ pub struct CUlaunchAttributeValue_union__bindgen_ty_4 {
     pub y: ::core::ffi::c_uint,
     pub z: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUlaunchAttributeValue_union__bindgen_ty_5 {
     pub deviceUpdatable: ::core::ffi::c_int,
     pub devNode: CUgraphDeviceNode,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUlaunchAttribute_st {
@@ -6562,7 +6953,7 @@ pub struct CUlaunchAttribute_st {
     pub pad: [::core::ffi::c_char; 4usize],
     pub value: CUlaunchAttributeValue,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUlaunchConfig_st {
@@ -6577,20 +6968,20 @@ pub struct CUlaunchConfig_st {
     pub attrs: *mut CUlaunchAttribute,
     pub numAttrs: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUlaunchMemSyncDomainMap_st {
     pub default_: ::core::ffi::c_uchar,
     pub remote: ::core::ffi::c_uchar,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUlib_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUlibraryHostUniversalFunctionAndDataTable_st {
@@ -6604,7 +6995,35 @@ pub struct CUlibraryHostUniversalFunctionAndDataTable_st {
 pub struct CUlinkState_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUlogicalEndpointFabricHandle_st {
+    pub data: [::core::ffi::c_uchar; 64usize],
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct CUlogicalEndpointProp_struct {
+    pub type_: CUlogicalEndpointType,
+    pub __bindgen_anon_1: CUlogicalEndpointProp_struct__bindgen_ty_1,
+    pub size: ::core::ffi::c_ulonglong,
+    pub ipcHandleTypes: ::core::ffi::c_uint,
+    pub flags: ::core::ffi::c_uint,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUlogicalEndpointProp_struct__bindgen_ty_1__bindgen_ty_1 {
+    pub device: CUdevice,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct CUlogicalEndpointProp_struct__bindgen_ty_1__bindgen_ty_2 {
+    pub numDevices: ::core::ffi::c_uint,
+}
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUlogsCallbackEntry_st {
@@ -6617,7 +7036,7 @@ pub struct CUmemAccessDesc_st {
     pub location: CUmemLocation,
     pub flags: CUmemAccess_flags,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUmemAccessDesc_st {
@@ -6637,7 +7056,7 @@ pub struct CUmemAllocationProp_st {
     pub win32HandleMetaData: *mut ::core::ffi::c_void,
     pub allocFlags: CUmemAllocationProp_st__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUmemAllocationProp_st {
@@ -6655,7 +7074,7 @@ pub struct CUmemAllocationProp_st__bindgen_ty_1 {
     pub usage: ::core::ffi::c_ushort,
     pub reserved: [::core::ffi::c_uchar; 4usize],
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUmemDecompressParams_st {
@@ -6667,7 +7086,7 @@ pub struct CUmemDecompressParams_st {
     pub algo: CUmemDecompressAlgorithm,
     pub padding: [::core::ffi::c_uchar; 20usize],
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUmemFabricHandle_st {
@@ -6680,7 +7099,7 @@ pub struct CUmemLocation_st {
     pub type_: CUmemLocationType,
     pub id: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUmemLocation_st {
@@ -6725,7 +7144,7 @@ pub struct CUmemPoolProps_st {
     pub usage: ::core::ffi::c_ushort,
     pub reserved: [::core::ffi::c_uchar; 54usize],
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUmemPoolProps_st {
@@ -6742,7 +7161,7 @@ pub struct CUmemPoolProps_st {
 pub struct CUmemPoolPtrExportData_st {
     pub reserved: [::core::ffi::c_uchar; 64usize],
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUmemcpy3DOperand_st {
@@ -6758,7 +7177,7 @@ pub struct CUmemcpy3DOperand_st__bindgen_ty_1__bindgen_ty_1 {
     pub layerHeight: usize,
     pub locHint: CUmemLocation,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUmemcpy3DOperand_st__bindgen_ty_1__bindgen_ty_1 {
@@ -6767,7 +7186,7 @@ pub struct CUmemcpy3DOperand_st__bindgen_ty_1__bindgen_ty_1 {
     pub layerHeight: usize,
     pub locHint: CUmemLocation,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUmemcpy3DOperand_st__bindgen_ty_1__bindgen_ty_2 {
@@ -6783,7 +7202,7 @@ pub struct CUmemcpyAttributes_st {
     pub dstLocHint: CUmemLocation,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CUmemcpyAttributes_st {
@@ -6802,7 +7221,7 @@ pub struct CUmipmappedArray_st {
 pub struct CUmod_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUmulticastObjectProp_st {
@@ -6811,7 +7230,7 @@ pub struct CUmulticastObjectProp_st {
     pub handleTypes: ::core::ffi::c_ulonglong,
     pub flags: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUoffset3D_st {
@@ -6819,7 +7238,7 @@ pub struct CUoffset3D_st {
     pub y: usize,
     pub z: usize,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUstreamBatchMemOpParams_union_CUstreamMemOpAtomicReductionParams_st {
@@ -6837,7 +7256,7 @@ pub struct CUstreamBatchMemOpParams_union_CUstreamMemOpFlushRemoteWritesParams_s
     pub operation: CUstreamBatchMemOpType,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUstreamBatchMemOpParams_union_CUstreamMemOpMemoryBarrierParams_st {
@@ -6862,13 +7281,13 @@ pub struct CUstreamBatchMemOpParams_union_CUstreamMemOpWriteValueParams_st {
     pub flags: ::core::ffi::c_uint,
     pub alias: CUdeviceptr,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUstreamCigCaptureParams_st {
     pub streamCigParams: *mut CUstreamCigParam,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct CUstreamCigParam_st {
@@ -6892,7 +7311,7 @@ pub struct CUsurfref_st {
 pub struct CUtensorMap_st {
     pub opaque: [cuuint64_t; 16usize],
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[repr(align(128))]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -6938,7 +7357,7 @@ impl CUdevice_attribute_enum {
 impl CUdevice_attribute_enum {
     pub const CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED: CUdevice_attribute_enum = CUdevice_attribute_enum::CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED;
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl CUmemAllocationHandleType_enum {
     pub const CU_MEM_HANDLE_TYPE_FABRIC: CUmemAllocationHandleType_enum = CUmemAllocationHandleType_enum(8);
 }
@@ -6957,7 +7376,7 @@ impl CUmemAllocationHandleType_enum {
 impl CUmemAllocationHandleType_enum {
     pub const CU_MEM_HANDLE_TYPE_WIN32_KMT: CUmemAllocationHandleType_enum = CUmemAllocationHandleType_enum(4);
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl CUmemLocationType_enum {
     pub const CU_MEM_LOCATION_TYPE_NONE: CUmemLocationType_enum = CUmemLocationType_enum::CU_MEM_LOCATION_TYPE_INVALID;
 }
@@ -7039,7 +7458,7 @@ pub union CUarrayMapInfo_st__bindgen_ty_2 {
 pub union CUarrayMapInfo_st__bindgen_ty_3 {
     pub memHandle: CUmemGenericAllocationHandle,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUasyncNotificationInfo_st__bindgen_ty_1 {
@@ -7052,7 +7471,7 @@ pub union CUdevResource_st__bindgen_ty_1 {
     pub sm: CUdevSmResource,
     pub _oversize: [::core::ffi::c_uchar; 48usize],
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUdevResource_st__bindgen_ty_1 {
@@ -7102,6 +7521,26 @@ pub union CUgraphNodeParams_st__bindgen_ty_1 {
     pub free: CUDA_MEM_FREE_NODE_PARAMS,
     pub memOp: CUDA_BATCH_MEM_OP_NODE_PARAMS_v2,
     pub conditional: CUDA_CONDITIONAL_NODE_PARAMS,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union CUgraphNodeParams_st__bindgen_ty_1 {
+    pub reserved1: [::core::ffi::c_longlong; 29usize],
+    pub kernel: CUDA_KERNEL_NODE_PARAMS_v3,
+    pub memcpy: CUDA_MEMCPY_NODE_PARAMS,
+    pub memset: CUDA_MEMSET_NODE_PARAMS_v2,
+    pub host: CUDA_HOST_NODE_PARAMS_v2,
+    pub graph: CUDA_CHILD_GRAPH_NODE_PARAMS,
+    pub eventWait: CUDA_EVENT_WAIT_NODE_PARAMS,
+    pub eventRecord: CUDA_EVENT_RECORD_NODE_PARAMS,
+    pub extSemSignal: CUDA_EXT_SEM_SIGNAL_NODE_PARAMS_v2,
+    pub extSemWait: CUDA_EXT_SEM_WAIT_NODE_PARAMS_v2,
+    pub alloc: CUDA_MEM_ALLOC_NODE_PARAMS_v2,
+    pub free: CUDA_MEM_FREE_NODE_PARAMS,
+    pub memOp: CUDA_BATCH_MEM_OP_NODE_PARAMS_v2,
+    pub conditional: CUDA_CONDITIONAL_NODE_PARAMS,
+    pub asBytes: [::core::ffi::c_char; 232usize],
 }
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060"))]
 #[repr(C)]
@@ -7243,7 +7682,7 @@ pub union CUlaunchAttributeValue_union {
     pub sharedMemCarveout: ::core::ffi::c_uint,
     pub nvlinkUtilCentricScheduling: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUlaunchAttributeValue_union {
@@ -7266,13 +7705,20 @@ pub union CUlaunchAttributeValue_union {
     pub portableClusterSizeMode: CUlaunchAttributePortableClusterMode,
     pub sharedMemoryMode: CUsharedMemoryMode,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union CUlogicalEndpointProp_struct__bindgen_ty_1 {
+    pub unicast: CUlogicalEndpointProp_struct__bindgen_ty_1__bindgen_ty_1,
+    pub multicast: CUlogicalEndpointProp_struct__bindgen_ty_1__bindgen_ty_2,
+}
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUmemLocation_st__bindgen_ty_1 {
     pub id: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUmemcpy3DOperand_st__bindgen_ty_1 {
@@ -7307,7 +7753,7 @@ pub union CUstreamBatchMemOpParams_union {
     pub memoryBarrier: CUstreamBatchMemOpParams_union_CUstreamMemOpMemoryBarrierParams_st,
     pub pad: [cuuint64_t; 6usize],
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union CUstreamBatchMemOpParams_union {
@@ -7411,7 +7857,7 @@ pub unsafe fn cuArrayGetDescriptor_v2(pArrayDescriptor: *mut CUDA_ARRAY_DESCRIPT
         cuArrayGetDescriptor_v2(pArrayDescriptor, hArray)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuArrayGetMemoryRequirements(memoryRequirements: *mut CUDA_ARRAY_MEMORY_REQUIREMENTS, array: CUarray, device: CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7460,7 +7906,7 @@ pub unsafe fn cuArrayGetSparseProperties(sparseProperties: *mut CUDA_ARRAY_SPARS
         cuArrayGetSparseProperties(sparseProperties, array)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCoredumpDeregisterCompleteCallback(callback: CUcoredumpCallbackHandle) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7477,7 +7923,7 @@ pub unsafe fn cuCoredumpDeregisterCompleteCallback(callback: CUcoredumpCallbackH
         cuCoredumpDeregisterCompleteCallback(callback)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCoredumpDeregisterStartCallback(callback: CUcoredumpCallbackHandle) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7494,7 +7940,7 @@ pub unsafe fn cuCoredumpDeregisterStartCallback(callback: CUcoredumpCallbackHand
         cuCoredumpDeregisterStartCallback(callback)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCoredumpGetAttribute(attrib: CUcoredumpSettings, value: *mut ::core::ffi::c_void, size: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7511,7 +7957,7 @@ pub unsafe fn cuCoredumpGetAttribute(attrib: CUcoredumpSettings, value: *mut ::c
         cuCoredumpGetAttribute(attrib, value, size)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCoredumpGetAttributeGlobal(attrib: CUcoredumpSettings, value: *mut ::core::ffi::c_void, size: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7528,7 +7974,7 @@ pub unsafe fn cuCoredumpGetAttributeGlobal(attrib: CUcoredumpSettings, value: *m
         cuCoredumpGetAttributeGlobal(attrib, value, size)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCoredumpRegisterCompleteCallback(callback: CUcoredumpStatusCallback, userData: *mut ::core::ffi::c_void, callbackOut: *mut CUcoredumpCallbackHandle) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7545,7 +7991,7 @@ pub unsafe fn cuCoredumpRegisterCompleteCallback(callback: CUcoredumpStatusCallb
         cuCoredumpRegisterCompleteCallback(callback, userData, callbackOut)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCoredumpRegisterStartCallback(callback: CUcoredumpStatusCallback, userData: *mut ::core::ffi::c_void, callbackOut: *mut CUcoredumpCallbackHandle) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7562,7 +8008,7 @@ pub unsafe fn cuCoredumpRegisterStartCallback(callback: CUcoredumpStatusCallback
         cuCoredumpRegisterStartCallback(callback, userData, callbackOut)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCoredumpSetAttribute(attrib: CUcoredumpSettings, value: *mut ::core::ffi::c_void, size: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7579,7 +8025,7 @@ pub unsafe fn cuCoredumpSetAttribute(attrib: CUcoredumpSettings, value: *mut ::c
         cuCoredumpSetAttribute(attrib, value, size)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCoredumpSetAttributeGlobal(attrib: CUcoredumpSettings, value: *mut ::core::ffi::c_void, size: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7646,7 +8092,7 @@ pub unsafe fn cuCtxCreate_v3(pctx: *mut CUcontext, paramsArray: *mut CUexecAffin
         cuCtxCreate_v3(pctx, paramsArray, numParams, flags, dev)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCtxCreate_v4(pctx: *mut CUcontext, ctxCreateParams: *mut CUctxCreateParams, flags: ::core::ffi::c_uint, dev: CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7727,7 +8173,7 @@ pub unsafe fn cuCtxEnablePeerAccess(peerContext: CUcontext, Flags: ::core::ffi::
         cuCtxEnablePeerAccess(peerContext, Flags)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCtxFromGreenCtx(pContext: *mut CUcontext, hCtx: CUgreenCtx) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7792,7 +8238,7 @@ pub unsafe fn cuCtxGetCurrent(pctx: *mut CUcontext) -> CUresult {
         cuCtxGetCurrent(pctx)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCtxGetDevResource(hCtx: CUcontext, resource: *mut CUdevResource, type_: CUdevResourceType) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7825,7 +8271,7 @@ pub unsafe fn cuCtxGetDevice(device: *mut CUdevice) -> CUresult {
         cuCtxGetDevice(device)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCtxGetDevice_v2(device: *mut CUdevice, ctx: CUcontext) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7874,7 +8320,7 @@ pub unsafe fn cuCtxGetFlags(flags: *mut ::core::ffi::c_uint) -> CUresult {
         cuCtxGetFlags(flags)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCtxGetId(ctx: CUcontext, ctxId: *mut ::core::ffi::c_ulonglong) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7971,7 +8417,7 @@ pub unsafe fn cuCtxPushCurrent_v2(ctx: CUcontext) -> CUresult {
         cuCtxPushCurrent_v2(ctx)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCtxRecordEvent(hCtx: CUcontext, hEvent: CUevent) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8036,7 +8482,7 @@ pub unsafe fn cuCtxSetCurrent(ctx: CUcontext) -> CUresult {
         cuCtxSetCurrent(ctx)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCtxSetFlags(flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8101,7 +8547,7 @@ pub unsafe fn cuCtxSynchronize() -> CUresult {
         cuCtxSynchronize()
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCtxSynchronize_v2(ctx: CUcontext) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8118,7 +8564,7 @@ pub unsafe fn cuCtxSynchronize_v2(ctx: CUcontext) -> CUresult {
         cuCtxSynchronize_v2(ctx)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuCtxWaitEvent(hCtx: CUcontext, hEvent: CUevent) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8167,7 +8613,7 @@ pub unsafe fn cuDestroyExternalSemaphore(extSem: CUexternalSemaphore) -> CUresul
         cuDestroyExternalSemaphore(extSem)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuDevResourceGenerateDesc(phDesc: *mut CUdevResourceDesc, resources: *mut CUdevResource, nbResources: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8184,7 +8630,7 @@ pub unsafe fn cuDevResourceGenerateDesc(phDesc: *mut CUdevResourceDesc, resource
         cuDevResourceGenerateDesc(phDesc, resources, nbResources)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuDevSmResourceSplit(result: *mut CUdevResource, nbGroups: ::core::ffi::c_uint, input: *const CUdevResource, remainder: *mut CUdevResource, flags: ::core::ffi::c_uint, groupParams: *mut CU_DEV_SM_RESOURCE_GROUP_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8218,7 +8664,7 @@ pub unsafe fn cuDevSmResourceSplitByCount(result: *mut CUdevResource, nbGroups: 
         cuDevSmResourceSplitByCount(result, nbGroups, input, remaining, useFlags, minCount)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuDevSmResourceSplitByCount(result: *mut CUdevResource, nbGroups: *mut ::core::ffi::c_uint, input: *const CUdevResource, remainder: *mut CUdevResource, flags: ::core::ffi::c_uint, minCount: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8347,7 +8793,7 @@ pub unsafe fn cuDeviceGetDefaultMemPool(pool_out: *mut CUmemoryPool, dev: CUdevi
         cuDeviceGetDefaultMemPool(pool_out, dev)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuDeviceGetDevResource(device: CUdevice, resource: *mut CUdevResource, type_: CUdevResourceType) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8396,7 +8842,7 @@ pub unsafe fn cuDeviceGetGraphMemAttribute(device: CUdevice, attr: CUgraphMem_at
         cuDeviceGetGraphMemAttribute(device, attr, value)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuDeviceGetHostAtomicCapabilities(capabilities: *mut ::core::ffi::c_uint, operations: *const CUatomicOperation, count: ::core::ffi::c_uint, dev: CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8461,7 +8907,7 @@ pub unsafe fn cuDeviceGetName(name: *mut ::core::ffi::c_char, len: ::core::ffi::
         cuDeviceGetName(name, len, dev)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuDeviceGetP2PAtomicCapabilities(capabilities: *mut ::core::ffi::c_uint, operations: *const CUatomicOperation, count: ::core::ffi::c_uint, srcDevice: CUdevice, dstDevice: CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8671,7 +9117,7 @@ pub unsafe fn cuDevicePrimaryCtxSetFlags_v2(dev: CUdevice, flags: ::core::ffi::c
         cuDevicePrimaryCtxSetFlags_v2(dev, flags)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuDeviceRegisterAsyncNotification(device: CUdevice, callbackFunc: CUasyncCallback, userData: *mut ::core::ffi::c_void, callback: *mut CUasyncCallbackHandle) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8736,7 +9182,7 @@ pub unsafe fn cuDeviceTotalMem_v2(bytes: *mut usize, dev: CUdevice) -> CUresult 
         cuDeviceTotalMem_v2(bytes, dev)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuDeviceUnregisterAsyncNotification(device: CUdevice, callback: CUasyncCallbackHandle) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8818,7 +9264,7 @@ pub unsafe fn cuEventElapsedTime(pMilliseconds: *mut f32, hStart: CUevent, hEnd:
         cuEventElapsedTime(pMilliseconds, hStart, hEnd)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuEventElapsedTime_v2(pMilliseconds: *mut f32, hStart: CUevent, hEnd: CUevent) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8979,7 +9425,7 @@ pub unsafe fn cuFuncGetModule(hmod: *mut CUmodule, hfunc: CUfunction) -> CUresul
         cuFuncGetModule(hmod, hfunc)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFuncGetName(name: *mut *const ::core::ffi::c_char, hfunc: CUfunction) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8996,7 +9442,7 @@ pub unsafe fn cuFuncGetName(name: *mut *const ::core::ffi::c_char, hfunc: CUfunc
         cuFuncGetName(name, hfunc)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFuncGetParamCount(func: CUfunction, paramCount: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9013,7 +9459,7 @@ pub unsafe fn cuFuncGetParamCount(func: CUfunction, paramCount: *mut usize) -> C
         cuFuncGetParamCount(func, paramCount)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFuncGetParamInfo(func: CUfunction, paramIndex: usize, paramOffset: *mut usize, paramSize: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9030,7 +9476,7 @@ pub unsafe fn cuFuncGetParamInfo(func: CUfunction, paramIndex: usize, paramOffse
         cuFuncGetParamInfo(func, paramIndex, paramOffset, paramSize)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFuncIsLoaded(state: *mut CUfunctionLoadingState, function: CUfunction) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9047,7 +9493,7 @@ pub unsafe fn cuFuncIsLoaded(state: *mut CUfunctionLoadingState, function: CUfun
         cuFuncIsLoaded(state, function)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuFuncLoad(function: CUfunction) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9209,7 +9655,7 @@ pub unsafe fn cuGetProcAddress(symbol: *const ::core::ffi::c_char, pfn: *mut *mu
         cuGetProcAddress(symbol, pfn, cudaVersion, flags)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGetProcAddress_v2(symbol: *const ::core::ffi::c_char, pfn: *mut *mut ::core::ffi::c_void, cudaVersion: ::core::ffi::c_int, flags: cuuint64_t, symbolStatus: *mut CUdriverProcAddressQueryResult) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9226,7 +9672,7 @@ pub unsafe fn cuGetProcAddress_v2(symbol: *const ::core::ffi::c_char, pfn: *mut 
         cuGetProcAddress_v2(symbol, pfn, cudaVersion, flags, symbolStatus)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphAddBatchMemOpNode(phGraphNode: *mut CUgraphNode, hGraph: CUgraph, dependencies: *const CUgraphNode, numDependencies: usize, nodeParams: *const CUDA_BATCH_MEM_OP_NODE_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9276,7 +9722,7 @@ pub unsafe fn cuGraphAddDependencies(hGraph: CUgraph, from: *const CUgraphNode, 
         cuGraphAddDependencies(hGraph, from, to, numDependencies)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphAddDependencies_v2(hGraph: CUgraph, from: *const CUgraphNode, to: *const CUgraphNode, edgeData: *const CUgraphEdgeData, numDependencies: usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9406,7 +9852,7 @@ pub unsafe fn cuGraphAddKernelNode(phGraphNode: *mut CUgraphNode, hGraph: CUgrap
         cuGraphAddKernelNode(phGraphNode, hGraph, dependencies, numDependencies, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphAddKernelNode_v2(phGraphNode: *mut CUgraphNode, hGraph: CUgraph, dependencies: *const CUgraphNode, numDependencies: usize, nodeParams: *const CUDA_KERNEL_NODE_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9504,7 +9950,7 @@ pub unsafe fn cuGraphAddNode(phGraphNode: *mut CUgraphNode, hGraph: CUgraph, dep
         cuGraphAddNode(phGraphNode, hGraph, dependencies, numDependencies, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphAddNode_v2(phGraphNode: *mut CUgraphNode, hGraph: CUgraph, dependencies: *const CUgraphNode, dependencyData: *const CUgraphEdgeData, numDependencies: usize, nodeParams: *mut CUgraphNodeParams) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9521,7 +9967,7 @@ pub unsafe fn cuGraphAddNode_v2(phGraphNode: *mut CUgraphNode, hGraph: CUgraph, 
         cuGraphAddNode_v2(phGraphNode, hGraph, dependencies, dependencyData, numDependencies, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphBatchMemOpNodeGetParams(hNode: CUgraphNode, nodeParams_out: *mut CUDA_BATCH_MEM_OP_NODE_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9538,7 +9984,7 @@ pub unsafe fn cuGraphBatchMemOpNodeGetParams(hNode: CUgraphNode, nodeParams_out:
         cuGraphBatchMemOpNodeGetParams(hNode, nodeParams_out)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphBatchMemOpNodeSetParams(hNode: CUgraphNode, nodeParams: *const CUDA_BATCH_MEM_OP_NODE_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9587,7 +10033,7 @@ pub unsafe fn cuGraphClone(phGraphClone: *mut CUgraph, originalGraph: CUgraph) -
         cuGraphClone(phGraphClone, originalGraph)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphConditionalHandleCreate(pHandle_out: *mut CUgraphConditionalHandle, hGraph: CUgraph, ctx: CUcontext, defaultLaunchValue: ::core::ffi::c_uint, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9732,7 +10178,7 @@ pub unsafe fn cuGraphEventWaitNodeSetEvent(hNode: CUgraphNode, event: CUevent) -
         cuGraphEventWaitNodeSetEvent(hNode, event)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphExecBatchMemOpNodeSetParams(hGraphExec: CUgraphExec, hNode: CUgraphNode, nodeParams: *const CUDA_BATCH_MEM_OP_NODE_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9845,7 +10291,7 @@ pub unsafe fn cuGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec: CUgraph
         cuGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec, hNode, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphExecGetFlags(hGraphExec: CUgraphExec, flags: *mut cuuint64_t) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9862,7 +10308,7 @@ pub unsafe fn cuGraphExecGetFlags(hGraphExec: CUgraphExec, flags: *mut cuuint64_
         cuGraphExecGetFlags(hGraphExec, flags)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphExecGetId(hGraphExec: CUgraphExec, graphId: *mut ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9912,7 +10358,7 @@ pub unsafe fn cuGraphExecKernelNodeSetParams(hGraphExec: CUgraphExec, hNode: CUg
         cuGraphExecKernelNodeSetParams(hGraphExec, hNode, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphExecKernelNodeSetParams_v2(hGraphExec: CUgraphExec, hNode: CUgraphNode, nodeParams: *const CUDA_KERNEL_NODE_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9961,7 +10407,7 @@ pub unsafe fn cuGraphExecMemsetNodeSetParams(hGraphExec: CUgraphExec, hNode: CUg
         cuGraphExecMemsetNodeSetParams(hGraphExec, hNode, memsetParams, ctx)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphExecNodeSetParams(hGraphExec: CUgraphExec, hNode: CUgraphNode, nodeParams: *mut CUgraphNodeParams) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9995,7 +10441,7 @@ pub unsafe fn cuGraphExecUpdate(hGraphExec: CUgraphExec, hGraph: CUgraph, hError
         cuGraphExecUpdate(hGraphExec, hGraph, hErrorNode_out, updateResult_out)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphExecUpdate_v2(hGraphExec: CUgraphExec, hGraph: CUgraph, resultInfo: *mut CUgraphExecUpdateResultInfo) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10093,7 +10539,7 @@ pub unsafe fn cuGraphGetEdges(hGraph: CUgraph, from: *mut CUgraphNode, to: *mut 
         cuGraphGetEdges(hGraph, from, to, numEdges)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphGetEdges_v2(hGraph: CUgraph, from: *mut CUgraphNode, to: *mut CUgraphNode, edgeData: *mut CUgraphEdgeData, numEdges: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10110,7 +10556,7 @@ pub unsafe fn cuGraphGetEdges_v2(hGraph: CUgraph, from: *mut CUgraphNode, to: *m
         cuGraphGetEdges_v2(hGraph, from, to, edgeData, numEdges)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphGetId(hGraph: CUgraph, graphId: *mut ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10207,7 +10653,7 @@ pub unsafe fn cuGraphInstantiateWithFlags(phGraphExec: *mut CUgraphExec, hGraph:
         cuGraphInstantiateWithFlags(phGraphExec, hGraph, flags)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphInstantiateWithParams(phGraphExec: *mut CUgraphExec, hGraph: CUgraph, instantiateParams: *mut CUDA_GRAPH_INSTANTIATE_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10290,7 +10736,7 @@ pub unsafe fn cuGraphKernelNodeGetParams(hNode: CUgraphNode, nodeParams: *mut CU
         cuGraphKernelNodeGetParams(hNode, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphKernelNodeGetParams_v2(hNode: CUgraphNode, nodeParams: *mut CUDA_KERNEL_NODE_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10340,7 +10786,7 @@ pub unsafe fn cuGraphKernelNodeSetParams(hNode: CUgraphNode, nodeParams: *const 
         cuGraphKernelNodeSetParams(hNode, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphKernelNodeSetParams_v2(hNode: CUgraphNode, nodeParams: *const CUDA_KERNEL_NODE_PARAMS) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10485,7 +10931,7 @@ pub unsafe fn cuGraphNodeFindInClone(phNode: *mut CUgraphNode, hOriginalNode: CU
         cuGraphNodeFindInClone(phNode, hOriginalNode, hClonedGraph)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphNodeGetContainingGraph(hNode: CUgraphNode, phGraph: *mut CUgraph) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10519,7 +10965,7 @@ pub unsafe fn cuGraphNodeGetDependencies(hNode: CUgraphNode, dependencies: *mut 
         cuGraphNodeGetDependencies(hNode, dependencies, numDependencies)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphNodeGetDependencies_v2(hNode: CUgraphNode, dependencies: *mut CUgraphNode, edgeData: *mut CUgraphEdgeData, numDependencies: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10553,7 +10999,7 @@ pub unsafe fn cuGraphNodeGetDependentNodes(hNode: CUgraphNode, dependentNodes: *
         cuGraphNodeGetDependentNodes(hNode, dependentNodes, numDependentNodes)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphNodeGetDependentNodes_v2(hNode: CUgraphNode, dependentNodes: *mut CUgraphNode, edgeData: *mut CUgraphEdgeData, numDependentNodes: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10570,7 +11016,7 @@ pub unsafe fn cuGraphNodeGetDependentNodes_v2(hNode: CUgraphNode, dependentNodes
         cuGraphNodeGetDependentNodes_v2(hNode, dependentNodes, edgeData, numDependentNodes)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphNodeGetEnabled(hGraphExec: CUgraphExec, hNode: CUgraphNode, isEnabled: *mut ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10587,7 +11033,7 @@ pub unsafe fn cuGraphNodeGetEnabled(hGraphExec: CUgraphExec, hNode: CUgraphNode,
         cuGraphNodeGetEnabled(hGraphExec, hNode, isEnabled)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphNodeGetLocalId(hNode: CUgraphNode, nodeId: *mut ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10604,7 +11050,7 @@ pub unsafe fn cuGraphNodeGetLocalId(hNode: CUgraphNode, nodeId: *mut ::core::ffi
         cuGraphNodeGetLocalId(hNode, nodeId)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphNodeGetParams(hNode: CUgraphNode, nodeParams: *mut CUgraphNodeParams) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10621,7 +11067,7 @@ pub unsafe fn cuGraphNodeGetParams(hNode: CUgraphNode, nodeParams: *mut CUgraphN
         cuGraphNodeGetParams(hNode, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphNodeGetToolsId(hNode: CUgraphNode, toolsNodeId: *mut ::core::ffi::c_ulonglong) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10654,7 +11100,7 @@ pub unsafe fn cuGraphNodeGetType(hNode: CUgraphNode, type_: *mut CUgraphNodeType
         cuGraphNodeGetType(hNode, type_)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphNodeSetEnabled(hGraphExec: CUgraphExec, hNode: CUgraphNode, isEnabled: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10671,7 +11117,7 @@ pub unsafe fn cuGraphNodeSetEnabled(hGraphExec: CUgraphExec, hNode: CUgraphNode,
         cuGraphNodeSetEnabled(hGraphExec, hNode, isEnabled)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphNodeSetParams(hNode: CUgraphNode, nodeParams: *mut CUgraphNodeParams) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10721,7 +11167,7 @@ pub unsafe fn cuGraphRemoveDependencies(hGraph: CUgraph, from: *const CUgraphNod
         cuGraphRemoveDependencies(hGraph, from, to, numDependencies)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGraphRemoveDependencies_v2(hGraph: CUgraph, from: *const CUgraphNode, to: *const CUgraphNode, edgeData: *const CUgraphEdgeData, numDependencies: usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10882,7 +11328,7 @@ pub unsafe fn cuGraphicsUnregisterResource(resource: CUgraphicsResource) -> CUre
         cuGraphicsUnregisterResource(resource)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGreenCtxCreate(phCtx: *mut CUgreenCtx, desc: CUdevResourceDesc, dev: CUdevice, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10899,7 +11345,7 @@ pub unsafe fn cuGreenCtxCreate(phCtx: *mut CUgreenCtx, desc: CUdevResourceDesc, 
         cuGreenCtxCreate(phCtx, desc, dev, flags)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGreenCtxDestroy(hCtx: CUgreenCtx) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10916,7 +11362,7 @@ pub unsafe fn cuGreenCtxDestroy(hCtx: CUgreenCtx) -> CUresult {
         cuGreenCtxDestroy(hCtx)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGreenCtxGetDevResource(hCtx: CUgreenCtx, resource: *mut CUdevResource, type_: CUdevResourceType) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10933,7 +11379,7 @@ pub unsafe fn cuGreenCtxGetDevResource(hCtx: CUgreenCtx, resource: *mut CUdevRes
         cuGreenCtxGetDevResource(hCtx, resource, type_)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGreenCtxGetId(greenCtx: CUgreenCtx, greenCtxId: *mut ::core::ffi::c_ulonglong) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10950,7 +11396,7 @@ pub unsafe fn cuGreenCtxGetId(greenCtx: CUgreenCtx, greenCtxId: *mut ::core::ffi
         cuGreenCtxGetId(greenCtx, greenCtxId)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGreenCtxRecordEvent(hCtx: CUgreenCtx, hEvent: CUevent) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10967,7 +11413,7 @@ pub unsafe fn cuGreenCtxRecordEvent(hCtx: CUgreenCtx, hEvent: CUevent) -> CUresu
         cuGreenCtxRecordEvent(hCtx, hEvent)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGreenCtxStreamCreate(phStream: *mut CUstream, greenCtx: CUgreenCtx, flags: ::core::ffi::c_uint, priority: ::core::ffi::c_int) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10984,7 +11430,7 @@ pub unsafe fn cuGreenCtxStreamCreate(phStream: *mut CUstream, greenCtx: CUgreenC
         cuGreenCtxStreamCreate(phStream, greenCtx, flags, priority)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuGreenCtxWaitEvent(hCtx: CUgreenCtx, hEvent: CUevent) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11129,7 +11575,7 @@ pub unsafe fn cuIpcOpenMemHandle_v2(pdptr: *mut CUdeviceptr, handle: CUipcMemHan
         cuIpcOpenMemHandle_v2(pdptr, handle, Flags)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuKernelGetAttribute(pi: *mut ::core::ffi::c_int, attrib: CUfunction_attribute, kernel: CUkernel, dev: CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11146,7 +11592,7 @@ pub unsafe fn cuKernelGetAttribute(pi: *mut ::core::ffi::c_int, attrib: CUfuncti
         cuKernelGetAttribute(pi, attrib, kernel, dev)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuKernelGetFunction(pFunc: *mut CUfunction, kernel: CUkernel) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11163,7 +11609,7 @@ pub unsafe fn cuKernelGetFunction(pFunc: *mut CUfunction, kernel: CUkernel) -> C
         cuKernelGetFunction(pFunc, kernel)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuKernelGetLibrary(pLib: *mut CUlibrary, kernel: CUkernel) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11180,7 +11626,7 @@ pub unsafe fn cuKernelGetLibrary(pLib: *mut CUlibrary, kernel: CUkernel) -> CUre
         cuKernelGetLibrary(pLib, kernel)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuKernelGetName(name: *mut *const ::core::ffi::c_char, hfunc: CUkernel) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11197,7 +11643,7 @@ pub unsafe fn cuKernelGetName(name: *mut *const ::core::ffi::c_char, hfunc: CUke
         cuKernelGetName(name, hfunc)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuKernelGetParamCount(kernel: CUkernel, paramCount: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11214,7 +11660,7 @@ pub unsafe fn cuKernelGetParamCount(kernel: CUkernel, paramCount: *mut usize) ->
         cuKernelGetParamCount(kernel, paramCount)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuKernelGetParamInfo(kernel: CUkernel, paramIndex: usize, paramOffset: *mut usize, paramSize: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11231,7 +11677,7 @@ pub unsafe fn cuKernelGetParamInfo(kernel: CUkernel, paramIndex: usize, paramOff
         cuKernelGetParamInfo(kernel, paramIndex, paramOffset, paramSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuKernelSetAttribute(attrib: CUfunction_attribute, val: ::core::ffi::c_int, kernel: CUkernel, dev: CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11248,7 +11694,7 @@ pub unsafe fn cuKernelSetAttribute(attrib: CUfunction_attribute, val: ::core::ff
         cuKernelSetAttribute(attrib, val, kernel, dev)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuKernelSetCacheConfig(kernel: CUkernel, config: CUfunc_cache, dev: CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11361,7 +11807,7 @@ pub unsafe fn cuLaunchHostFunc(hStream: CUstream, fn_: CUhostFn, userData: *mut 
         cuLaunchHostFunc(hStream, fn_, userData)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLaunchHostFunc_v2(hStream: CUstream, fn_: CUhostFn, userData: *mut ::core::ffi::c_void, syncMode: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11394,7 +11840,7 @@ pub unsafe fn cuLaunchKernel(f: CUfunction, gridDimX: ::core::ffi::c_uint, gridD
         cuLaunchKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ, sharedMemBytes, hStream, kernelParams, extra)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLaunchKernelEx(config: *const CUlaunchConfig, f: CUfunction, kernelParams: *mut *mut ::core::ffi::c_void, extra: *mut *mut ::core::ffi::c_void) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11411,7 +11857,7 @@ pub unsafe fn cuLaunchKernelEx(config: *const CUlaunchConfig, f: CUfunction, ker
         cuLaunchKernelEx(config, f, kernelParams, extra)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryEnumerateKernels(kernels: *mut CUkernel, numKernels: ::core::ffi::c_uint, lib: CUlibrary) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11428,7 +11874,7 @@ pub unsafe fn cuLibraryEnumerateKernels(kernels: *mut CUkernel, numKernels: ::co
         cuLibraryEnumerateKernels(kernels, numKernels, lib)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryGetGlobal(dptr: *mut CUdeviceptr, bytes: *mut usize, library: CUlibrary, name: *const ::core::ffi::c_char) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11445,7 +11891,7 @@ pub unsafe fn cuLibraryGetGlobal(dptr: *mut CUdeviceptr, bytes: *mut usize, libr
         cuLibraryGetGlobal(dptr, bytes, library, name)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryGetKernel(pKernel: *mut CUkernel, library: CUlibrary, name: *const ::core::ffi::c_char) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11462,7 +11908,7 @@ pub unsafe fn cuLibraryGetKernel(pKernel: *mut CUkernel, library: CUlibrary, nam
         cuLibraryGetKernel(pKernel, library, name)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryGetKernelCount(count: *mut ::core::ffi::c_uint, lib: CUlibrary) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11479,7 +11925,7 @@ pub unsafe fn cuLibraryGetKernelCount(count: *mut ::core::ffi::c_uint, lib: CUli
         cuLibraryGetKernelCount(count, lib)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryGetManaged(dptr: *mut CUdeviceptr, bytes: *mut usize, library: CUlibrary, name: *const ::core::ffi::c_char) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11496,7 +11942,7 @@ pub unsafe fn cuLibraryGetManaged(dptr: *mut CUdeviceptr, bytes: *mut usize, lib
         cuLibraryGetManaged(dptr, bytes, library, name)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryGetModule(pMod: *mut CUmodule, library: CUlibrary) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11513,7 +11959,7 @@ pub unsafe fn cuLibraryGetModule(pMod: *mut CUmodule, library: CUlibrary) -> CUr
         cuLibraryGetModule(pMod, library)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryGetUnifiedFunction(fptr: *mut *mut ::core::ffi::c_void, library: CUlibrary, symbol: *const ::core::ffi::c_char) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11530,7 +11976,7 @@ pub unsafe fn cuLibraryGetUnifiedFunction(fptr: *mut *mut ::core::ffi::c_void, l
         cuLibraryGetUnifiedFunction(fptr, library, symbol)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryLoadData(library: *mut CUlibrary, code: *const ::core::ffi::c_void, jitOptions: *mut CUjit_option, jitOptionsValues: *mut *mut ::core::ffi::c_void, numJitOptions: ::core::ffi::c_uint, libraryOptions: *mut CUlibraryOption, libraryOptionValues: *mut *mut ::core::ffi::c_void, numLibraryOptions: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11547,7 +11993,7 @@ pub unsafe fn cuLibraryLoadData(library: *mut CUlibrary, code: *const ::core::ff
         cuLibraryLoadData(library, code, jitOptions, jitOptionsValues, numJitOptions, libraryOptions, libraryOptionValues, numLibraryOptions)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryLoadFromFile(library: *mut CUlibrary, fileName: *const ::core::ffi::c_char, jitOptions: *mut CUjit_option, jitOptionsValues: *mut *mut ::core::ffi::c_void, numJitOptions: ::core::ffi::c_uint, libraryOptions: *mut CUlibraryOption, libraryOptionValues: *mut *mut ::core::ffi::c_void, numLibraryOptions: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11564,7 +12010,7 @@ pub unsafe fn cuLibraryLoadFromFile(library: *mut CUlibrary, fileName: *const ::
         cuLibraryLoadFromFile(library, fileName, jitOptions, jitOptionsValues, numJitOptions, libraryOptions, libraryOptionValues, numLibraryOptions)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLibraryUnload(library: CUlibrary) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11661,7 +12107,211 @@ pub unsafe fn cuLinkDestroy(state: CUlinkState) -> CUresult {
         cuLinkDestroy(state)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointAddDevice(leId: CUlogicalEndpointId, dev: CUdevice) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUlogicalEndpointId, CUdevice) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointAddDevice") });
+        _f(leId, dev)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointAddDevice(leId: CUlogicalEndpointId, dev: CUdevice) -> CUresult;
+        }
+        cuLogicalEndpointAddDevice(leId, dev)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointBindAddr(leId: CUlogicalEndpointId, dev: CUdevice, offset: cuuint64_t, ptr: *mut ::core::ffi::c_void, size: cuuint64_t, flags: ::core::ffi::c_ulonglong) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUlogicalEndpointId, CUdevice, cuuint64_t, *mut ::core::ffi::c_void, cuuint64_t, ::core::ffi::c_ulonglong) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointBindAddr") });
+        _f(leId, dev, offset, ptr, size, flags)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointBindAddr(leId: CUlogicalEndpointId, dev: CUdevice, offset: cuuint64_t, ptr: *mut ::core::ffi::c_void, size: cuuint64_t, flags: ::core::ffi::c_ulonglong) -> CUresult;
+        }
+        cuLogicalEndpointBindAddr(leId, dev, offset, ptr, size, flags)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointBindMem(leId: CUlogicalEndpointId, dev: CUdevice, offset: cuuint64_t, memHandle: CUmemGenericAllocationHandle, memOffset: cuuint64_t, size: cuuint64_t, flags: ::core::ffi::c_ulonglong) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUlogicalEndpointId, CUdevice, cuuint64_t, CUmemGenericAllocationHandle, cuuint64_t, cuuint64_t, ::core::ffi::c_ulonglong) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointBindMem") });
+        _f(leId, dev, offset, memHandle, memOffset, size, flags)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointBindMem(leId: CUlogicalEndpointId, dev: CUdevice, offset: cuuint64_t, memHandle: CUmemGenericAllocationHandle, memOffset: cuuint64_t, size: cuuint64_t, flags: ::core::ffi::c_ulonglong) -> CUresult;
+        }
+        cuLogicalEndpointBindMem(leId, dev, offset, memHandle, memOffset, size, flags)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointCreate(leId: CUlogicalEndpointId, prop: *const CUlogicalEndpointProp) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUlogicalEndpointId, *const CUlogicalEndpointProp) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointCreate") });
+        _f(leId, prop)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointCreate(leId: CUlogicalEndpointId, prop: *const CUlogicalEndpointProp) -> CUresult;
+        }
+        cuLogicalEndpointCreate(leId, prop)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointDestroy(leId: CUlogicalEndpointId) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUlogicalEndpointId) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointDestroy") });
+        _f(leId)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointDestroy(leId: CUlogicalEndpointId) -> CUresult;
+        }
+        cuLogicalEndpointDestroy(leId)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointExport(handle: *mut ::core::ffi::c_void, leId: CUlogicalEndpointId, handleType: CUlogicalEndpointIpcHandleType) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(*mut ::core::ffi::c_void, CUlogicalEndpointId, CUlogicalEndpointIpcHandleType) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointExport") });
+        _f(handle, leId, handleType)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointExport(handle: *mut ::core::ffi::c_void, leId: CUlogicalEndpointId, handleType: CUlogicalEndpointIpcHandleType) -> CUresult;
+        }
+        cuLogicalEndpointExport(handle, leId, handleType)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointGetLimits(bindAlignment: *mut cuuint64_t, maxSize: *mut cuuint64_t, prop: *const CUlogicalEndpointProp) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(*mut cuuint64_t, *mut cuuint64_t, *const CUlogicalEndpointProp) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointGetLimits") });
+        _f(bindAlignment, maxSize, prop)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointGetLimits(bindAlignment: *mut cuuint64_t, maxSize: *mut cuuint64_t, prop: *const CUlogicalEndpointProp) -> CUresult;
+        }
+        cuLogicalEndpointGetLimits(bindAlignment, maxSize, prop)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointIdRelease(baseLeId: CUlogicalEndpointId, count: cuuint32_t) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUlogicalEndpointId, cuuint32_t) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointIdRelease") });
+        _f(baseLeId, count)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointIdRelease(baseLeId: CUlogicalEndpointId, count: cuuint32_t) -> CUresult;
+        }
+        cuLogicalEndpointIdRelease(baseLeId, count)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointIdReserve(baseLeId: *mut CUlogicalEndpointId, count: cuuint32_t) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(*mut CUlogicalEndpointId, cuuint32_t) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointIdReserve") });
+        _f(baseLeId, count)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointIdReserve(baseLeId: *mut CUlogicalEndpointId, count: cuuint32_t) -> CUresult;
+        }
+        cuLogicalEndpointIdReserve(baseLeId, count)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointImport(leId: CUlogicalEndpointId, handle: *const ::core::ffi::c_void, handleType: CUlogicalEndpointIpcHandleType) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUlogicalEndpointId, *const ::core::ffi::c_void, CUlogicalEndpointIpcHandleType) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointImport") });
+        _f(leId, handle, handleType)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointImport(leId: CUlogicalEndpointId, handle: *const ::core::ffi::c_void, handleType: CUlogicalEndpointIpcHandleType) -> CUresult;
+        }
+        cuLogicalEndpointImport(leId, handle, handleType)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointQuery(leId: CUlogicalEndpointId, count: cuuint32_t, queryStatus: *mut ::core::ffi::c_int) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUlogicalEndpointId, cuuint32_t, *mut ::core::ffi::c_int) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointQuery") });
+        _f(leId, count, queryStatus)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointQuery(leId: CUlogicalEndpointId, count: cuuint32_t, queryStatus: *mut ::core::ffi::c_int) -> CUresult;
+        }
+        cuLogicalEndpointQuery(leId, count, queryStatus)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuLogicalEndpointUnbind(leId: CUlogicalEndpointId, dev: CUdevice, offset: cuuint64_t, size: cuuint64_t) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUlogicalEndpointId, CUdevice, cuuint64_t, cuuint64_t) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuLogicalEndpointUnbind") });
+        _f(leId, dev, offset, size)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuLogicalEndpointUnbind(leId: CUlogicalEndpointId, dev: CUdevice, offset: cuuint64_t, size: cuuint64_t) -> CUresult;
+        }
+        cuLogicalEndpointUnbind(leId, dev, offset, size)
+    }
+}
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLogsCurrent(iterator_out: *mut CUlogIterator, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11678,7 +12328,7 @@ pub unsafe fn cuLogsCurrent(iterator_out: *mut CUlogIterator, flags: ::core::ffi
         cuLogsCurrent(iterator_out, flags)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLogsDumpToFile(iterator: *mut CUlogIterator, pathToFile: *const ::core::ffi::c_char, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11695,7 +12345,7 @@ pub unsafe fn cuLogsDumpToFile(iterator: *mut CUlogIterator, pathToFile: *const 
         cuLogsDumpToFile(iterator, pathToFile, flags)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLogsDumpToMemory(iterator: *mut CUlogIterator, buffer: *mut ::core::ffi::c_char, size: *mut usize, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11712,7 +12362,7 @@ pub unsafe fn cuLogsDumpToMemory(iterator: *mut CUlogIterator, buffer: *mut ::co
         cuLogsDumpToMemory(iterator, buffer, size, flags)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLogsRegisterCallback(callbackFunc: CUlogsCallback, userData: *mut ::core::ffi::c_void, callback_out: *mut CUlogsCallbackHandle) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11729,7 +12379,7 @@ pub unsafe fn cuLogsRegisterCallback(callbackFunc: CUlogsCallback, userData: *mu
         cuLogsRegisterCallback(callbackFunc, userData, callback_out)
     }
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuLogsUnregisterCallback(callback: CUlogsCallbackHandle) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11795,7 +12445,7 @@ pub unsafe fn cuMemAdvise(devPtr: CUdeviceptr, count: usize, advice: CUmem_advis
         cuMemAdvise(devPtr, count, advice, device)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemAdvise_v2(devPtr: CUdeviceptr, count: usize, advice: CUmem_advise, location: CUmemLocation) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11908,7 +12558,7 @@ pub unsafe fn cuMemAlloc_v2(dptr: *mut CUdeviceptr, bytesize: usize) -> CUresult
         cuMemAlloc_v2(dptr, bytesize)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemBatchDecompressAsync(paramsArray: *mut CUmemDecompressParams, count: usize, flags: ::core::ffi::c_uint, errorIndex: *mut usize, stream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11941,7 +12591,7 @@ pub unsafe fn cuMemCreate(handle: *mut CUmemGenericAllocationHandle, size: usize
         cuMemCreate(handle, size, prop, flags)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemDiscardAndPrefetchBatchAsync(dptrs: *mut CUdeviceptr, sizes: *mut usize, count: usize, prefetchLocs: *mut CUmemLocation, prefetchLocIdxs: *mut usize, numPrefetchLocs: usize, flags: ::core::ffi::c_ulonglong, hStream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11958,7 +12608,7 @@ pub unsafe fn cuMemDiscardAndPrefetchBatchAsync(dptrs: *mut CUdeviceptr, sizes: 
         cuMemDiscardAndPrefetchBatchAsync(dptrs, sizes, count, prefetchLocs, prefetchLocIdxs, numPrefetchLocs, flags, hStream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemDiscardBatchAsync(dptrs: *mut CUdeviceptr, sizes: *mut usize, count: usize, flags: ::core::ffi::c_ulonglong, hStream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12103,7 +12753,7 @@ pub unsafe fn cuMemGetAllocationPropertiesFromHandle(prop: *mut CUmemAllocationP
         cuMemGetAllocationPropertiesFromHandle(prop, handle)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemGetDefaultMemPool(pool_out: *mut CUmemoryPool, location: *mut CUmemLocation, type_: CUmemAllocationType) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12120,7 +12770,7 @@ pub unsafe fn cuMemGetDefaultMemPool(pool_out: *mut CUmemoryPool, location: *mut
         cuMemGetDefaultMemPool(pool_out, location, type_)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemGetHandleForAddressRange(handle: *mut ::core::ffi::c_void, dptr: CUdeviceptr, size: usize, handleType: CUmemRangeHandleType, flags: ::core::ffi::c_ulonglong) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12153,7 +12803,7 @@ pub unsafe fn cuMemGetInfo_v2(free: *mut usize, total: *mut usize) -> CUresult {
         cuMemGetInfo_v2(free, total)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemGetMemPool(pool: *mut CUmemoryPool, location: *mut CUmemLocation, type_: CUmemAllocationType) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12491,7 +13141,7 @@ pub unsafe fn cuMemPrefetchAsync(devPtr: CUdeviceptr, count: usize, dstDevice: C
         cuMemPrefetchAsync(devPtr, count, dstDevice, hStream)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemPrefetchAsync_v2(devPtr: CUdeviceptr, count: usize, location: CUmemLocation, flags: ::core::ffi::c_uint, hStream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12508,7 +13158,7 @@ pub unsafe fn cuMemPrefetchAsync_v2(devPtr: CUdeviceptr, count: usize, location:
         cuMemPrefetchAsync_v2(devPtr, count, location, flags, hStream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemPrefetchBatchAsync(dptrs: *mut CUdeviceptr, sizes: *mut usize, count: usize, prefetchLocs: *mut CUmemLocation, prefetchLocIdxs: *mut usize, numPrefetchLocs: usize, flags: ::core::ffi::c_ulonglong, hStream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12605,7 +13255,7 @@ pub unsafe fn cuMemSetAccess(ptr: CUdeviceptr, size: usize, desc: *const CUmemAc
         cuMemSetAccess(ptr, size, desc, count)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemSetMemPool(location: *mut CUmemLocation, type_: CUmemAllocationType, pool: CUmemoryPool) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12735,7 +13385,7 @@ pub unsafe fn cuMemcpy3DBatchAsync(numOps: usize, opList: *mut CUDA_MEMCPY3D_BAT
         cuMemcpy3DBatchAsync(numOps, opList, failIdx, flags, hStream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemcpy3DBatchAsync_v2(numOps: usize, opList: *mut CUDA_MEMCPY3D_BATCH_OP, flags: ::core::ffi::c_ulonglong, hStream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12784,7 +13434,7 @@ pub unsafe fn cuMemcpy3DPeerAsync(pCopy: *const CUDA_MEMCPY3D_PEER, hStream: CUs
         cuMemcpy3DPeerAsync(pCopy, hStream)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemcpy3DWithAttributesAsync(op: *mut CUDA_MEMCPY3D_BATCH_OP, flags: ::core::ffi::c_ulonglong, hStream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12914,7 +13564,7 @@ pub unsafe fn cuMemcpyBatchAsync(dsts: *mut CUdeviceptr, srcs: *mut CUdeviceptr,
         cuMemcpyBatchAsync(dsts, srcs, sizes, count, attrs, attrsIdxs, numAttrs, failIdx, hStream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemcpyBatchAsync_v2(dsts: *mut CUdeviceptr, srcs: *mut CUdeviceptr, sizes: *mut usize, count: usize, attrs: *mut CUmemcpyAttributes, attrsIdxs: *mut usize, numAttrs: usize, hStream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13107,7 +13757,7 @@ pub unsafe fn cuMemcpyPeerAsync(dstDevice: CUdeviceptr, dstContext: CUcontext, s
         cuMemcpyPeerAsync(dstDevice, dstContext, srcDevice, srcContext, ByteCount, hStream)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMemcpyWithAttributesAsync(dst: CUdeviceptr, src: CUdeviceptr, size: usize, attr: *mut CUmemcpyAttributes, hStream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13364,7 +14014,7 @@ pub unsafe fn cuMipmappedArrayGetLevel(pLevelArray: *mut CUarray, hMipmappedArra
         cuMipmappedArrayGetLevel(pLevelArray, hMipmappedArray, level)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMipmappedArrayGetMemoryRequirements(memoryRequirements: *mut CUDA_ARRAY_MEMORY_REQUIREMENTS, mipmap: CUmipmappedArray, device: CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13397,7 +14047,7 @@ pub unsafe fn cuMipmappedArrayGetSparseProperties(sparseProperties: *mut CUDA_AR
         cuMipmappedArrayGetSparseProperties(sparseProperties, mipmap)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuModuleEnumerateFunctions(functions: *mut CUfunction, numFunctions: ::core::ffi::c_uint, mod_: CUmodule) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13430,7 +14080,7 @@ pub unsafe fn cuModuleGetFunction(hfunc: *mut CUfunction, hmod: CUmodule, name: 
         cuModuleGetFunction(hfunc, hmod, name)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuModuleGetFunctionCount(count: *mut ::core::ffi::c_uint, mod_: CUmodule) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13463,7 +14113,7 @@ pub unsafe fn cuModuleGetGlobal_v2(dptr: *mut CUdeviceptr, bytes: *mut usize, hm
         cuModuleGetGlobal_v2(dptr, bytes, hmod, name)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuModuleGetLoadingMode(mode: *mut CUmoduleLoadingMode) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13592,7 +14242,7 @@ pub unsafe fn cuModuleUnload(hmod: CUmodule) -> CUresult {
         cuModuleUnload(hmod)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMulticastAddDevice(mcHandle: CUmemGenericAllocationHandle, dev: CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13609,7 +14259,7 @@ pub unsafe fn cuMulticastAddDevice(mcHandle: CUmemGenericAllocationHandle, dev: 
         cuMulticastAddDevice(mcHandle, dev)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMulticastBindAddr(mcHandle: CUmemGenericAllocationHandle, mcOffset: usize, memptr: CUdeviceptr, size: usize, flags: ::core::ffi::c_ulonglong) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13626,7 +14276,7 @@ pub unsafe fn cuMulticastBindAddr(mcHandle: CUmemGenericAllocationHandle, mcOffs
         cuMulticastBindAddr(mcHandle, mcOffset, memptr, size, flags)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMulticastBindAddr_v2(mcHandle: CUmemGenericAllocationHandle, dev: CUdevice, mcOffset: usize, memptr: CUdeviceptr, size: usize, flags: ::core::ffi::c_ulonglong) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13643,7 +14293,7 @@ pub unsafe fn cuMulticastBindAddr_v2(mcHandle: CUmemGenericAllocationHandle, dev
         cuMulticastBindAddr_v2(mcHandle, dev, mcOffset, memptr, size, flags)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMulticastBindMem(mcHandle: CUmemGenericAllocationHandle, mcOffset: usize, memHandle: CUmemGenericAllocationHandle, memOffset: usize, size: usize, flags: ::core::ffi::c_ulonglong) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13660,7 +14310,7 @@ pub unsafe fn cuMulticastBindMem(mcHandle: CUmemGenericAllocationHandle, mcOffse
         cuMulticastBindMem(mcHandle, mcOffset, memHandle, memOffset, size, flags)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMulticastBindMem_v2(mcHandle: CUmemGenericAllocationHandle, dev: CUdevice, mcOffset: usize, memHandle: CUmemGenericAllocationHandle, memOffset: usize, size: usize, flags: ::core::ffi::c_ulonglong) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13677,7 +14327,7 @@ pub unsafe fn cuMulticastBindMem_v2(mcHandle: CUmemGenericAllocationHandle, dev:
         cuMulticastBindMem_v2(mcHandle, dev, mcOffset, memHandle, memOffset, size, flags)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMulticastCreate(mcHandle: *mut CUmemGenericAllocationHandle, prop: *const CUmulticastObjectProp) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13694,7 +14344,7 @@ pub unsafe fn cuMulticastCreate(mcHandle: *mut CUmemGenericAllocationHandle, pro
         cuMulticastCreate(mcHandle, prop)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMulticastGetGranularity(granularity: *mut usize, prop: *const CUmulticastObjectProp, option: CUmulticastGranularity_flags) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13711,7 +14361,7 @@ pub unsafe fn cuMulticastGetGranularity(granularity: *mut usize, prop: *const CU
         cuMulticastGetGranularity(granularity, prop, option)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuMulticastUnbind(mcHandle: CUmemGenericAllocationHandle, dev: CUdevice, mcOffset: usize, size: usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13776,7 +14426,7 @@ pub unsafe fn cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(numBlocks: *m
         cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(numBlocks, func, blockSize, dynamicSMemSize, flags)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuOccupancyMaxActiveClusters(numClusters: *mut ::core::ffi::c_int, func: CUfunction, config: *const CUlaunchConfig) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -13825,7 +14475,7 @@ pub unsafe fn cuOccupancyMaxPotentialBlockSizeWithFlags(minGridSize: *mut ::core
         cuOccupancyMaxPotentialBlockSizeWithFlags(minGridSize, blockSize, func, blockSizeToDynamicSMemSize, dynamicSMemSize, blockSizeLimit, flags)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuOccupancyMaxPotentialClusterSize(clusterSize: *mut ::core::ffi::c_int, func: CUfunction, config: *const CUlaunchConfig) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14083,7 +14733,7 @@ pub unsafe fn cuStreamBatchMemOp(stream: CUstream, count: ::core::ffi::c_uint, p
         cuStreamBatchMemOp(stream, count, paramArray, flags)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamBatchMemOp_v2(stream: CUstream, count: ::core::ffi::c_uint, paramArray: *mut CUstreamBatchMemOpParams, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14100,7 +14750,7 @@ pub unsafe fn cuStreamBatchMemOp_v2(stream: CUstream, count: ::core::ffi::c_uint
         cuStreamBatchMemOp_v2(stream, count, paramArray, flags)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamBeginCaptureToCig(hStream: CUstream, streamCigCaptureParams: *mut CUstreamCigCaptureParams) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14117,7 +14767,7 @@ pub unsafe fn cuStreamBeginCaptureToCig(hStream: CUstream, streamCigCaptureParam
         cuStreamBeginCaptureToCig(hStream, streamCigCaptureParams)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamBeginCaptureToGraph(hStream: CUstream, hGraph: CUgraph, dependencies: *const CUgraphNode, dependencyData: *const CUgraphEdgeData, numDependencies: usize, mode: CUstreamCaptureMode) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14148,6 +14798,23 @@ pub unsafe fn cuStreamBeginCapture_v2(hStream: CUstream, mode: CUstreamCaptureMo
             fn cuStreamBeginCapture_v2(hStream: CUstream, mode: CUstreamCaptureMode) -> CUresult;
         }
         cuStreamBeginCapture_v2(hStream, mode)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cuStreamBeginRecaptureToGraph(hStream: CUstream, mode: CUstreamCaptureMode, hGraph: CUgraph, callbackFunc: CUgraphRecaptureCallback, userData: *mut ::core::ffi::c_void) -> CUresult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(CUstream, CUstreamCaptureMode, CUgraph, CUgraphRecaptureCallback, *mut ::core::ffi::c_void) -> CUresult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cuStreamBeginRecaptureToGraph") });
+        _f(hStream, mode, hGraph, callbackFunc, userData)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cuStreamBeginRecaptureToGraph(hStream: CUstream, mode: CUstreamCaptureMode, hGraph: CUgraph, callbackFunc: CUgraphRecaptureCallback, userData: *mut ::core::ffi::c_void) -> CUresult;
+        }
+        cuStreamBeginRecaptureToGraph(hStream, mode, hGraph, callbackFunc, userData)
     }
 }
 pub unsafe fn cuStreamCopyAttributes(dst: CUstream, src: CUstream) -> CUresult {
@@ -14230,7 +14897,7 @@ pub unsafe fn cuStreamEndCapture(hStream: CUstream, phGraph: *mut CUgraph) -> CU
         cuStreamEndCapture(hStream, phGraph)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamEndCaptureToCig(hStream: CUstream) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14297,7 +14964,7 @@ pub unsafe fn cuStreamGetCaptureInfo_v2(hStream: CUstream, captureStatus_out: *m
         cuStreamGetCaptureInfo_v2(hStream, captureStatus_out, id_out, graph_out, dependencies_out, numDependencies_out)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamGetCaptureInfo_v3(hStream: CUstream, captureStatus_out: *mut CUstreamCaptureStatus, id_out: *mut cuuint64_t, graph_out: *mut CUgraph, dependencies_out: *mut *const CUgraphNode, edgeData_out: *mut *const CUgraphEdgeData, numDependencies_out: *mut usize) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14330,7 +14997,7 @@ pub unsafe fn cuStreamGetCtx(hStream: CUstream, pctx: *mut CUcontext) -> CUresul
         cuStreamGetCtx(hStream, pctx)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamGetCtx_v2(hStream: CUstream, pCtx: *mut CUcontext, pGreenCtx: *mut CUgreenCtx) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14347,7 +15014,7 @@ pub unsafe fn cuStreamGetCtx_v2(hStream: CUstream, pCtx: *mut CUcontext, pGreenC
         cuStreamGetCtx_v2(hStream, pCtx, pGreenCtx)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamGetDevResource(hStream: CUstream, resource: *mut CUdevResource, type_: CUdevResourceType) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14364,7 +15031,7 @@ pub unsafe fn cuStreamGetDevResource(hStream: CUstream, resource: *mut CUdevReso
         cuStreamGetDevResource(hStream, resource, type_)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamGetDevice(hStream: CUstream, device: *mut CUdevice) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14397,7 +15064,7 @@ pub unsafe fn cuStreamGetFlags(hStream: CUstream, flags: *mut ::core::ffi::c_uin
         cuStreamGetFlags(hStream, flags)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamGetGreenCtx(hStream: CUstream, phCtx: *mut CUgreenCtx) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14414,7 +15081,7 @@ pub unsafe fn cuStreamGetGreenCtx(hStream: CUstream, phCtx: *mut CUgreenCtx) -> 
         cuStreamGetGreenCtx(hStream, phCtx)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamGetId(hStream: CUstream, streamId: *mut ::core::ffi::c_ulonglong) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14528,7 +15195,7 @@ pub unsafe fn cuStreamUpdateCaptureDependencies(hStream: CUstream, dependencies:
         cuStreamUpdateCaptureDependencies(hStream, dependencies, numDependencies, flags)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamUpdateCaptureDependencies_v2(hStream: CUstream, dependencies: *mut CUgraphNode, dependencyData: *const CUgraphEdgeData, numDependencies: usize, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14578,7 +15245,7 @@ pub unsafe fn cuStreamWaitValue32(stream: CUstream, addr: CUdeviceptr, value: cu
         cuStreamWaitValue32(stream, addr, value, flags)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamWaitValue32_v2(stream: CUstream, addr: CUdeviceptr, value: cuuint32_t, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14612,7 +15279,7 @@ pub unsafe fn cuStreamWaitValue64(stream: CUstream, addr: CUdeviceptr, value: cu
         cuStreamWaitValue64(stream, addr, value, flags)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamWaitValue64_v2(stream: CUstream, addr: CUdeviceptr, value: cuuint64_t, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14646,7 +15313,7 @@ pub unsafe fn cuStreamWriteValue32(stream: CUstream, addr: CUdeviceptr, value: c
         cuStreamWriteValue32(stream, addr, value, flags)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamWriteValue32_v2(stream: CUstream, addr: CUdeviceptr, value: cuuint32_t, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14680,7 +15347,7 @@ pub unsafe fn cuStreamWriteValue64(stream: CUstream, addr: CUdeviceptr, value: c
         cuStreamWriteValue64(stream, addr, value, flags)
     }
 }
-#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuStreamWriteValue64_v2(stream: CUstream, addr: CUdeviceptr, value: cuuint64_t, flags: ::core::ffi::c_uint) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14777,7 +15444,7 @@ pub unsafe fn cuSurfRefSetArray(hSurfRef: CUsurfref, hArray: CUarray, Flags: ::c
         cuSurfRefSetArray(hSurfRef, hArray, Flags)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuTensorMapEncodeIm2col(tensorMap: *mut CUtensorMap, tensorDataType: CUtensorMapDataType, tensorRank: cuuint32_t, globalAddress: *mut ::core::ffi::c_void, globalDim: *const cuuint64_t, globalStrides: *const cuuint64_t, pixelBoxLowerCorner: *const ::core::ffi::c_int, pixelBoxUpperCorner: *const ::core::ffi::c_int, channelsPerPixel: cuuint32_t, pixelsPerColumn: cuuint32_t, elementStrides: *const cuuint32_t, interleave: CUtensorMapInterleave, swizzle: CUtensorMapSwizzle, l2Promotion: CUtensorMapL2promotion, oobFill: CUtensorMapFloatOOBfill) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14794,7 +15461,7 @@ pub unsafe fn cuTensorMapEncodeIm2col(tensorMap: *mut CUtensorMap, tensorDataTyp
         cuTensorMapEncodeIm2col(tensorMap, tensorDataType, tensorRank, globalAddress, globalDim, globalStrides, pixelBoxLowerCorner, pixelBoxUpperCorner, channelsPerPixel, pixelsPerColumn, elementStrides, interleave, swizzle, l2Promotion, oobFill)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuTensorMapEncodeIm2colWide(tensorMap: *mut CUtensorMap, tensorDataType: CUtensorMapDataType, tensorRank: cuuint32_t, globalAddress: *mut ::core::ffi::c_void, globalDim: *const cuuint64_t, globalStrides: *const cuuint64_t, pixelBoxLowerCornerWidth: ::core::ffi::c_int, pixelBoxUpperCornerWidth: ::core::ffi::c_int, channelsPerPixel: cuuint32_t, pixelsPerColumn: cuuint32_t, elementStrides: *const cuuint32_t, interleave: CUtensorMapInterleave, mode: CUtensorMapIm2ColWideMode, swizzle: CUtensorMapSwizzle, l2Promotion: CUtensorMapL2promotion, oobFill: CUtensorMapFloatOOBfill) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14811,7 +15478,7 @@ pub unsafe fn cuTensorMapEncodeIm2colWide(tensorMap: *mut CUtensorMap, tensorDat
         cuTensorMapEncodeIm2colWide(tensorMap, tensorDataType, tensorRank, globalAddress, globalDim, globalStrides, pixelBoxLowerCornerWidth, pixelBoxUpperCornerWidth, channelsPerPixel, pixelsPerColumn, elementStrides, interleave, mode, swizzle, l2Promotion, oobFill)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuTensorMapEncodeTiled(tensorMap: *mut CUtensorMap, tensorDataType: CUtensorMapDataType, tensorRank: cuuint32_t, globalAddress: *mut ::core::ffi::c_void, globalDim: *const cuuint64_t, globalStrides: *const cuuint64_t, boxDim: *const cuuint32_t, elementStrides: *const cuuint32_t, interleave: CUtensorMapInterleave, swizzle: CUtensorMapSwizzle, l2Promotion: CUtensorMapL2promotion, oobFill: CUtensorMapFloatOOBfill) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -14828,7 +15495,7 @@ pub unsafe fn cuTensorMapEncodeTiled(tensorMap: *mut CUtensorMap, tensorDataType
         cuTensorMapEncodeTiled(tensorMap, tensorDataType, tensorRank, globalAddress, globalDim, globalStrides, boxDim, elementStrides, interleave, swizzle, l2Promotion, oobFill)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cuTensorMapReplaceAddress(tensorMap: *mut CUtensorMap, globalAddress: *mut ::core::ffi::c_void) -> CUresult {
     #[cfg(feature = "dynamic-loading")]
     {

--- a/src/nvrtc/sys/mod.rs
+++ b/src/nvrtc/sys/mod.rs
@@ -92,10 +92,45 @@ pub enum nvrtcResult {
     NVRTC_ERROR_CANCELLED = 16,
     NVRTC_ERROR_TIME_TRACE_FILE_WRITE_FAILED = 17,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum nvrtcResult {
+    NVRTC_SUCCESS = 0,
+    NVRTC_ERROR_OUT_OF_MEMORY = 1,
+    NVRTC_ERROR_PROGRAM_CREATION_FAILURE = 2,
+    NVRTC_ERROR_INVALID_INPUT = 3,
+    NVRTC_ERROR_INVALID_PROGRAM = 4,
+    NVRTC_ERROR_INVALID_OPTION = 5,
+    NVRTC_ERROR_COMPILATION = 6,
+    NVRTC_ERROR_BUILTIN_OPERATION_FAILURE = 7,
+    NVRTC_ERROR_NO_NAME_EXPRESSIONS_AFTER_COMPILATION = 8,
+    NVRTC_ERROR_NO_LOWERED_NAMES_BEFORE_COMPILATION = 9,
+    NVRTC_ERROR_NAME_EXPRESSION_NOT_VALID = 10,
+    NVRTC_ERROR_INTERNAL_ERROR = 11,
+    NVRTC_ERROR_TIME_FILE_WRITE_FAILED = 12,
+    NVRTC_ERROR_NO_PCH_CREATE_ATTEMPTED = 13,
+    NVRTC_ERROR_PCH_CREATE_HEAP_EXHAUSTED = 14,
+    NVRTC_ERROR_PCH_CREATE = 15,
+    NVRTC_ERROR_CANCELLED = 16,
+    NVRTC_ERROR_TIME_TRACE_FILE_WRITE_FAILED = 17,
+    NVRTC_ERROR_BUSY = 18,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _nvrtcProgram {
     _unused: [u8; 0],
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct nvrtcBundledHeadersInfo {
+    pub available: ::core::ffi::c_int,
+    pub compressedSize: usize,
+    pub uncompressedSize: usize,
+    pub cudaVersionMajor: ::core::ffi::c_int,
+    pub cudaVersionMinor: ::core::ffi::c_int,
+    pub numFiles: ::core::ffi::c_uint,
 }
 pub unsafe fn nvrtcAddNameExpression(prog: nvrtcProgram, name_expression: *const ::core::ffi::c_char) -> nvrtcResult {
     #[cfg(feature = "dynamic-loading")]
@@ -161,6 +196,23 @@ pub unsafe fn nvrtcDestroyProgram(prog: *mut nvrtcProgram) -> nvrtcResult {
         nvrtcDestroyProgram(prog)
     }
 }
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn nvrtcGetBundledHeadersInfo(info: *mut nvrtcBundledHeadersInfo, errorLog: *mut *const ::core::ffi::c_char) -> nvrtcResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(*mut nvrtcBundledHeadersInfo, *mut *const ::core::ffi::c_char) -> nvrtcResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("nvrtcGetBundledHeadersInfo") });
+        _f(info, errorLog)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn nvrtcGetBundledHeadersInfo(info: *mut nvrtcBundledHeadersInfo, errorLog: *mut *const ::core::ffi::c_char) -> nvrtcResult;
+        }
+        nvrtcGetBundledHeadersInfo(info, errorLog)
+    }
+}
 pub unsafe fn nvrtcGetCUBIN(prog: nvrtcProgram, cubin: *mut ::core::ffi::c_char) -> nvrtcResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -209,7 +261,7 @@ pub unsafe fn nvrtcGetErrorString(result: nvrtcResult) -> *const ::core::ffi::c_
         nvrtcGetErrorString(result)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn nvrtcGetLTOIR(prog: nvrtcProgram, LTOIR: *mut ::core::ffi::c_char) -> nvrtcResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -226,7 +278,7 @@ pub unsafe fn nvrtcGetLTOIR(prog: nvrtcProgram, LTOIR: *mut ::core::ffi::c_char)
         nvrtcGetLTOIR(prog, LTOIR)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn nvrtcGetLTOIRSize(prog: nvrtcProgram, LTOIRSizeRet: *mut usize) -> nvrtcResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -275,7 +327,7 @@ pub unsafe fn nvrtcGetNumSupportedArchs(numArchs: *mut ::core::ffi::c_int) -> nv
         nvrtcGetNumSupportedArchs(numArchs)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn nvrtcGetOptiXIR(prog: nvrtcProgram, optixir: *mut ::core::ffi::c_char) -> nvrtcResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -292,7 +344,7 @@ pub unsafe fn nvrtcGetOptiXIR(prog: nvrtcProgram, optixir: *mut ::core::ffi::c_c
         nvrtcGetOptiXIR(prog, optixir)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn nvrtcGetOptiXIRSize(prog: nvrtcProgram, optixirSizeRet: *mut usize) -> nvrtcResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -389,7 +441,7 @@ pub unsafe fn nvrtcGetSupportedArchs(supportedArchs: *mut ::core::ffi::c_int) ->
         nvrtcGetSupportedArchs(supportedArchs)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn nvrtcGetTileIR(prog: nvrtcProgram, TileIR: *mut ::core::ffi::c_char) -> nvrtcResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -406,7 +458,7 @@ pub unsafe fn nvrtcGetTileIR(prog: nvrtcProgram, TileIR: *mut ::core::ffi::c_cha
         nvrtcGetTileIR(prog, TileIR)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn nvrtcGetTileIRSize(prog: nvrtcProgram, TileIRSizeRet: *mut usize) -> nvrtcResult {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -421,6 +473,40 @@ pub unsafe fn nvrtcGetTileIRSize(prog: nvrtcProgram, TileIRSizeRet: *mut usize) 
             fn nvrtcGetTileIRSize(prog: nvrtcProgram, TileIRSizeRet: *mut usize) -> nvrtcResult;
         }
         nvrtcGetTileIRSize(prog, TileIRSizeRet)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn nvrtcInstallBundledHeaders(installPath: *const ::core::ffi::c_char, flags: ::core::ffi::c_uint, errorLog: *mut *const ::core::ffi::c_char) -> nvrtcResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(*const ::core::ffi::c_char, ::core::ffi::c_uint, *mut *const ::core::ffi::c_char) -> nvrtcResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("nvrtcInstallBundledHeaders") });
+        _f(installPath, flags, errorLog)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn nvrtcInstallBundledHeaders(installPath: *const ::core::ffi::c_char, flags: ::core::ffi::c_uint, errorLog: *mut *const ::core::ffi::c_char) -> nvrtcResult;
+        }
+        nvrtcInstallBundledHeaders(installPath, flags, errorLog)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn nvrtcRemoveBundledHeaders(installPath: *const ::core::ffi::c_char, errorLog: *mut *const ::core::ffi::c_char) -> nvrtcResult {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(*const ::core::ffi::c_char, *mut *const ::core::ffi::c_char) -> nvrtcResult;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("nvrtcRemoveBundledHeaders") });
+        _f(installPath, errorLog)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn nvrtcRemoveBundledHeaders(installPath: *const ::core::ffi::c_char, errorLog: *mut *const ::core::ffi::c_char) -> nvrtcResult;
+        }
+        nvrtcRemoveBundledHeaders(installPath, errorLog)
     }
 }
 pub unsafe fn nvrtcVersion(major: *mut ::core::ffi::c_int, minor: *mut ::core::ffi::c_int) -> nvrtcResult {

--- a/src/nvtx/sys/mod.rs
+++ b/src/nvtx/sys/mod.rs
@@ -27,27 +27,27 @@ pub type nvtxDomainRegisterStringW_impl_fntype = ::core::option::Option<unsafe e
 pub type nvtxDomainRegistration = nvtxDomainRegistration_st;
 pub type nvtxDomainResourceCreate_impl_fntype = ::core::option::Option<unsafe extern "C" fn(domain: nvtxDomainHandle_t, attribs: *mut nvtxResourceAttributes_t) -> nvtxResourceHandle_t>;
 pub type nvtxDomainResourceDestroy_impl_fntype = ::core::option::Option<unsafe extern "C" fn(resource: nvtxResourceHandle_t)>;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtxDomainSyncUserAcquireFailed_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtx_nvtxSyncUser_t)>;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080"))]
 pub type nvtxDomainSyncUserAcquireFailed_impl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtxSyncUser_t)>;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtxDomainSyncUserAcquireStart_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtx_nvtxSyncUser_t)>;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080"))]
 pub type nvtxDomainSyncUserAcquireStart_impl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtxSyncUser_t)>;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtxDomainSyncUserAcquireSuccess_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtx_nvtxSyncUser_t)>;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080"))]
 pub type nvtxDomainSyncUserAcquireSuccess_impl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtxSyncUser_t)>;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtxDomainSyncUserCreate_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(domain: nvtxDomainHandle_t, attribs: *const nvtx_nvtxSyncUserAttributes_t) -> nvtx_nvtxSyncUser_t>;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080"))]
 pub type nvtxDomainSyncUserCreate_impl_fntype = ::core::option::Option<unsafe extern "C" fn(domain: nvtxDomainHandle_t, attribs: *const nvtxSyncUserAttributes_t) -> nvtxSyncUser_t>;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtxDomainSyncUserDestroy_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtx_nvtxSyncUser_t)>;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080"))]
 pub type nvtxDomainSyncUserDestroy_impl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtxSyncUser_t)>;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtxDomainSyncUserReleasing_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtx_nvtxSyncUser_t)>;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080"))]
 pub type nvtxDomainSyncUserReleasing_impl_fntype = ::core::option::Option<unsafe extern "C" fn(handle: nvtxSyncUser_t)>;
@@ -80,11 +80,11 @@ pub type nvtxNameCuEventA_fakeimpl_fntype = ::core::option::Option<unsafe extern
 pub type nvtxNameCuEventW_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(event: nvtx_CUevent, name: *const wchar_t)>;
 pub type nvtxNameCuStreamA_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(stream: nvtx_CUstream, name: *const ::core::ffi::c_char)>;
 pub type nvtxNameCuStreamW_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(stream: nvtx_CUstream, name: *const wchar_t)>;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtxNameCudaDeviceA_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(device: ::core::ffi::c_int, name: *const ::core::ffi::c_char)>;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080"))]
 pub type nvtxNameCudaDeviceA_impl_fntype = ::core::option::Option<unsafe extern "C" fn(device: ::core::ffi::c_int, name: *const ::core::ffi::c_char)>;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtxNameCudaDeviceW_fakeimpl_fntype = ::core::option::Option<unsafe extern "C" fn(device: ::core::ffi::c_int, name: *const wchar_t)>;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080"))]
 pub type nvtxNameCudaDeviceW_impl_fntype = ::core::option::Option<unsafe extern "C" fn(device: ::core::ffi::c_int, name: *const wchar_t)>;
@@ -126,9 +126,9 @@ pub type nvtx_cl_program = *mut ::core::ffi::c_void;
 pub type nvtx_cl_sampler = *mut ::core::ffi::c_void;
 pub type nvtx_cudaEvent_t = *mut ::core::ffi::c_void;
 pub type nvtx_cudaStream_t = *mut ::core::ffi::c_void;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtx_nvtxSyncUserAttributes_t = ::core::ffi::c_void;
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type nvtx_nvtxSyncUser_t = *mut ::core::ffi::c_void;
 pub type wchar_t = ::core::ffi::c_int;
 #[repr(u32)]

--- a/src/runtime/result.rs
+++ b/src/runtime/result.rs
@@ -201,7 +201,8 @@ pub mod device {
             feature = "cuda-11040",
             feature = "cuda-13000",
             feature = "cuda-13010",
-            feature = "cuda-13020"
+            feature = "cuda-13020",
+            feature = "cuda-13030"
         )))]
         unsafe {
             sys::cudaGetDeviceProperties_v2(prop.as_mut_ptr(), ordinal).result()?;
@@ -215,7 +216,8 @@ pub mod device {
             feature = "cuda-11040",
             feature = "cuda-13000",
             feature = "cuda-13010",
-            feature = "cuda-13020"
+            feature = "cuda-13020",
+            feature = "cuda-13030"
         ))]
         unsafe {
             sys::cudaGetDeviceProperties(prop.as_mut_ptr(), ordinal).result()?;
@@ -947,7 +949,12 @@ pub mod external_memory {
             handle: sys::cudaExternalMemoryHandleDesc__bindgen_ty_1 { fd },
             size,
             flags: 0,
-            #[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+            #[cfg(any(
+                feature = "cuda-13000",
+                feature = "cuda-13010",
+                feature = "cuda-13020",
+                feature = "cuda-13030"
+            ))]
             reserved: [0; 16],
         };
         sys::cudaImportExternalMemory(external_memory.as_mut_ptr(), &handle_description)
@@ -979,7 +986,12 @@ pub mod external_memory {
             },
             size,
             flags: 0,
-            #[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+            #[cfg(any(
+                feature = "cuda-13000",
+                feature = "cuda-13010",
+                feature = "cuda-13020",
+                feature = "cuda-13030"
+            ))]
             reserved: [0; 16],
         };
         sys::cudaImportExternalMemory(external_memory.as_mut_ptr(), &handle_description)
@@ -1018,7 +1030,12 @@ pub mod external_memory {
             offset,
             size,
             flags: 0,
-            #[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+            #[cfg(any(
+                feature = "cuda-13000",
+                feature = "cuda-13010",
+                feature = "cuda-13020",
+                feature = "cuda-13030"
+            ))]
             reserved: [0; 16],
         };
         sys::cudaExternalMemoryGetMappedBuffer(

--- a/src/runtime/sys/mod.rs
+++ b/src/runtime/sys/mod.rs
@@ -11,21 +11,21 @@ extern crate no_std_compat as std;
 fn load<F: Copy>(name: &str) -> F {
     unsafe { *culib().get::<F>(name.as_bytes()).unwrap_or_else(|e| panic!("Missing symbol {name}: {e}")) }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::cudaAsyncNotificationType_enum as cudaAsyncNotificationType;
 pub use self::cudaDataType_t as cudaDataType;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::cudaEmulationMantissaControl_t as cudaEmulationMantissaControl;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::cudaEmulationSpecialValuesSupport_t as cudaEmulationSpecialValuesSupport;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::cudaEmulationStrategy_t as cudaEmulationStrategy;
 pub use self::cudaError as cudaError_t;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::cudaGraphDependencyType_enum as cudaGraphDependencyType;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080"))]
 pub use self::cudaOutputMode as cudaOutputMode_t;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub use self::CUDAlogLevel_enum as cudaLogLevel;
 #[cfg(any(feature = "cuda-11040"))]
 pub const CUDART_VERSION: u32 = 11040;
@@ -61,11 +61,13 @@ pub const CUDART_VERSION: u32 = 13000;
 pub const CUDART_VERSION: u32 = 13010;
 #[cfg(any(feature = "cuda-13020"))]
 pub const CUDART_VERSION: u32 = 13020;
+#[cfg(any(feature = "cuda-13030"))]
+pub const CUDART_VERSION: u32 = 13030;
 pub const CUDA_IPC_HANDLE_SIZE: u32 = 64;
 pub const cudaArrayColorAttachment: u32 = 32;
 pub const cudaArrayCubemap: u32 = 4;
 pub const cudaArrayDefault: u32 = 0;
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const cudaArrayDeferredMapping: u32 = 128;
 pub const cudaArrayLayered: u32 = 1;
 pub const cudaArraySparse: u32 = 64;
@@ -81,14 +83,14 @@ pub const cudaDeviceLmemResizeToMax: u32 = 16;
 pub const cudaDeviceMapHost: u32 = 8;
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000"))]
 pub const cudaDeviceMask: u32 = 31;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const cudaDeviceMask: u32 = 255;
 pub const cudaDeviceScheduleAuto: u32 = 0;
 pub const cudaDeviceScheduleBlockingSync: u32 = 4;
 pub const cudaDeviceScheduleMask: u32 = 7;
 pub const cudaDeviceScheduleSpin: u32 = 1;
 pub const cudaDeviceScheduleYield: u32 = 2;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const cudaDeviceSyncMemops: u32 = 128;
 pub const cudaEventBlockingSync: u32 = 1;
 pub const cudaEventDefault: u32 = 0;
@@ -101,11 +103,11 @@ pub const cudaEventWaitExternal: u32 = 1;
 pub const cudaExternalMemoryDedicated: u32 = 1;
 pub const cudaExternalSemaphoreSignalSkipNvSciBufMemSync: u32 = 1;
 pub const cudaExternalSemaphoreWaitSkipNvSciBufMemSync: u32 = 2;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const cudaGraphKernelNodePortDefault: u32 = 0;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const cudaGraphKernelNodePortLaunchCompletion: u32 = 2;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const cudaGraphKernelNodePortProgrammatic: u32 = 1;
 pub const cudaHostAllocDefault: u32 = 0;
 pub const cudaHostAllocMapped: u32 = 2;
@@ -116,13 +118,13 @@ pub const cudaHostRegisterIoMemory: u32 = 4;
 pub const cudaHostRegisterMapped: u32 = 2;
 pub const cudaHostRegisterPortable: u32 = 1;
 pub const cudaHostRegisterReadOnly: u32 = 8;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const cudaInitDeviceFlagsAreValid: u32 = 1;
 pub const cudaIpcMemLazyEnablePeerAccess: u32 = 1;
 pub const cudaMemAttachGlobal: u32 = 1;
 pub const cudaMemAttachHost: u32 = 2;
 pub const cudaMemAttachSingle: u32 = 4;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub const cudaMemPoolCreateUsageHwDecompress: u32 = 2;
 pub const cudaNvSciSyncAttrSignal: u32 = 1;
 pub const cudaNvSciSyncAttrWait: u32 = 2;
@@ -147,58 +149,60 @@ pub const cudaTextureTypeCubemap: u32 = 12;
 pub const cudaTextureTypeCubemapLayered: u32 = 252;
 pub type cudaArray_const_t = *const cudaArray;
 pub type cudaArray_t = *mut cudaArray;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaAsyncCallback = ::core::option::Option<unsafe extern "C" fn(arg1: *mut cudaAsyncNotificationInfo_t, arg2: *mut ::core::ffi::c_void, arg3: cudaAsyncCallbackHandle_t)>;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaAsyncCallbackHandle_t = *mut cudaAsyncCallbackEntry;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaAsyncNotificationInfo_t = cudaAsyncNotificationInfo;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDevResource = cudaDevResource_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDevResourceDesc_t = *mut CUdevResourceDesc_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaDevSmResourceGroupParams = cudaDevSmResourceGroupParams_st;
 pub type cudaEvent_t = *mut CUevent_st;
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaExecutionContext_t = *mut cudaExecutionContext_st;
 pub type cudaExternalMemory_t = *mut CUexternalMemory_st;
 pub type cudaExternalSemaphore_t = *mut CUexternalSemaphore_st;
 pub type cudaFunction_t = *mut CUfunc_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphConditionalHandle = ::core::ffi::c_ulonglong;
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphDeviceNode_t = *mut CUgraphDeviceUpdatableNode_st;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphEdgeData = cudaGraphEdgeData_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphExecUpdateResultInfo = cudaGraphExecUpdateResultInfo_st;
 pub type cudaGraphExec_t = *mut CUgraphExec_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaGraphInstantiateParams = cudaGraphInstantiateParams_st;
 pub type cudaGraphNode_t = *mut CUgraphNode_st;
+#[cfg(any(feature = "cuda-13030"))]
+pub type cudaGraphRecaptureCallback_t = ::core::option::Option<unsafe extern "C" fn(data: *mut ::core::ffi::c_void, node: cudaGraphNode_t, originalParams: *const cudaGraphNodeParams, recaptureParams: *const cudaGraphNodeParams, status: cudaGraphRecaptureStatus) -> cudaError_t>;
 pub type cudaGraph_t = *mut CUgraph_st;
 pub type cudaGraphicsResource_t = *mut cudaGraphicsResource;
 pub type cudaHostFn_t = ::core::option::Option<unsafe extern "C" fn(userData: *mut ::core::ffi::c_void)>;
 pub type cudaIpcEventHandle_t = cudaIpcEventHandle_st;
 pub type cudaIpcMemHandle_t = cudaIpcMemHandle_st;
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaKernel_t = *mut CUkern_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLaunchAttribute = cudaLaunchAttribute_st;
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLaunchConfig_t = cudaLaunchConfig_st;
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLaunchMemSyncDomainMap = cudaLaunchMemSyncDomainMap_st;
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLibrary_t = *mut CUlib_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLogIterator = ::core::ffi::c_uint;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLogsCallbackHandle = *mut CUlogsCallbackEntry_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaLogsCallback_t = ::core::option::Option<unsafe extern "C" fn(data: *mut ::core::ffi::c_void, logLevel: cudaLogLevel, message: *mut ::core::ffi::c_char, length: usize)>;
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub type cudaMemFabricHandle_t = cudaMemFabricHandle_st;
 pub type cudaMemPool_t = *mut CUmemPoolHandle_st;
 pub type cudaMipmappedArray_const_t = *const cudaMipmappedArray;
@@ -209,7 +213,7 @@ pub type cudaSurfaceObject_t = ::core::ffi::c_ulonglong;
 pub type cudaTextureObject_t = ::core::ffi::c_ulonglong;
 pub type cudaUUID_t = CUuuid_st;
 pub type cudaUserObject_t = *mut CUuserObject_st;
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CUDAlogLevel_enum {
@@ -223,13 +227,13 @@ pub enum cudaAccessProperty {
     cudaAccessPropertyStreaming = 1,
     cudaAccessPropertyPersisting = 2,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaAsyncNotificationType_enum {
     cudaAsyncNotificationTypeOverBudget = 1,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaAtomicOperation {
@@ -247,7 +251,7 @@ pub enum cudaAtomicOperation {
     cudaAtomicOperationFloatMin = 11,
     cudaAtomicOperationFloatMax = 12,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaAtomicOperationCapability {
@@ -267,7 +271,7 @@ pub enum cudaCGScope {
     cudaCGScopeGrid = 1,
     cudaCGScopeMultiGrid = 2,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaCGScope {
@@ -358,7 +362,58 @@ pub enum cudaChannelFormatKind {
     cudaChannelFormatKindUnsignedBlockCompressed7SRGB = 30,
     cudaChannelFormatKindUnsignedNormalized1010102 = 31,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cudaChannelFormatKind {
+    cudaChannelFormatKindSigned = 0,
+    cudaChannelFormatKindUnsigned = 1,
+    cudaChannelFormatKindFloat = 2,
+    cudaChannelFormatKindNone = 3,
+    cudaChannelFormatKindNV12 = 4,
+    cudaChannelFormatKindUnsignedNormalized8X1 = 5,
+    cudaChannelFormatKindUnsignedNormalized8X2 = 6,
+    cudaChannelFormatKindUnsignedNormalized8X4 = 7,
+    cudaChannelFormatKindUnsignedNormalized16X1 = 8,
+    cudaChannelFormatKindUnsignedNormalized16X2 = 9,
+    cudaChannelFormatKindUnsignedNormalized16X4 = 10,
+    cudaChannelFormatKindSignedNormalized8X1 = 11,
+    cudaChannelFormatKindSignedNormalized8X2 = 12,
+    cudaChannelFormatKindSignedNormalized8X4 = 13,
+    cudaChannelFormatKindSignedNormalized16X1 = 14,
+    cudaChannelFormatKindSignedNormalized16X2 = 15,
+    cudaChannelFormatKindSignedNormalized16X4 = 16,
+    cudaChannelFormatKindUnsignedBlockCompressed1 = 17,
+    cudaChannelFormatKindUnsignedBlockCompressed1SRGB = 18,
+    cudaChannelFormatKindUnsignedBlockCompressed2 = 19,
+    cudaChannelFormatKindUnsignedBlockCompressed2SRGB = 20,
+    cudaChannelFormatKindUnsignedBlockCompressed3 = 21,
+    cudaChannelFormatKindUnsignedBlockCompressed3SRGB = 22,
+    cudaChannelFormatKindUnsignedBlockCompressed4 = 23,
+    cudaChannelFormatKindSignedBlockCompressed4 = 24,
+    cudaChannelFormatKindUnsignedBlockCompressed5 = 25,
+    cudaChannelFormatKindSignedBlockCompressed5 = 26,
+    cudaChannelFormatKindUnsignedBlockCompressed6H = 27,
+    cudaChannelFormatKindSignedBlockCompressed6H = 28,
+    cudaChannelFormatKindUnsignedBlockCompressed7 = 29,
+    cudaChannelFormatKindUnsignedBlockCompressed7SRGB = 30,
+    cudaChannelFormatKindUnsignedNormalized1010102 = 31,
+    cudaChannelFormatKindUnsigned8Packed422 = 32,
+    cudaChannelFormatKindUnsigned8Packed444 = 33,
+    cudaChannelFormatKindUnsigned8SemiPlanar420 = 34,
+    cudaChannelFormatKindUnsigned16SemiPlanar420 = 35,
+    cudaChannelFormatKindUnsigned8SemiPlanar422 = 36,
+    cudaChannelFormatKindUnsigned16SemiPlanar422 = 37,
+    cudaChannelFormatKindUnsigned8SemiPlanar444 = 38,
+    cudaChannelFormatKindUnsigned16SemiPlanar444 = 39,
+    cudaChannelFormatKindUnsigned8Planar420 = 40,
+    cudaChannelFormatKindUnsigned16Planar420 = 41,
+    cudaChannelFormatKindUnsigned8Planar422 = 42,
+    cudaChannelFormatKindUnsigned16Planar422 = 43,
+    cudaChannelFormatKindUnsigned8Planar444 = 44,
+    cudaChannelFormatKindUnsigned16Planar444 = 45,
+}
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaClusterSchedulingPolicy {
@@ -442,7 +497,7 @@ pub enum cudaDataType_t {
     CUDA_R_8F_E4M3 = 28,
     CUDA_R_8F_E5M2 = 29,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDataType_t {
@@ -481,7 +536,7 @@ pub enum cudaDataType_t {
     CUDA_R_6F_E3M2 = 32,
     CUDA_R_4F_E2M1 = 33,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDevResourceType {
@@ -490,21 +545,21 @@ pub enum cudaDevResourceType {
     cudaDevResourceTypeWorkqueueConfig = 1000,
     cudaDevResourceTypeWorkqueue = 10000,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDevSmResourceGroup_flags {
     cudaDevSmResourceGroupDefault = 0,
     cudaDevSmResourceGroupBackfill = 1,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDevSmResourceSplitByCount_flags {
     cudaDevSmResourceSplitIgnoreSmCoscheduling = 1,
     cudaDevSmResourceSplitMaxPotentialClusterSize = 2,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDevWorkqueueConfigScope {
@@ -2059,7 +2114,152 @@ pub enum cudaDeviceAttr {
     cudaDevAttrOnlyPartialHostNativeAtomicSupported = 147,
     cudaDevAttrMax = 148,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cudaDeviceAttr {
+    cudaDevAttrMaxThreadsPerBlock = 1,
+    cudaDevAttrMaxBlockDimX = 2,
+    cudaDevAttrMaxBlockDimY = 3,
+    cudaDevAttrMaxBlockDimZ = 4,
+    cudaDevAttrMaxGridDimX = 5,
+    cudaDevAttrMaxGridDimY = 6,
+    cudaDevAttrMaxGridDimZ = 7,
+    cudaDevAttrMaxSharedMemoryPerBlock = 8,
+    cudaDevAttrTotalConstantMemory = 9,
+    cudaDevAttrWarpSize = 10,
+    cudaDevAttrMaxPitch = 11,
+    cudaDevAttrMaxRegistersPerBlock = 12,
+    cudaDevAttrClockRate = 13,
+    cudaDevAttrTextureAlignment = 14,
+    cudaDevAttrGpuOverlap = 15,
+    cudaDevAttrMultiProcessorCount = 16,
+    cudaDevAttrKernelExecTimeout = 17,
+    cudaDevAttrIntegrated = 18,
+    cudaDevAttrCanMapHostMemory = 19,
+    cudaDevAttrComputeMode = 20,
+    cudaDevAttrMaxTexture1DWidth = 21,
+    cudaDevAttrMaxTexture2DWidth = 22,
+    cudaDevAttrMaxTexture2DHeight = 23,
+    cudaDevAttrMaxTexture3DWidth = 24,
+    cudaDevAttrMaxTexture3DHeight = 25,
+    cudaDevAttrMaxTexture3DDepth = 26,
+    cudaDevAttrMaxTexture2DLayeredWidth = 27,
+    cudaDevAttrMaxTexture2DLayeredHeight = 28,
+    cudaDevAttrMaxTexture2DLayeredLayers = 29,
+    cudaDevAttrSurfaceAlignment = 30,
+    cudaDevAttrConcurrentKernels = 31,
+    cudaDevAttrEccEnabled = 32,
+    cudaDevAttrPciBusId = 33,
+    cudaDevAttrPciDeviceId = 34,
+    cudaDevAttrTccDriver = 35,
+    cudaDevAttrMemoryClockRate = 36,
+    cudaDevAttrGlobalMemoryBusWidth = 37,
+    cudaDevAttrL2CacheSize = 38,
+    cudaDevAttrMaxThreadsPerMultiProcessor = 39,
+    cudaDevAttrAsyncEngineCount = 40,
+    cudaDevAttrUnifiedAddressing = 41,
+    cudaDevAttrMaxTexture1DLayeredWidth = 42,
+    cudaDevAttrMaxTexture1DLayeredLayers = 43,
+    cudaDevAttrMaxTexture2DGatherWidth = 45,
+    cudaDevAttrMaxTexture2DGatherHeight = 46,
+    cudaDevAttrMaxTexture3DWidthAlt = 47,
+    cudaDevAttrMaxTexture3DHeightAlt = 48,
+    cudaDevAttrMaxTexture3DDepthAlt = 49,
+    cudaDevAttrPciDomainId = 50,
+    cudaDevAttrTexturePitchAlignment = 51,
+    cudaDevAttrMaxTextureCubemapWidth = 52,
+    cudaDevAttrMaxTextureCubemapLayeredWidth = 53,
+    cudaDevAttrMaxTextureCubemapLayeredLayers = 54,
+    cudaDevAttrMaxSurface1DWidth = 55,
+    cudaDevAttrMaxSurface2DWidth = 56,
+    cudaDevAttrMaxSurface2DHeight = 57,
+    cudaDevAttrMaxSurface3DWidth = 58,
+    cudaDevAttrMaxSurface3DHeight = 59,
+    cudaDevAttrMaxSurface3DDepth = 60,
+    cudaDevAttrMaxSurface1DLayeredWidth = 61,
+    cudaDevAttrMaxSurface1DLayeredLayers = 62,
+    cudaDevAttrMaxSurface2DLayeredWidth = 63,
+    cudaDevAttrMaxSurface2DLayeredHeight = 64,
+    cudaDevAttrMaxSurface2DLayeredLayers = 65,
+    cudaDevAttrMaxSurfaceCubemapWidth = 66,
+    cudaDevAttrMaxSurfaceCubemapLayeredWidth = 67,
+    cudaDevAttrMaxSurfaceCubemapLayeredLayers = 68,
+    cudaDevAttrMaxTexture1DLinearWidth = 69,
+    cudaDevAttrMaxTexture2DLinearWidth = 70,
+    cudaDevAttrMaxTexture2DLinearHeight = 71,
+    cudaDevAttrMaxTexture2DLinearPitch = 72,
+    cudaDevAttrMaxTexture2DMipmappedWidth = 73,
+    cudaDevAttrMaxTexture2DMipmappedHeight = 74,
+    cudaDevAttrComputeCapabilityMajor = 75,
+    cudaDevAttrComputeCapabilityMinor = 76,
+    cudaDevAttrMaxTexture1DMipmappedWidth = 77,
+    cudaDevAttrStreamPrioritiesSupported = 78,
+    cudaDevAttrGlobalL1CacheSupported = 79,
+    cudaDevAttrLocalL1CacheSupported = 80,
+    cudaDevAttrMaxSharedMemoryPerMultiprocessor = 81,
+    cudaDevAttrMaxRegistersPerMultiprocessor = 82,
+    cudaDevAttrManagedMemory = 83,
+    cudaDevAttrIsMultiGpuBoard = 84,
+    cudaDevAttrMultiGpuBoardGroupID = 85,
+    cudaDevAttrHostNativeAtomicSupported = 86,
+    cudaDevAttrSingleToDoublePrecisionPerfRatio = 87,
+    cudaDevAttrPageableMemoryAccess = 88,
+    cudaDevAttrConcurrentManagedAccess = 89,
+    cudaDevAttrComputePreemptionSupported = 90,
+    cudaDevAttrCanUseHostPointerForRegisteredMem = 91,
+    cudaDevAttrReserved92 = 92,
+    cudaDevAttrReserved93 = 93,
+    cudaDevAttrReserved94 = 94,
+    cudaDevAttrCooperativeLaunch = 95,
+    cudaDevAttrReserved96 = 96,
+    cudaDevAttrMaxSharedMemoryPerBlockOptin = 97,
+    cudaDevAttrCanFlushRemoteWrites = 98,
+    cudaDevAttrHostRegisterSupported = 99,
+    cudaDevAttrPageableMemoryAccessUsesHostPageTables = 100,
+    cudaDevAttrDirectManagedMemAccessFromHost = 101,
+    cudaDevAttrMaxBlocksPerMultiprocessor = 106,
+    cudaDevAttrMaxPersistingL2CacheSize = 108,
+    cudaDevAttrMaxAccessPolicyWindowSize = 109,
+    cudaDevAttrReservedSharedMemoryPerBlock = 111,
+    cudaDevAttrSparseCudaArraySupported = 112,
+    cudaDevAttrHostRegisterReadOnlySupported = 113,
+    cudaDevAttrTimelineSemaphoreInteropSupported = 114,
+    cudaDevAttrMemoryPoolsSupported = 115,
+    cudaDevAttrGPUDirectRDMASupported = 116,
+    cudaDevAttrGPUDirectRDMAFlushWritesOptions = 117,
+    cudaDevAttrGPUDirectRDMAWritesOrdering = 118,
+    cudaDevAttrMemoryPoolSupportedHandleTypes = 119,
+    cudaDevAttrClusterLaunch = 120,
+    cudaDevAttrDeferredMappingCudaArraySupported = 121,
+    cudaDevAttrReserved122 = 122,
+    cudaDevAttrReserved123 = 123,
+    cudaDevAttrReserved124 = 124,
+    cudaDevAttrIpcEventSupport = 125,
+    cudaDevAttrMemSyncDomainCount = 126,
+    cudaDevAttrReserved127 = 127,
+    cudaDevAttrReserved128 = 128,
+    cudaDevAttrReserved129 = 129,
+    cudaDevAttrNumaConfig = 130,
+    cudaDevAttrNumaId = 131,
+    cudaDevAttrReserved132 = 132,
+    cudaDevAttrMpsEnabled = 133,
+    cudaDevAttrHostNumaId = 134,
+    cudaDevAttrD3D12CigSupported = 135,
+    cudaDevAttrVulkanCigSupported = 138,
+    cudaDevAttrGpuPciDeviceId = 139,
+    cudaDevAttrGpuPciSubsystemId = 140,
+    cudaDevAttrReserved141 = 141,
+    cudaDevAttrHostNumaMemoryPoolsSupported = 142,
+    cudaDevAttrHostNumaMultinodeIpcSupported = 143,
+    cudaDevAttrHostMemoryPoolsSupported = 144,
+    cudaDevAttrReserved145 = 145,
+    cudaDevAttrOnlyPartialHostNativeAtomicSupported = 147,
+    cudaDevAttrAtomicReductionSupported = 148,
+    cudaDevAttrCigStreamsSupported = 151,
+    cudaDevAttrMax = 152,
+}
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDeviceNumaConfig {
@@ -2075,7 +2275,7 @@ pub enum cudaDeviceP2PAttr {
     cudaDevP2PAttrNativeAtomicSupported = 3,
     cudaDevP2PAttrCudaArrayAccessSupported = 4,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDeviceP2PAttr {
@@ -2085,7 +2285,7 @@ pub enum cudaDeviceP2PAttr {
     cudaDevP2PAttrCudaArrayAccessSupported = 4,
     cudaDevP2PAttrOnlyPartialNativeAtomicSupported = 5,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaDriverEntryPointQueryResult {
@@ -2093,14 +2293,14 @@ pub enum cudaDriverEntryPointQueryResult {
     cudaDriverEntryPointSymbolNotFound = 1,
     cudaDriverEntryPointVersionNotSufficent = 2,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaEmulationMantissaControl_t {
     CUDA_EMULATION_MANTISSA_CONTROL_DYNAMIC = 0,
     CUDA_EMULATION_MANTISSA_CONTROL_FIXED = 1,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaEmulationSpecialValuesSupport_t {
@@ -2109,7 +2309,7 @@ pub enum cudaEmulationSpecialValuesSupport_t {
     CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_INFINITY = 1,
     CUDA_EMULATION_SPECIAL_VALUES_SUPPORT_NAN = 2,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaEmulationStrategy_t {
@@ -3331,6 +3531,148 @@ pub enum cudaError {
     cudaErrorUnknown = 999,
     cudaErrorApiFailureBase = 10000,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cudaError {
+    cudaSuccess = 0,
+    cudaErrorInvalidValue = 1,
+    cudaErrorMemoryAllocation = 2,
+    cudaErrorInitializationError = 3,
+    cudaErrorCudartUnloading = 4,
+    cudaErrorProfilerDisabled = 5,
+    cudaErrorProfilerNotInitialized = 6,
+    cudaErrorProfilerAlreadyStarted = 7,
+    cudaErrorProfilerAlreadyStopped = 8,
+    cudaErrorInvalidConfiguration = 9,
+    cudaErrorVersionTranslation = 10,
+    cudaErrorInvalidPitchValue = 12,
+    cudaErrorInvalidSymbol = 13,
+    cudaErrorInvalidHostPointer = 16,
+    cudaErrorInvalidDevicePointer = 17,
+    cudaErrorInvalidTexture = 18,
+    cudaErrorInvalidTextureBinding = 19,
+    cudaErrorInvalidChannelDescriptor = 20,
+    cudaErrorInvalidMemcpyDirection = 21,
+    cudaErrorAddressOfConstant = 22,
+    cudaErrorTextureFetchFailed = 23,
+    cudaErrorTextureNotBound = 24,
+    cudaErrorSynchronizationError = 25,
+    cudaErrorInvalidFilterSetting = 26,
+    cudaErrorInvalidNormSetting = 27,
+    cudaErrorMixedDeviceExecution = 28,
+    cudaErrorNotYetImplemented = 31,
+    cudaErrorMemoryValueTooLarge = 32,
+    cudaErrorStubLibrary = 34,
+    cudaErrorInsufficientDriver = 35,
+    cudaErrorCallRequiresNewerDriver = 36,
+    cudaErrorInvalidSurface = 37,
+    cudaErrorDuplicateVariableName = 43,
+    cudaErrorDuplicateTextureName = 44,
+    cudaErrorDuplicateSurfaceName = 45,
+    cudaErrorDevicesUnavailable = 46,
+    cudaErrorIncompatibleDriverContext = 49,
+    cudaErrorMissingConfiguration = 52,
+    cudaErrorPriorLaunchFailure = 53,
+    cudaErrorLaunchMaxDepthExceeded = 65,
+    cudaErrorLaunchFileScopedTex = 66,
+    cudaErrorLaunchFileScopedSurf = 67,
+    cudaErrorSyncDepthExceeded = 68,
+    cudaErrorLaunchPendingCountExceeded = 69,
+    cudaErrorInvalidDeviceFunction = 98,
+    cudaErrorNoDevice = 100,
+    cudaErrorInvalidDevice = 101,
+    cudaErrorDeviceNotLicensed = 102,
+    cudaErrorSoftwareValidityNotEstablished = 103,
+    cudaErrorStartupFailure = 127,
+    cudaErrorInvalidKernelImage = 200,
+    cudaErrorDeviceUninitialized = 201,
+    cudaErrorMapBufferObjectFailed = 205,
+    cudaErrorUnmapBufferObjectFailed = 206,
+    cudaErrorArrayIsMapped = 207,
+    cudaErrorAlreadyMapped = 208,
+    cudaErrorNoKernelImageForDevice = 209,
+    cudaErrorAlreadyAcquired = 210,
+    cudaErrorNotMapped = 211,
+    cudaErrorNotMappedAsArray = 212,
+    cudaErrorNotMappedAsPointer = 213,
+    cudaErrorECCUncorrectable = 214,
+    cudaErrorUnsupportedLimit = 215,
+    cudaErrorDeviceAlreadyInUse = 216,
+    cudaErrorPeerAccessUnsupported = 217,
+    cudaErrorInvalidPtx = 218,
+    cudaErrorInvalidGraphicsContext = 219,
+    cudaErrorNvlinkUncorrectable = 220,
+    cudaErrorJitCompilerNotFound = 221,
+    cudaErrorUnsupportedPtxVersion = 222,
+    cudaErrorJitCompilationDisabled = 223,
+    cudaErrorUnsupportedExecAffinity = 224,
+    cudaErrorUnsupportedDevSideSync = 225,
+    cudaErrorContained = 226,
+    cudaErrorInvalidSource = 300,
+    cudaErrorFileNotFound = 301,
+    cudaErrorSharedObjectSymbolNotFound = 302,
+    cudaErrorSharedObjectInitFailed = 303,
+    cudaErrorOperatingSystem = 304,
+    cudaErrorInvalidResourceHandle = 400,
+    cudaErrorIllegalState = 401,
+    cudaErrorLossyQuery = 402,
+    cudaErrorSymbolNotFound = 500,
+    cudaErrorNotReady = 600,
+    cudaErrorIllegalAddress = 700,
+    cudaErrorLaunchOutOfResources = 701,
+    cudaErrorLaunchTimeout = 702,
+    cudaErrorLaunchIncompatibleTexturing = 703,
+    cudaErrorPeerAccessAlreadyEnabled = 704,
+    cudaErrorPeerAccessNotEnabled = 705,
+    cudaErrorSetOnActiveProcess = 708,
+    cudaErrorContextIsDestroyed = 709,
+    cudaErrorAssert = 710,
+    cudaErrorTooManyPeers = 711,
+    cudaErrorHostMemoryAlreadyRegistered = 712,
+    cudaErrorHostMemoryNotRegistered = 713,
+    cudaErrorHardwareStackError = 714,
+    cudaErrorIllegalInstruction = 715,
+    cudaErrorMisalignedAddress = 716,
+    cudaErrorInvalidAddressSpace = 717,
+    cudaErrorInvalidPc = 718,
+    cudaErrorLaunchFailure = 719,
+    cudaErrorCooperativeLaunchTooLarge = 720,
+    cudaErrorTensorMemoryLeak = 721,
+    cudaErrorNotPermitted = 800,
+    cudaErrorNotSupported = 801,
+    cudaErrorSystemNotReady = 802,
+    cudaErrorSystemDriverMismatch = 803,
+    cudaErrorCompatNotSupportedOnDevice = 804,
+    cudaErrorMpsConnectionFailed = 805,
+    cudaErrorMpsRpcFailure = 806,
+    cudaErrorMpsServerNotReady = 807,
+    cudaErrorMpsMaxClientsReached = 808,
+    cudaErrorMpsMaxConnectionsReached = 809,
+    cudaErrorMpsClientTerminated = 810,
+    cudaErrorCdpNotSupported = 811,
+    cudaErrorCdpVersionMismatch = 812,
+    cudaErrorStreamCaptureUnsupported = 900,
+    cudaErrorStreamCaptureInvalidated = 901,
+    cudaErrorStreamCaptureMerge = 902,
+    cudaErrorStreamCaptureUnmatched = 903,
+    cudaErrorStreamCaptureUnjoined = 904,
+    cudaErrorStreamCaptureIsolation = 905,
+    cudaErrorStreamCaptureImplicit = 906,
+    cudaErrorCapturedEvent = 907,
+    cudaErrorStreamCaptureWrongThread = 908,
+    cudaErrorTimeout = 909,
+    cudaErrorGraphExecUpdateFailure = 910,
+    cudaErrorExternalDevice = 911,
+    cudaErrorInvalidClusterSize = 912,
+    cudaErrorFunctionNotLoaded = 913,
+    cudaErrorInvalidResourceType = 914,
+    cudaErrorInvalidResourceConfiguration = 915,
+    cudaErrorStreamDetached = 917,
+    cudaErrorGraphRecaptureFailure = 918,
+    cudaErrorUnknown = 999,
+    cudaErrorApiFailureBase = 10000,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaExternalMemoryHandleType {
@@ -3357,6 +3699,20 @@ pub enum cudaExternalSemaphoreHandleType {
     cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd = 9,
     cudaExternalSemaphoreHandleTypeTimelineSemaphoreWin32 = 10,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cudaFabricOpStatusInfo {
+    cudaFabricOpStatusInfoSuccess = 0,
+    cudaFabricOpStatusInfoMax = 2147483647,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cudaFabricOpStatusSource {
+    cudaFabricOpStatusSourceMbarrierV1 = 0,
+    cudaFabricOpStatusSourceMax = 2147483647,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaFlushGPUDirectRDMAWritesOptions {
@@ -3382,7 +3738,7 @@ pub enum cudaFuncAttribute {
     cudaFuncAttributePreferredSharedMemoryCarveout = 9,
     cudaFuncAttributeMax = 10,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaFuncAttribute {
@@ -3425,7 +3781,7 @@ pub enum cudaGraphChildGraphNodeOwnership {
     cudaGraphChildGraphOwnershipClone = 0,
     cudaGraphChildGraphOwnershipMove = 1,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphChildGraphNodeOwnership {
@@ -3433,7 +3789,7 @@ pub enum cudaGraphChildGraphNodeOwnership {
     cudaGraphChildGraphOwnershipMove = 1,
     cudaGraphChildGraphOwnershipInvalid = -1,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphConditionalHandleFlags {
@@ -3446,7 +3802,7 @@ pub enum cudaGraphConditionalNodeType {
     cudaGraphCondTypeIf = 0,
     cudaGraphCondTypeWhile = 1,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphConditionalNodeType {
@@ -3469,7 +3825,7 @@ pub enum cudaGraphDebugDotFlags {
     cudaGraphDebugDotFlagsKernelNodeAttributes = 512,
     cudaGraphDebugDotFlagsHandles = 1024,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphDebugDotFlags {
@@ -3485,7 +3841,7 @@ pub enum cudaGraphDebugDotFlags {
     cudaGraphDebugDotFlagsHandles = 1024,
     cudaGraphDebugDotFlagsConditionalNodeParams = 32768,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphDependencyType_enum {
@@ -3505,7 +3861,7 @@ pub enum cudaGraphExecUpdateResult {
     cudaGraphExecUpdateErrorNotSupported = 6,
     cudaGraphExecUpdateErrorUnsupportedFunctionChange = 7,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphExecUpdateResult {
@@ -3532,7 +3888,7 @@ pub enum cudaGraphInstantiateFlags {
     cudaGraphInstantiateFlagAutoFreeOnLaunch = 1,
     cudaGraphInstantiateFlagUseNodePriority = 8,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphInstantiateFlags {
@@ -3551,7 +3907,7 @@ pub enum cudaGraphInstantiateResult {
     cudaGraphInstantiateNodeOperationNotSupported = 3,
     cudaGraphInstantiateMultipleDevicesNotSupported = 4,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphInstantiateResult {
@@ -3562,7 +3918,7 @@ pub enum cudaGraphInstantiateResult {
     cudaGraphInstantiateMultipleDevicesNotSupported = 4,
     cudaGraphInstantiateConditionalHandleUnused = 5,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphKernelNodeField {
@@ -3580,7 +3936,7 @@ pub enum cudaGraphMemAttributeType {
     cudaGraphMemAttrReservedMemCurrent = 3,
     cudaGraphMemAttrReservedMemHigh = 4,
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphMemAttributeType {
@@ -3626,6 +3982,34 @@ pub enum cudaGraphNodeType {
     cudaGraphNodeTypeConditional = 13,
     cudaGraphNodeTypeCount = 14,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cudaGraphNodeType {
+    cudaGraphNodeTypeKernel = 0,
+    cudaGraphNodeTypeMemcpy = 1,
+    cudaGraphNodeTypeMemset = 2,
+    cudaGraphNodeTypeHost = 3,
+    cudaGraphNodeTypeGraph = 4,
+    cudaGraphNodeTypeEmpty = 5,
+    cudaGraphNodeTypeWaitEvent = 6,
+    cudaGraphNodeTypeEventRecord = 7,
+    cudaGraphNodeTypeExtSemaphoreSignal = 8,
+    cudaGraphNodeTypeExtSemaphoreWait = 9,
+    cudaGraphNodeTypeMemAlloc = 10,
+    cudaGraphNodeTypeMemFree = 11,
+    cudaGraphNodeTypeConditional = 13,
+    cudaGraphNodeTypeReserved16 = 16,
+    cudaGraphNodeTypeCount = 17,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum cudaGraphRecaptureStatus {
+    cudaGraphRecaptureEligibleForUpdate = 0,
+    cudaGraphRecaptureIneligibleForUpdate = 1,
+    cudaGraphRecaptureError = 2,
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaGraphicsCubeFace {
@@ -3652,14 +4036,14 @@ pub enum cudaGraphicsRegisterFlags {
     cudaGraphicsRegisterFlagsSurfaceLoadStore = 4,
     cudaGraphicsRegisterFlagsTextureGather = 8,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaHostTaskSyncMode {
     cudaHostTaskBlocking = 0,
     cudaHostTaskSpinWait = 1,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaJitOption {
@@ -3681,7 +4065,7 @@ pub enum cudaJitOption {
     cudaJitMaxThreadsPerBlock = 32,
     cudaJitOverrideDirectiveValues = 33,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaJit_CacheMode {
@@ -3689,14 +4073,14 @@ pub enum cudaJit_CacheMode {
     cudaJitCacheOptionCG = 1,
     cudaJitCacheOptionCA = 2,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaJit_Fallback {
     cudaPreferPtx = 0,
     cudaPreferBinary = 1,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaKernelFunctionType {
@@ -3845,7 +4229,7 @@ pub enum cudaLaunchAttributeID {
     cudaLaunchAttributePreferredSharedMemoryCarveout = 14,
     cudaLaunchAttributeNvlinkUtilCentricScheduling = 16,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaLaunchAttributeID {
@@ -3868,7 +4252,7 @@ pub enum cudaLaunchAttributeID {
     cudaLaunchAttributePortableClusterSizeMode = 17,
     cudaLaunchAttributeSharedMemoryMode = 18,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaLaunchAttributePortableClusterMode {
@@ -3876,14 +4260,14 @@ pub enum cudaLaunchAttributePortableClusterMode {
     cudaLaunchPortableClusterModeRequirePortable = 1,
     cudaLaunchPortableClusterModeAllowNonPortable = 2,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaLaunchMemSyncDomain {
     cudaLaunchMemSyncDomainDefault = 0,
     cudaLaunchMemSyncDomainRemote = 1,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaLibraryOption {
@@ -3917,7 +4301,7 @@ pub enum cudaMemAllocationHandleType {
     cudaMemHandleTypeWin32 = 2,
     cudaMemHandleTypeWin32Kmt = 4,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaMemAllocationHandleType {
@@ -3935,7 +4319,7 @@ pub enum cudaMemAllocationType {
     cudaMemAllocationTypePinned = 1,
     cudaMemAllocationTypeMax = 2147483647,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaMemAllocationType {
@@ -3961,7 +4345,7 @@ pub enum cudaMemLocationType {
     cudaMemLocationTypeHostNuma = 3,
     cudaMemLocationTypeHostNumaCurrent = 4,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaMemLocationType {
@@ -3985,7 +4369,7 @@ pub enum cudaMemPoolAttr {
     cudaMemPoolAttrUsedMemCurrent = 7,
     cudaMemPoolAttrUsedMemHigh = 8,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaMemPoolAttr {
@@ -4013,7 +4397,7 @@ pub enum cudaMemRangeAttribute {
     cudaMemRangeAttributeAccessedBy = 3,
     cudaMemRangeAttributeLastPrefetchLocation = 4,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaMemRangeAttribute {
@@ -4026,7 +4410,7 @@ pub enum cudaMemRangeAttribute {
     cudaMemRangeAttributeLastPrefetchLocationType = 7,
     cudaMemRangeAttributeLastPrefetchLocationId = 8,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaMemcpy3DOperandType {
@@ -4034,7 +4418,7 @@ pub enum cudaMemcpy3DOperandType {
     cudaMemcpyOperandTypeArray = 2,
     cudaMemcpyOperandTypeMax = 2147483647,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaMemcpyFlags {
@@ -4050,7 +4434,7 @@ pub enum cudaMemcpyKind {
     cudaMemcpyDeviceToDevice = 3,
     cudaMemcpyDefault = 4,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaMemcpySrcAccessOrder {
@@ -4154,7 +4538,7 @@ pub enum cudaSharedMemConfig {
     cudaSharedMemBankSizeFourByte = 1,
     cudaSharedMemBankSizeEightByte = 2,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum cudaSharedMemoryMode {
@@ -4240,7 +4624,7 @@ pub enum cudaUserObjectFlags {
 pub enum cudaUserObjectRetainFlags {
     cudaGraphUserObjectMove = 1,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUdevResourceDesc_st {
@@ -4266,7 +4650,7 @@ pub struct CUexternalSemaphore_st {
 pub struct CUfunc_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUgraphDeviceUpdatableNode_st {
@@ -4287,19 +4671,19 @@ pub struct CUgraphNode_st {
 pub struct CUgraph_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUkern_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUlib_st {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CUlogsCallbackEntry_st {
@@ -4339,7 +4723,7 @@ pub struct cudaAccessPolicyWindow {
 pub struct cudaArray {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaArrayMemoryRequirements {
@@ -4363,20 +4747,20 @@ pub struct cudaArraySparseProperties__bindgen_ty_1 {
     pub height: ::core::ffi::c_uint,
     pub depth: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cudaAsyncCallbackEntry {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaAsyncNotificationInfo {
     pub type_: cudaAsyncNotificationType,
     pub info: cudaAsyncNotificationInfo__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaAsyncNotificationInfo__bindgen_ty_1__bindgen_ty_1 {
@@ -4397,7 +4781,7 @@ pub struct cudaChannelFormatDesc {
 pub struct cudaChildGraphNodeParams {
     pub graph: cudaGraph_t,
 }
-#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaChildGraphNodeParams {
@@ -4413,7 +4797,7 @@ pub struct cudaConditionalNodeParams {
     pub size: ::core::ffi::c_uint,
     pub phGraph_out: *mut cudaGraph_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaConditionalNodeParams {
@@ -4423,7 +4807,7 @@ pub struct cudaConditionalNodeParams {
     pub phGraph_out: *mut cudaGraph_t,
     pub ctx: cudaExecutionContext_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaDevResource_st {
@@ -4432,7 +4816,7 @@ pub struct cudaDevResource_st {
     pub __bindgen_anon_1: cudaDevResource_st__bindgen_ty_1,
     pub nextResource: *mut cudaDevResource_st,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDevSmResource {
@@ -4441,7 +4825,7 @@ pub struct cudaDevSmResource {
     pub smCoscheduledAlignment: ::core::ffi::c_uint,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDevSmResourceGroupParams_st {
@@ -4451,7 +4835,7 @@ pub struct cudaDevSmResourceGroupParams_st {
     pub flags: ::core::ffi::c_uint,
     pub reserved: [::core::ffi::c_uint; 12usize],
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDevWorkqueueConfigResource {
@@ -4459,7 +4843,7 @@ pub struct cudaDevWorkqueueConfigResource {
     pub wqConcurrencyLimit: ::core::ffi::c_uint,
     pub sharingScope: cudaDevWorkqueueConfigScope,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDevWorkqueueResource {
@@ -4949,7 +5333,7 @@ pub struct cudaDeviceProp {
     pub unifiedFunctionPointers: ::core::ffi::c_int,
     pub reserved: [::core::ffi::c_int; 63usize],
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaDeviceProp {
@@ -5047,19 +5431,19 @@ pub struct cudaDeviceProp {
     pub hostNumaMultinodeIpcSupported: ::core::ffi::c_int,
     pub reserved: [::core::ffi::c_int; 56usize],
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaEventRecordNodeParams {
     pub event: cudaEvent_t,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaEventWaitNodeParams {
     pub event: cudaEvent_t,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cudaExecutionContext_st {
@@ -5080,7 +5464,7 @@ pub struct cudaExternalMemoryBufferDesc {
     pub size: ::core::ffi::c_ulonglong,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaExternalMemoryBufferDesc {
@@ -5098,7 +5482,7 @@ pub struct cudaExternalMemoryHandleDesc {
     pub size: ::core::ffi::c_ulonglong,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaExternalMemoryHandleDesc {
@@ -5124,7 +5508,7 @@ pub struct cudaExternalMemoryMipmappedArrayDesc {
     pub flags: ::core::ffi::c_uint,
     pub numLevels: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaExternalMemoryMipmappedArrayDesc {
@@ -5143,7 +5527,7 @@ pub struct cudaExternalSemaphoreHandleDesc {
     pub handle: cudaExternalSemaphoreHandleDesc__bindgen_ty_1,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaExternalSemaphoreHandleDesc {
@@ -5165,7 +5549,7 @@ pub struct cudaExternalSemaphoreSignalNodeParams {
     pub paramsArray: *const cudaExternalSemaphoreSignalParams,
     pub numExtSems: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaExternalSemaphoreSignalNodeParamsV2 {
@@ -5232,7 +5616,7 @@ pub struct cudaExternalSemaphoreWaitNodeParams {
     pub paramsArray: *const cudaExternalSemaphoreWaitParams,
     pub numExtSems: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaExternalSemaphoreWaitNodeParamsV2 {
@@ -5354,7 +5738,31 @@ pub struct cudaFuncAttributes {
     pub reserved0: ::core::ffi::c_int,
     pub reserved: [::core::ffi::c_int; 15usize],
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct cudaFuncAttributes {
+    pub sharedSizeBytes: usize,
+    pub constSizeBytes: usize,
+    pub localSizeBytes: usize,
+    pub maxThreadsPerBlock: ::core::ffi::c_int,
+    pub numRegs: ::core::ffi::c_int,
+    pub ptxVersion: ::core::ffi::c_int,
+    pub binaryVersion: ::core::ffi::c_int,
+    pub cacheModeCA: ::core::ffi::c_int,
+    pub maxDynamicSharedSizeBytes: ::core::ffi::c_int,
+    pub preferredShmemCarveout: ::core::ffi::c_int,
+    pub clusterDimMustBeSet: ::core::ffi::c_int,
+    pub requiredClusterWidth: ::core::ffi::c_int,
+    pub requiredClusterHeight: ::core::ffi::c_int,
+    pub requiredClusterDepth: ::core::ffi::c_int,
+    pub clusterSchedulingPolicyPreference: ::core::ffi::c_int,
+    pub nonPortableClusterSizeAllowed: ::core::ffi::c_int,
+    pub deviceNodeUpdateStatus: ::core::ffi::c_int,
+    pub reserved1: ::core::ffi::c_int,
+    pub reserved: [::core::ffi::c_int; 14usize],
+}
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGraphEdgeData_st {
@@ -5363,7 +5771,7 @@ pub struct cudaGraphEdgeData_st {
     pub type_: ::core::ffi::c_uchar,
     pub reserved: [::core::ffi::c_uchar; 5usize],
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGraphExecUpdateResultInfo_st {
@@ -5371,7 +5779,7 @@ pub struct cudaGraphExecUpdateResultInfo_st {
     pub errorNode: cudaGraphNode_t,
     pub errorFromNode: cudaGraphNode_t,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGraphInstantiateParams_st {
@@ -5380,7 +5788,7 @@ pub struct cudaGraphInstantiateParams_st {
     pub errNode_out: cudaGraphNode_t,
     pub result_out: cudaGraphInstantiateResult,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaGraphKernelNodeUpdate {
@@ -5388,7 +5796,7 @@ pub struct cudaGraphKernelNodeUpdate {
     pub field: cudaGraphKernelNodeField,
     pub updateData: cudaGraphKernelNodeUpdate__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaGraphKernelNodeUpdate__bindgen_ty_1__bindgen_ty_1 {
@@ -5396,7 +5804,7 @@ pub struct cudaGraphKernelNodeUpdate__bindgen_ty_1__bindgen_ty_1 {
     pub offset: usize,
     pub size: usize,
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaGraphNodeParams {
@@ -5404,6 +5812,13 @@ pub struct cudaGraphNodeParams {
     pub reserved0: [::core::ffi::c_int; 3usize],
     pub __bindgen_anon_1: cudaGraphNodeParams__bindgen_ty_1,
     pub reserved2: ::core::ffi::c_longlong,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct cudaGraphRecaptureCallbackData {
+    pub callbackFunc: cudaGraphRecaptureCallback_t,
+    pub userData: *mut ::core::ffi::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -5423,7 +5838,7 @@ pub struct cudaHostNodeParamsV2 {
     pub fn_: cudaHostFn_t,
     pub userData: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaHostNodeParamsV2 {
@@ -5474,7 +5889,7 @@ pub struct cudaKernelNodeParamsV2 {
     pub extra: *mut *mut ::core::ffi::c_void,
     pub ctx: cudaExecutionContext_t,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaKernelNodeParamsV2 {
@@ -5487,7 +5902,7 @@ pub struct cudaKernelNodeParamsV2 {
     pub ctx: cudaExecutionContext_t,
     pub functionType: cudaKernelFunctionType,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLaunchAttributeValue__bindgen_ty_1 {
@@ -5495,7 +5910,7 @@ pub struct cudaLaunchAttributeValue__bindgen_ty_1 {
     pub y: ::core::ffi::c_uint,
     pub z: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLaunchAttributeValue__bindgen_ty_2 {
@@ -5510,7 +5925,7 @@ pub struct cudaLaunchAttributeValue__bindgen_ty_3 {
     pub event: cudaEvent_t,
     pub flags: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLaunchAttributeValue__bindgen_ty_3 {
@@ -5525,21 +5940,21 @@ pub struct cudaLaunchAttributeValue__bindgen_ty_4 {
     pub deviceUpdatable: ::core::ffi::c_int,
     pub devNode: cudaGraphDeviceNode_t,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLaunchAttributeValue__bindgen_ty_4 {
     pub event: cudaEvent_t,
     pub flags: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLaunchAttributeValue__bindgen_ty_5 {
     pub deviceUpdatable: ::core::ffi::c_int,
     pub devNode: cudaGraphDeviceNode_t,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaLaunchAttribute_st {
@@ -5547,7 +5962,7 @@ pub struct cudaLaunchAttribute_st {
     pub pad: [::core::ffi::c_char; 4usize],
     pub val: cudaLaunchAttributeValue,
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLaunchConfig_st {
@@ -5558,7 +5973,7 @@ pub struct cudaLaunchConfig_st {
     pub attrs: *mut cudaLaunchAttribute,
     pub numAttrs: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaLaunchMemSyncDomainMap_st {
@@ -5576,14 +5991,33 @@ pub struct cudaLaunchParams {
     pub sharedMem: usize,
     pub stream: cudaStream_t,
 }
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaMemAccessDesc {
     pub location: cudaMemLocation,
     pub flags: cudaMemAccessFlags,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct cudaMemAccessDesc {
+    pub location: cudaMemLocation,
+    pub flags: cudaMemAccessFlags,
+}
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct cudaMemAllocNodeParams {
+    pub poolProps: cudaMemPoolProps,
+    pub accessDescs: *const cudaMemAccessDesc,
+    pub accessDescCount: usize,
+    pub bytesize: usize,
+    pub dptr: *mut ::core::ffi::c_void,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
 pub struct cudaMemAllocNodeParams {
     pub poolProps: cudaMemPoolProps,
     pub accessDescs: *const cudaMemAccessDesc,
@@ -5601,23 +6035,41 @@ pub struct cudaMemAllocNodeParamsV2 {
     pub bytesize: usize,
     pub dptr: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct cudaMemAllocNodeParamsV2 {
+    pub poolProps: cudaMemPoolProps,
+    pub accessDescs: *const cudaMemAccessDesc,
+    pub accessDescCount: usize,
+    pub bytesize: usize,
+    pub dptr: *mut ::core::ffi::c_void,
+}
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaMemFabricHandle_st {
     pub reserved: [::core::ffi::c_char; 64usize],
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaMemFreeNodeParams {
     pub dptr: *mut ::core::ffi::c_void,
 }
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaMemLocation {
     pub type_: cudaMemLocationType,
     pub id: ::core::ffi::c_int,
+}
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct cudaMemLocation {
+    pub type_: cudaMemLocationType,
+    pub __bindgen_anon_1: cudaMemLocation__bindgen_ty_1,
 }
 #[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010"))]
 #[repr(C)]
@@ -5652,12 +6104,24 @@ pub struct cudaMemPoolProps {
     pub usage: ::core::ffi::c_ushort,
     pub reserved: [::core::ffi::c_uchar; 54usize],
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct cudaMemPoolProps {
+    pub allocType: cudaMemAllocationType,
+    pub handleTypes: cudaMemAllocationHandleType,
+    pub location: cudaMemLocation,
+    pub win32SecurityAttributes: *mut ::core::ffi::c_void,
+    pub maxSize: usize,
+    pub usage: ::core::ffi::c_ushort,
+    pub reserved: [::core::ffi::c_uchar; 54usize],
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaMemPoolPtrExportData {
     pub reserved: [::core::ffi::c_uchar; 64usize],
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaMemcpy3DBatchOp {
@@ -5667,7 +6131,7 @@ pub struct cudaMemcpy3DBatchOp {
     pub srcAccessOrder: cudaMemcpySrcAccessOrder,
     pub flags: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaMemcpy3DOperand {
@@ -5683,7 +6147,16 @@ pub struct cudaMemcpy3DOperand__bindgen_ty_1__bindgen_ty_1 {
     pub layerHeight: usize,
     pub locHint: cudaMemLocation,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct cudaMemcpy3DOperand__bindgen_ty_1__bindgen_ty_1 {
+    pub ptr: *mut ::core::ffi::c_void,
+    pub rowLength: usize,
+    pub layerHeight: usize,
+    pub locHint: cudaMemLocation,
+}
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaMemcpy3DOperand__bindgen_ty_1__bindgen_ty_2 {
@@ -5724,6 +6197,15 @@ pub struct cudaMemcpyAttributes {
     pub dstLocHint: cudaMemLocation,
     pub flags: ::core::ffi::c_uint,
 }
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct cudaMemcpyAttributes {
+    pub srcAccessOrder: cudaMemcpySrcAccessOrder,
+    pub srcLocHint: cudaMemLocation,
+    pub dstLocHint: cudaMemLocation,
+    pub flags: ::core::ffi::c_uint,
+}
 #[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -5732,7 +6214,7 @@ pub struct cudaMemcpyNodeParams {
     pub reserved: [::core::ffi::c_int; 3usize],
     pub copyParams: cudaMemcpy3DParms,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaMemcpyNodeParams {
@@ -5762,7 +6244,7 @@ pub struct cudaMemsetParamsV2 {
     pub width: usize,
     pub height: usize,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaMemsetParamsV2 {
@@ -5779,7 +6261,7 @@ pub struct cudaMemsetParamsV2 {
 pub struct cudaMipmappedArray {
     _unused: [u8; 0],
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaOffset3D {
@@ -5804,7 +6286,7 @@ pub struct cudaPointerAttributes {
     pub devicePointer: *mut ::core::ffi::c_void,
     pub hostPointer: *mut ::core::ffi::c_void,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaPointerAttributes {
@@ -5828,7 +6310,7 @@ pub struct cudaResourceDesc {
     pub resType: cudaResourceType,
     pub res: cudaResourceDesc__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct cudaResourceDesc {
@@ -5862,7 +6344,7 @@ pub struct cudaResourceDesc__bindgen_ty_1__bindgen_ty_4 {
     pub height: usize,
     pub pitchInBytes: usize,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaResourceDesc__bindgen_ty_1__bindgen_ty_5 {
@@ -5881,7 +6363,7 @@ pub struct cudaResourceViewDesc {
     pub firstLayer: ::core::ffi::c_uint,
     pub lastLayer: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudaResourceViewDesc {
@@ -5947,7 +6429,7 @@ pub struct cudaTextureDesc {
     pub maxMipmapLevelClamp: f32,
     pub disableTrilinearOptimization: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
 pub struct cudaTextureDesc {
@@ -5983,7 +6465,7 @@ pub struct cudaTextureDesc_v2 {
     pub disableTrilinearOptimization: ::core::ffi::c_int,
     pub seamlessCubemap: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct cudalibraryHostUniversalFunctionAndDataTable {
@@ -6022,7 +6504,7 @@ pub struct textureReference {
     pub disableTrilinearOptimization: ::core::ffi::c_int,
     pub __cudaReserved: [::core::ffi::c_int; 14usize],
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl cudaDataType_t {
     pub const CUDA_R_8F_UE4M3: cudaDataType_t = cudaDataType_t::CUDA_R_8F_E4M3;
 }
@@ -6030,17 +6512,21 @@ impl cudaDataType_t {
 impl cudaDeviceAttr {
     pub const cudaDevAttrMaxTimelineSemaphoreInteropSupported: cudaDeviceAttr = cudaDeviceAttr::cudaDevAttrTimelineSemaphoreInteropSupported;
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+impl cudaFabricOpStatusInfo {
+    pub const cudaFabricOpStatusInfoLast: cudaFabricOpStatusInfo = cudaFabricOpStatusInfo::cudaFabricOpStatusInfoSuccess;
+}
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 impl cudaMemLocationType {
     pub const cudaMemLocationTypeNone: cudaMemLocationType = cudaMemLocationType::cudaMemLocationTypeInvalid;
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union cudaAsyncNotificationInfo__bindgen_ty_1 {
     pub overBudget: cudaAsyncNotificationInfo__bindgen_ty_1__bindgen_ty_1,
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union cudaDevResource_st__bindgen_ty_1 {
@@ -6089,7 +6575,7 @@ pub union cudaExternalSemaphoreWaitParams_v1__bindgen_ty_1__bindgen_ty_2 {
     pub fence: *mut ::core::ffi::c_void,
     pub reserved: ::core::ffi::c_ulonglong,
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union cudaGraphKernelNodeUpdate__bindgen_ty_1 {
@@ -6114,7 +6600,7 @@ pub union cudaGraphNodeParams__bindgen_ty_1 {
     pub alloc: cudaMemAllocNodeParamsV2,
     pub free: cudaMemFreeNodeParams,
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union cudaGraphNodeParams__bindgen_ty_1 {
@@ -6147,7 +6633,7 @@ pub union cudaKernelNodeAttrValue {
     pub cooperative: ::core::ffi::c_int,
     pub priority: ::core::ffi::c_int,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union cudaKernelNodeParamsV2__bindgen_ty_1 {
@@ -6280,7 +6766,7 @@ pub union cudaLaunchAttributeValue {
     pub sharedMemCarveout: ::core::ffi::c_uint,
     pub nvlinkUtilCentricScheduling: ::core::ffi::c_uint,
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union cudaLaunchAttributeValue {
@@ -6303,7 +6789,13 @@ pub union cudaLaunchAttributeValue {
     pub portableClusterSizeMode: cudaLaunchAttributePortableClusterMode,
     pub sharedMemoryMode: cudaSharedMemoryMode,
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13030"))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union cudaMemLocation__bindgen_ty_1 {
+    pub id: ::core::ffi::c_int,
+}
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union cudaMemcpy3DOperand__bindgen_ty_1 {
@@ -6319,7 +6811,7 @@ pub union cudaResourceDesc__bindgen_ty_1 {
     pub linear: cudaResourceDesc__bindgen_ty_1__bindgen_ty_3,
     pub pitch2D: cudaResourceDesc__bindgen_ty_1__bindgen_ty_4,
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union cudaResourceDesc__bindgen_ty_1 {
@@ -6352,7 +6844,7 @@ pub unsafe fn cudaArrayGetInfo(desc: *mut cudaChannelFormatDesc, extent: *mut cu
         cudaArrayGetInfo(desc, extent, flags, array)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaArrayGetMemoryRequirements(memoryRequirements: *mut cudaArrayMemoryRequirements, array: cudaArray_t, device: ::core::ffi::c_int) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6647,7 +7139,7 @@ pub unsafe fn cudaDestroyTextureObject(texObject: cudaTextureObject_t) -> cudaEr
         cudaDestroyTextureObject(texObject)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaDevResourceGenerateDesc(phDesc: *mut cudaDevResourceDesc_t, resources: *mut cudaDevResource, nbResources: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6664,7 +7156,7 @@ pub unsafe fn cudaDevResourceGenerateDesc(phDesc: *mut cudaDevResourceDesc_t, re
         cudaDevResourceGenerateDesc(phDesc, resources, nbResources)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaDevSmResourceSplit(result: *mut cudaDevResource, nbGroups: ::core::ffi::c_uint, input: *const cudaDevResource, remainder: *mut cudaDevResource, flags: ::core::ffi::c_uint, groupParams: *mut cudaDevSmResourceGroupParams) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6681,7 +7173,7 @@ pub unsafe fn cudaDevSmResourceSplit(result: *mut cudaDevResource, nbGroups: ::c
         cudaDevSmResourceSplit(result, nbGroups, input, remainder, flags, groupParams)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaDevSmResourceSplitByCount(result: *mut cudaDevResource, nbGroups: *mut ::core::ffi::c_uint, input: *const cudaDevResource, remaining: *mut cudaDevResource, flags: ::core::ffi::c_uint, minCount: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6826,7 +7318,7 @@ pub unsafe fn cudaDeviceGetDefaultMemPool(memPool: *mut cudaMemPool_t, device: :
         cudaDeviceGetDefaultMemPool(memPool, device)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaDeviceGetDevResource(device: ::core::ffi::c_int, resource: *mut cudaDevResource, type_: cudaDevResourceType) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6843,7 +7335,7 @@ pub unsafe fn cudaDeviceGetDevResource(device: ::core::ffi::c_int, resource: *mu
         cudaDeviceGetDevResource(device, resource, type_)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaDeviceGetExecutionCtx(ctx: *mut cudaExecutionContext_t, device: ::core::ffi::c_int) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6876,7 +7368,7 @@ pub unsafe fn cudaDeviceGetGraphMemAttribute(device: ::core::ffi::c_int, attr: c
         cudaDeviceGetGraphMemAttribute(device, attr, value)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaDeviceGetHostAtomicCapabilities(capabilities: *mut ::core::ffi::c_uint, operations: *const cudaAtomicOperation, count: ::core::ffi::c_uint, device: ::core::ffi::c_int) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -6925,7 +7417,7 @@ pub unsafe fn cudaDeviceGetMemPool(memPool: *mut cudaMemPool_t, device: ::core::
         cudaDeviceGetMemPool(memPool, device)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaDeviceGetP2PAtomicCapabilities(capabilities: *mut ::core::ffi::c_uint, operations: *const cudaAtomicOperation, count: ::core::ffi::c_uint, srcDevice: ::core::ffi::c_int, dstDevice: ::core::ffi::c_int) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7038,7 +7530,7 @@ pub unsafe fn cudaDeviceGraphMemTrim(device: ::core::ffi::c_int) -> cudaError_t 
         cudaDeviceGraphMemTrim(device)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaDeviceRegisterAsyncNotification(device: ::core::ffi::c_int, callbackFunc: cudaAsyncCallback, userData: *mut ::core::ffi::c_void, callback: *mut cudaAsyncCallbackHandle_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7167,7 +7659,7 @@ pub unsafe fn cudaDeviceSynchronize() -> cudaError_t {
         cudaDeviceSynchronize()
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaDeviceUnregisterAsyncNotification(device: ::core::ffi::c_int, callback: cudaAsyncCallbackHandle_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7345,7 +7837,7 @@ pub unsafe fn cudaEventSynchronize(event: cudaEvent_t) -> cudaError_t {
         cudaEventSynchronize(event)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaExecutionCtxDestroy(ctx: cudaExecutionContext_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7362,7 +7854,7 @@ pub unsafe fn cudaExecutionCtxDestroy(ctx: cudaExecutionContext_t) -> cudaError_
         cudaExecutionCtxDestroy(ctx)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaExecutionCtxGetDevResource(ctx: cudaExecutionContext_t, resource: *mut cudaDevResource, type_: cudaDevResourceType) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7379,7 +7871,7 @@ pub unsafe fn cudaExecutionCtxGetDevResource(ctx: cudaExecutionContext_t, resour
         cudaExecutionCtxGetDevResource(ctx, resource, type_)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaExecutionCtxGetDevice(device: *mut ::core::ffi::c_int, ctx: cudaExecutionContext_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7396,7 +7888,7 @@ pub unsafe fn cudaExecutionCtxGetDevice(device: *mut ::core::ffi::c_int, ctx: cu
         cudaExecutionCtxGetDevice(device, ctx)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaExecutionCtxGetId(ctx: cudaExecutionContext_t, ctxId: *mut ::core::ffi::c_ulonglong) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7413,7 +7905,7 @@ pub unsafe fn cudaExecutionCtxGetId(ctx: cudaExecutionContext_t, ctxId: *mut ::c
         cudaExecutionCtxGetId(ctx, ctxId)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaExecutionCtxRecordEvent(ctx: cudaExecutionContext_t, event: cudaEvent_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7430,7 +7922,7 @@ pub unsafe fn cudaExecutionCtxRecordEvent(ctx: cudaExecutionContext_t, event: cu
         cudaExecutionCtxRecordEvent(ctx, event)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaExecutionCtxStreamCreate(phStream: *mut cudaStream_t, ctx: cudaExecutionContext_t, flags: ::core::ffi::c_uint, priority: ::core::ffi::c_int) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7447,7 +7939,7 @@ pub unsafe fn cudaExecutionCtxStreamCreate(phStream: *mut cudaStream_t, ctx: cud
         cudaExecutionCtxStreamCreate(phStream, ctx, flags, priority)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaExecutionCtxSynchronize(ctx: cudaExecutionContext_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7464,7 +7956,7 @@ pub unsafe fn cudaExecutionCtxSynchronize(ctx: cudaExecutionContext_t) -> cudaEr
         cudaExecutionCtxSynchronize(ctx)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaExecutionCtxWaitEvent(ctx: cudaExecutionContext_t, event: cudaEvent_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7609,7 +8101,7 @@ pub unsafe fn cudaFuncGetAttributes(attr: *mut cudaFuncAttributes, func: *const 
         cudaFuncGetAttributes(attr, func)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaFuncGetName(name: *mut *const ::core::ffi::c_char, func: *const ::core::ffi::c_void) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7626,7 +8118,7 @@ pub unsafe fn cudaFuncGetName(name: *mut *const ::core::ffi::c_char, func: *cons
         cudaFuncGetName(name, func)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaFuncGetParamCount(func: *const ::core::ffi::c_void, paramCount: *mut usize) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7643,7 +8135,7 @@ pub unsafe fn cudaFuncGetParamCount(func: *const ::core::ffi::c_void, paramCount
         cudaFuncGetParamCount(func, paramCount)
     }
 }
-#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaFuncGetParamInfo(func: *const ::core::ffi::c_void, paramIndex: usize, paramOffset: *mut usize, paramSize: *mut usize) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7772,7 +8264,7 @@ pub unsafe fn cudaGetDeviceFlags(flags: *mut ::core::ffi::c_uint) -> cudaError_t
         cudaGetDeviceFlags(flags)
     }
 }
-#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11040", feature = "cuda-11050", feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGetDeviceProperties(prop: *mut cudaDeviceProp, device: ::core::ffi::c_int) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7823,7 +8315,7 @@ pub unsafe fn cudaGetDriverEntryPoint(symbol: *const ::core::ffi::c_char, funcPt
         cudaGetDriverEntryPoint(symbol, funcPtr, flags)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGetDriverEntryPoint(symbol: *const ::core::ffi::c_char, funcPtr: *mut *mut ::core::ffi::c_void, flags: ::core::ffi::c_ulonglong, driverStatus: *mut cudaDriverEntryPointQueryResult) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7840,7 +8332,7 @@ pub unsafe fn cudaGetDriverEntryPoint(symbol: *const ::core::ffi::c_char, funcPt
         cudaGetDriverEntryPoint(symbol, funcPtr, flags, driverStatus)
     }
 }
-#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGetDriverEntryPointByVersion(symbol: *const ::core::ffi::c_char, funcPtr: *mut *mut ::core::ffi::c_void, cudaVersion: ::core::ffi::c_uint, flags: ::core::ffi::c_ulonglong, driverStatus: *mut cudaDriverEntryPointQueryResult) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -7921,7 +8413,7 @@ pub unsafe fn cudaGetFuncBySymbol(functionPtr: *mut cudaFunction_t, symbolPtr: *
         cudaGetFuncBySymbol(functionPtr, symbolPtr)
     }
 }
-#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGetKernel(kernelPtr: *mut cudaKernel_t, entryFuncAddr: *const ::core::ffi::c_void) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8167,7 +8659,7 @@ pub unsafe fn cudaGraphAddDependencies(graph: cudaGraph_t, from: *const cudaGrap
         cudaGraphAddDependencies(graph, from, to, numDependencies)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphAddDependencies(graph: cudaGraph_t, from: *const cudaGraphNode_t, to: *const cudaGraphNode_t, edgeData: *const cudaGraphEdgeData, numDependencies: usize) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8442,7 +8934,7 @@ pub unsafe fn cudaGraphAddNode(pGraphNode: *mut cudaGraphNode_t, graph: cudaGrap
         cudaGraphAddNode(pGraphNode, graph, pDependencies, numDependencies, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphAddNode(pGraphNode: *mut cudaGraphNode_t, graph: cudaGraph_t, pDependencies: *const cudaGraphNode_t, dependencyData: *const cudaGraphEdgeData, numDependencies: usize, nodeParams: *mut cudaGraphNodeParams) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8508,7 +9000,7 @@ pub unsafe fn cudaGraphClone(pGraphClone: *mut cudaGraph_t, originalGraph: cudaG
         cudaGraphClone(pGraphClone, originalGraph)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphConditionalHandleCreate(pHandle_out: *mut cudaGraphConditionalHandle, graph: cudaGraph_t, defaultLaunchValue: ::core::ffi::c_uint, flags: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8525,7 +9017,7 @@ pub unsafe fn cudaGraphConditionalHandleCreate(pHandle_out: *mut cudaGraphCondit
         cudaGraphConditionalHandleCreate(pHandle_out, graph, defaultLaunchValue, flags)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphConditionalHandleCreate_v2(pHandle_out: *mut cudaGraphConditionalHandle, graph: cudaGraph_t, ctx: cudaExecutionContext_t, defaultLaunchValue: ::core::ffi::c_uint, flags: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8766,7 +9258,7 @@ pub unsafe fn cudaGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec: cudaG
         cudaGraphExecExternalSemaphoresWaitNodeSetParams(hGraphExec, hNode, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphExecGetFlags(graphExec: cudaGraphExec_t, flags: *mut ::core::ffi::c_ulonglong) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8783,7 +9275,7 @@ pub unsafe fn cudaGraphExecGetFlags(graphExec: cudaGraphExec_t, flags: *mut ::co
         cudaGraphExecGetFlags(graphExec, flags)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphExecGetId(hGraphExec: cudaGraphExec_t, graphID: *mut ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8912,7 +9404,7 @@ pub unsafe fn cudaGraphExecMemsetNodeSetParams(hGraphExec: cudaGraphExec_t, node
         cudaGraphExecMemsetNodeSetParams(hGraphExec, node, pNodeParams)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphExecNodeSetParams(graphExec: cudaGraphExec_t, node: cudaGraphNode_t, nodeParams: *mut cudaGraphNodeParams) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -8946,7 +9438,7 @@ pub unsafe fn cudaGraphExecUpdate(hGraphExec: cudaGraphExec_t, hGraph: cudaGraph
         cudaGraphExecUpdate(hGraphExec, hGraph, hErrorNode_out, updateResult_out)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphExecUpdate(hGraphExec: cudaGraphExec_t, hGraph: cudaGraph_t, resultInfo: *mut cudaGraphExecUpdateResultInfo) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9044,7 +9536,7 @@ pub unsafe fn cudaGraphGetEdges(graph: cudaGraph_t, from: *mut cudaGraphNode_t, 
         cudaGraphGetEdges(graph, from, to, numEdges)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphGetEdges(graph: cudaGraph_t, from: *mut cudaGraphNode_t, to: *mut cudaGraphNode_t, edgeData: *mut cudaGraphEdgeData, numEdges: *mut usize) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9078,7 +9570,7 @@ pub unsafe fn cudaGraphGetEdges_v2(graph: cudaGraph_t, from: *mut cudaGraphNode_
         cudaGraphGetEdges_v2(graph, from, to, edgeData, numEdges)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphGetId(hGraph: cudaGraph_t, graphID: *mut ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9176,7 +9668,7 @@ pub unsafe fn cudaGraphInstantiate(pGraphExec: *mut cudaGraphExec_t, graph: cuda
         cudaGraphInstantiate(pGraphExec, graph, pErrorNode, pLogBuffer, bufferSize)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphInstantiate(pGraphExec: *mut cudaGraphExec_t, graph: cudaGraph_t, flags: ::core::ffi::c_ulonglong) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9209,7 +9701,7 @@ pub unsafe fn cudaGraphInstantiateWithFlags(pGraphExec: *mut cudaGraphExec_t, gr
         cudaGraphInstantiateWithFlags(pGraphExec, graph, flags)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphInstantiateWithParams(pGraphExec: *mut cudaGraphExec_t, graph: cudaGraph_t, instantiateParams: *mut cudaGraphInstantiateParams) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9243,7 +9735,7 @@ pub unsafe fn cudaGraphKernelNodeCopyAttributes(hSrc: cudaGraphNode_t, hDst: cud
         cudaGraphKernelNodeCopyAttributes(hSrc, hDst)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphKernelNodeCopyAttributes(hDst: cudaGraphNode_t, hSrc: cudaGraphNode_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9277,7 +9769,7 @@ pub unsafe fn cudaGraphKernelNodeGetAttribute(hNode: cudaGraphNode_t, attr: cuda
         cudaGraphKernelNodeGetAttribute(hNode, attr, value_out)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphKernelNodeGetAttribute(hNode: cudaGraphNode_t, attr: cudaLaunchAttributeID, value_out: *mut cudaLaunchAttributeValue) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9327,7 +9819,7 @@ pub unsafe fn cudaGraphKernelNodeSetAttribute(hNode: cudaGraphNode_t, attr: cuda
         cudaGraphKernelNodeSetAttribute(hNode, attr, value)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphKernelNodeSetAttribute(hNode: cudaGraphNode_t, attr: cudaLaunchAttributeID, value: *const cudaLaunchAttributeValue) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9536,7 +10028,7 @@ pub unsafe fn cudaGraphNodeFindInClone(pNode: *mut cudaGraphNode_t, originalNode
         cudaGraphNodeFindInClone(pNode, originalNode, clonedGraph)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphNodeGetContainingGraph(hNode: cudaGraphNode_t, phGraph: *mut cudaGraph_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9570,7 +10062,7 @@ pub unsafe fn cudaGraphNodeGetDependencies(node: cudaGraphNode_t, pDependencies:
         cudaGraphNodeGetDependencies(node, pDependencies, pNumDependencies)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphNodeGetDependencies(node: cudaGraphNode_t, pDependencies: *mut cudaGraphNode_t, edgeData: *mut cudaGraphEdgeData, pNumDependencies: *mut usize) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9621,7 +10113,7 @@ pub unsafe fn cudaGraphNodeGetDependentNodes(node: cudaGraphNode_t, pDependentNo
         cudaGraphNodeGetDependentNodes(node, pDependentNodes, pNumDependentNodes)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphNodeGetDependentNodes(node: cudaGraphNode_t, pDependentNodes: *mut cudaGraphNode_t, edgeData: *mut cudaGraphEdgeData, pNumDependentNodes: *mut usize) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9655,7 +10147,7 @@ pub unsafe fn cudaGraphNodeGetDependentNodes_v2(node: cudaGraphNode_t, pDependen
         cudaGraphNodeGetDependentNodes_v2(node, pDependentNodes, edgeData, pNumDependentNodes)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphNodeGetEnabled(hGraphExec: cudaGraphExec_t, hNode: cudaGraphNode_t, isEnabled: *mut ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9672,7 +10164,7 @@ pub unsafe fn cudaGraphNodeGetEnabled(hGraphExec: cudaGraphExec_t, hNode: cudaGr
         cudaGraphNodeGetEnabled(hGraphExec, hNode, isEnabled)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphNodeGetLocalId(hNode: cudaGraphNode_t, nodeId: *mut ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9689,7 +10181,7 @@ pub unsafe fn cudaGraphNodeGetLocalId(hNode: cudaGraphNode_t, nodeId: *mut ::cor
         cudaGraphNodeGetLocalId(hNode, nodeId)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphNodeGetParams(node: cudaGraphNode_t, nodeParams: *mut cudaGraphNodeParams) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9706,7 +10198,7 @@ pub unsafe fn cudaGraphNodeGetParams(node: cudaGraphNode_t, nodeParams: *mut cud
         cudaGraphNodeGetParams(node, nodeParams)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphNodeGetToolsId(hNode: cudaGraphNode_t, toolsNodeId: *mut ::core::ffi::c_ulonglong) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9739,7 +10231,7 @@ pub unsafe fn cudaGraphNodeGetType(node: cudaGraphNode_t, pType: *mut cudaGraphN
         cudaGraphNodeGetType(node, pType)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphNodeSetEnabled(hGraphExec: cudaGraphExec_t, hNode: cudaGraphNode_t, isEnabled: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9756,7 +10248,7 @@ pub unsafe fn cudaGraphNodeSetEnabled(hGraphExec: cudaGraphExec_t, hNode: cudaGr
         cudaGraphNodeSetEnabled(hGraphExec, hNode, isEnabled)
     }
 }
-#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphNodeSetParams(node: cudaGraphNode_t, nodeParams: *mut cudaGraphNodeParams) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9806,7 +10298,7 @@ pub unsafe fn cudaGraphRemoveDependencies(graph: cudaGraph_t, from: *const cudaG
         cudaGraphRemoveDependencies(graph, from, to, numDependencies)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGraphRemoveDependencies(graph: cudaGraph_t, from: *const cudaGraphNode_t, to: *const cudaGraphNode_t, edgeData: *const cudaGraphEdgeData, numDependencies: usize) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -9984,7 +10476,7 @@ pub unsafe fn cudaGraphicsUnregisterResource(resource: cudaGraphicsResource_t) -
         cudaGraphicsUnregisterResource(resource)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaGreenCtxCreate(phCtx: *mut cudaExecutionContext_t, desc: cudaDevResourceDesc_t, device: ::core::ffi::c_int, flags: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10113,7 +10605,7 @@ pub unsafe fn cudaImportExternalSemaphore(extSem_out: *mut cudaExternalSemaphore
         cudaImportExternalSemaphore(extSem_out, semHandleDesc)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaInitDevice(device: ::core::ffi::c_int, deviceFlags: ::core::ffi::c_uint, flags: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10210,7 +10702,7 @@ pub unsafe fn cudaIpcOpenMemHandle(devPtr: *mut *mut ::core::ffi::c_void, handle
         cudaIpcOpenMemHandle(devPtr, handle, flags)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaKernelSetAttributeForDevice(kernel: cudaKernel_t, attr: cudaFuncAttribute, value: ::core::ffi::c_int, device: ::core::ffi::c_int) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10276,7 +10768,7 @@ pub unsafe fn cudaLaunchHostFunc(stream: cudaStream_t, fn_: cudaHostFn_t, userDa
         cudaLaunchHostFunc(stream, fn_, userData)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLaunchHostFunc_v2(stream: cudaStream_t, fn_: cudaHostFn_t, userData: *mut ::core::ffi::c_void, syncMode: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10309,7 +10801,7 @@ pub unsafe fn cudaLaunchKernel(func: *const ::core::ffi::c_void, gridDim: dim3, 
         cudaLaunchKernel(func, gridDim, blockDim, args, sharedMem, stream)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLaunchKernelExC(config: *const cudaLaunchConfig_t, func: *const ::core::ffi::c_void, args: *mut *mut ::core::ffi::c_void) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10326,7 +10818,7 @@ pub unsafe fn cudaLaunchKernelExC(config: *const cudaLaunchConfig_t, func: *cons
         cudaLaunchKernelExC(config, func, args)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLibraryEnumerateKernels(kernels: *mut cudaKernel_t, numKernels: ::core::ffi::c_uint, lib: cudaLibrary_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10343,7 +10835,7 @@ pub unsafe fn cudaLibraryEnumerateKernels(kernels: *mut cudaKernel_t, numKernels
         cudaLibraryEnumerateKernels(kernels, numKernels, lib)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLibraryGetGlobal(dptr: *mut *mut ::core::ffi::c_void, bytes: *mut usize, library: cudaLibrary_t, name: *const ::core::ffi::c_char) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10360,7 +10852,7 @@ pub unsafe fn cudaLibraryGetGlobal(dptr: *mut *mut ::core::ffi::c_void, bytes: *
         cudaLibraryGetGlobal(dptr, bytes, library, name)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLibraryGetKernel(pKernel: *mut cudaKernel_t, library: cudaLibrary_t, name: *const ::core::ffi::c_char) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10377,7 +10869,7 @@ pub unsafe fn cudaLibraryGetKernel(pKernel: *mut cudaKernel_t, library: cudaLibr
         cudaLibraryGetKernel(pKernel, library, name)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLibraryGetKernelCount(count: *mut ::core::ffi::c_uint, lib: cudaLibrary_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10394,7 +10886,7 @@ pub unsafe fn cudaLibraryGetKernelCount(count: *mut ::core::ffi::c_uint, lib: cu
         cudaLibraryGetKernelCount(count, lib)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLibraryGetManaged(dptr: *mut *mut ::core::ffi::c_void, bytes: *mut usize, library: cudaLibrary_t, name: *const ::core::ffi::c_char) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10411,7 +10903,7 @@ pub unsafe fn cudaLibraryGetManaged(dptr: *mut *mut ::core::ffi::c_void, bytes: 
         cudaLibraryGetManaged(dptr, bytes, library, name)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLibraryGetUnifiedFunction(fptr: *mut *mut ::core::ffi::c_void, library: cudaLibrary_t, symbol: *const ::core::ffi::c_char) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10428,7 +10920,7 @@ pub unsafe fn cudaLibraryGetUnifiedFunction(fptr: *mut *mut ::core::ffi::c_void,
         cudaLibraryGetUnifiedFunction(fptr, library, symbol)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLibraryLoadData(library: *mut cudaLibrary_t, code: *const ::core::ffi::c_void, jitOptions: *mut cudaJitOption, jitOptionsValues: *mut *mut ::core::ffi::c_void, numJitOptions: ::core::ffi::c_uint, libraryOptions: *mut cudaLibraryOption, libraryOptionValues: *mut *mut ::core::ffi::c_void, numLibraryOptions: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10445,7 +10937,7 @@ pub unsafe fn cudaLibraryLoadData(library: *mut cudaLibrary_t, code: *const ::co
         cudaLibraryLoadData(library, code, jitOptions, jitOptionsValues, numJitOptions, libraryOptions, libraryOptionValues, numLibraryOptions)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLibraryLoadFromFile(library: *mut cudaLibrary_t, fileName: *const ::core::ffi::c_char, jitOptions: *mut cudaJitOption, jitOptionsValues: *mut *mut ::core::ffi::c_void, numJitOptions: ::core::ffi::c_uint, libraryOptions: *mut cudaLibraryOption, libraryOptionValues: *mut *mut ::core::ffi::c_void, numLibraryOptions: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10462,7 +10954,7 @@ pub unsafe fn cudaLibraryLoadFromFile(library: *mut cudaLibrary_t, fileName: *co
         cudaLibraryLoadFromFile(library, fileName, jitOptions, jitOptionsValues, numJitOptions, libraryOptions, libraryOptionValues, numLibraryOptions)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLibraryUnload(library: cudaLibrary_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10479,7 +10971,7 @@ pub unsafe fn cudaLibraryUnload(library: cudaLibrary_t) -> cudaError_t {
         cudaLibraryUnload(library)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLogsCurrent(iterator_out: *mut cudaLogIterator, flags: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10496,7 +10988,7 @@ pub unsafe fn cudaLogsCurrent(iterator_out: *mut cudaLogIterator, flags: ::core:
         cudaLogsCurrent(iterator_out, flags)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLogsDumpToFile(iterator: *mut cudaLogIterator, pathToFile: *const ::core::ffi::c_char, flags: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10513,7 +11005,7 @@ pub unsafe fn cudaLogsDumpToFile(iterator: *mut cudaLogIterator, pathToFile: *co
         cudaLogsDumpToFile(iterator, pathToFile, flags)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLogsDumpToMemory(iterator: *mut cudaLogIterator, buffer: *mut ::core::ffi::c_char, size: *mut usize, flags: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10530,7 +11022,7 @@ pub unsafe fn cudaLogsDumpToMemory(iterator: *mut cudaLogIterator, buffer: *mut 
         cudaLogsDumpToMemory(iterator, buffer, size, flags)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLogsRegisterCallback(callbackFunc: cudaLogsCallback_t, userData: *mut ::core::ffi::c_void, callback_out: *mut cudaLogsCallbackHandle) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10547,7 +11039,7 @@ pub unsafe fn cudaLogsRegisterCallback(callbackFunc: cudaLogsCallback_t, userDat
         cudaLogsRegisterCallback(callbackFunc, userData, callback_out)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaLogsUnregisterCallback(callback: cudaLogsCallbackHandle) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10741,7 +11233,7 @@ pub unsafe fn cudaMemAdvise(devPtr: *const ::core::ffi::c_void, count: usize, ad
         cudaMemAdvise(devPtr, count, advice, device)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemAdvise(devPtr: *const ::core::ffi::c_void, count: usize, advice: cudaMemoryAdvise, location: cudaMemLocation) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10775,7 +11267,7 @@ pub unsafe fn cudaMemAdvise_v2(devPtr: *const ::core::ffi::c_void, count: usize,
         cudaMemAdvise_v2(devPtr, count, advice, location)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemDiscardAndPrefetchBatchAsync(dptrs: *mut *mut ::core::ffi::c_void, sizes: *mut usize, count: usize, prefetchLocs: *mut cudaMemLocation, prefetchLocIdxs: *mut usize, numPrefetchLocs: usize, flags: ::core::ffi::c_ulonglong, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10792,7 +11284,7 @@ pub unsafe fn cudaMemDiscardAndPrefetchBatchAsync(dptrs: *mut *mut ::core::ffi::
         cudaMemDiscardAndPrefetchBatchAsync(dptrs, sizes, count, prefetchLocs, prefetchLocIdxs, numPrefetchLocs, flags, stream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemDiscardBatchAsync(dptrs: *mut *mut ::core::ffi::c_void, sizes: *mut usize, count: usize, flags: ::core::ffi::c_ulonglong, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10809,7 +11301,7 @@ pub unsafe fn cudaMemDiscardBatchAsync(dptrs: *mut *mut ::core::ffi::c_void, siz
         cudaMemDiscardBatchAsync(dptrs, sizes, count, flags, stream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemGetDefaultMemPool(memPool: *mut cudaMemPool_t, location: *mut cudaMemLocation, type_: cudaMemAllocationType) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -10842,7 +11334,7 @@ pub unsafe fn cudaMemGetInfo(free: *mut usize, total: *mut usize) -> cudaError_t
         cudaMemGetInfo(free, total)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemGetMemPool(memPool: *mut cudaMemPool_t, location: *mut cudaMemLocation, type_: cudaMemAllocationType) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11052,7 +11544,7 @@ pub unsafe fn cudaMemPrefetchAsync(devPtr: *const ::core::ffi::c_void, count: us
         cudaMemPrefetchAsync(devPtr, count, dstDevice, stream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemPrefetchAsync(devPtr: *const ::core::ffi::c_void, count: usize, location: cudaMemLocation, flags: ::core::ffi::c_uint, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11086,7 +11578,7 @@ pub unsafe fn cudaMemPrefetchAsync_v2(devPtr: *const ::core::ffi::c_void, count:
         cudaMemPrefetchAsync_v2(devPtr, count, location, flags, stream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemPrefetchBatchAsync(dptrs: *mut *mut ::core::ffi::c_void, sizes: *mut usize, count: usize, prefetchLocs: *mut cudaMemLocation, prefetchLocIdxs: *mut usize, numPrefetchLocs: usize, flags: ::core::ffi::c_ulonglong, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11135,7 +11627,7 @@ pub unsafe fn cudaMemRangeGetAttributes(data: *mut *mut ::core::ffi::c_void, dat
         cudaMemRangeGetAttributes(data, dataSizes, attributes, numAttributes, devPtr, count)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemSetMemPool(location: *mut cudaMemLocation, type_: cudaMemAllocationType, memPool: cudaMemPool_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11329,7 +11821,7 @@ pub unsafe fn cudaMemcpy3DBatchAsync(numOps: usize, opList: *mut cudaMemcpy3DBat
         cudaMemcpy3DBatchAsync(numOps, opList, failIdx, flags, stream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemcpy3DBatchAsync(numOps: usize, opList: *mut cudaMemcpy3DBatchOp, flags: ::core::ffi::c_ulonglong, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11378,7 +11870,7 @@ pub unsafe fn cudaMemcpy3DPeerAsync(p: *const cudaMemcpy3DPeerParms, stream: cud
         cudaMemcpy3DPeerAsync(p, stream)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemcpy3DWithAttributesAsync(op: *mut cudaMemcpy3DBatchOp, flags: ::core::ffi::c_ulonglong, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11444,7 +11936,7 @@ pub unsafe fn cudaMemcpyBatchAsync(dsts: *mut *mut ::core::ffi::c_void, srcs: *m
         cudaMemcpyBatchAsync(dsts, srcs, sizes, count, attrs, attrsIdxs, numAttrs, failIdx, stream)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemcpyBatchAsync(dsts: *const *mut ::core::ffi::c_void, srcs: *const *const ::core::ffi::c_void, sizes: *const usize, count: usize, attrs: *mut cudaMemcpyAttributes, attrsIdxs: *mut usize, numAttrs: usize, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11621,7 +12113,7 @@ pub unsafe fn cudaMemcpyToSymbolAsync(symbol: *const ::core::ffi::c_void, src: *
         cudaMemcpyToSymbolAsync(symbol, src, count, offset, kind, stream)
     }
 }
-#[cfg(any(feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMemcpyWithAttributesAsync(dst: *mut ::core::ffi::c_void, src: *const ::core::ffi::c_void, size: usize, attr: *mut cudaMemcpyAttributes, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11734,7 +12226,7 @@ pub unsafe fn cudaMemsetAsync(devPtr: *mut ::core::ffi::c_void, value: ::core::f
         cudaMemsetAsync(devPtr, value, count, stream)
     }
 }
-#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11060", feature = "cuda-11070", feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaMipmappedArrayGetMemoryRequirements(memoryRequirements: *mut cudaArrayMemoryRequirements, mipmap: cudaMipmappedArray_t, device: ::core::ffi::c_int) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11815,7 +12307,7 @@ pub unsafe fn cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(numBlocks: 
         cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(numBlocks, func, blockSize, dynamicSMemSize, flags)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaOccupancyMaxActiveClusters(numClusters: *mut ::core::ffi::c_int, func: *const ::core::ffi::c_void, launchConfig: *const cudaLaunchConfig_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11832,7 +12324,7 @@ pub unsafe fn cudaOccupancyMaxActiveClusters(numClusters: *mut ::core::ffi::c_in
         cudaOccupancyMaxActiveClusters(numClusters, func, launchConfig)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaOccupancyMaxPotentialClusterSize(clusterSize: *mut ::core::ffi::c_int, func: *const ::core::ffi::c_void, launchConfig: *const cudaLaunchConfig_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -11995,7 +12487,7 @@ pub unsafe fn cudaSetValidDevices(device_arr: *mut ::core::ffi::c_int, len: ::co
         cudaSetValidDevices(device_arr, len)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaSignalExternalSemaphoresAsync(extSemArray: *const cudaExternalSemaphore_t, paramsArray: *const cudaExternalSemaphoreSignalParams, numExtSems: ::core::ffi::c_uint, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12077,7 +12569,7 @@ pub unsafe fn cudaStreamBeginCapture(stream: cudaStream_t, mode: cudaStreamCaptu
         cudaStreamBeginCapture(stream, mode)
     }
 }
-#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaStreamBeginCaptureToGraph(stream: cudaStream_t, graph: cudaGraph_t, dependencies: *const cudaGraphNode_t, dependencyData: *const cudaGraphEdgeData, numDependencies: usize, mode: cudaStreamCaptureMode) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12092,6 +12584,23 @@ pub unsafe fn cudaStreamBeginCaptureToGraph(stream: cudaStream_t, graph: cudaGra
             fn cudaStreamBeginCaptureToGraph(stream: cudaStream_t, graph: cudaGraph_t, dependencies: *const cudaGraphNode_t, dependencyData: *const cudaGraphEdgeData, numDependencies: usize, mode: cudaStreamCaptureMode) -> cudaError_t;
         }
         cudaStreamBeginCaptureToGraph(stream, graph, dependencies, dependencyData, numDependencies, mode)
+    }
+}
+#[cfg(any(feature = "cuda-13030"))]
+pub unsafe fn cudaStreamBeginRecaptureToGraph(stream: cudaStream_t, mode: cudaStreamCaptureMode, graph: cudaGraph_t, callbackData: *mut cudaGraphRecaptureCallbackData) -> cudaError_t {
+    #[cfg(feature = "dynamic-loading")]
+    {
+        type _F = unsafe extern "C" fn(cudaStream_t, cudaStreamCaptureMode, cudaGraph_t, *mut cudaGraphRecaptureCallbackData) -> cudaError_t;
+        static _S: OnceLock<_F> = OnceLock::new();
+        let _f = _S.get_or_init(|| unsafe { load::<_F>("cudaStreamBeginRecaptureToGraph") });
+        _f(stream, mode, graph, callbackData)
+    }
+    #[cfg(not(feature = "dynamic-loading"))]
+    {
+        extern "C" {
+            fn cudaStreamBeginRecaptureToGraph(stream: cudaStream_t, mode: cudaStreamCaptureMode, graph: cudaGraph_t, callbackData: *mut cudaGraphRecaptureCallbackData) -> cudaError_t;
+        }
+        cudaStreamBeginRecaptureToGraph(stream, mode, graph, callbackData)
     }
 }
 pub unsafe fn cudaStreamCopyAttributes(dst: cudaStream_t, src: cudaStream_t) -> cudaError_t {
@@ -12207,7 +12716,7 @@ pub unsafe fn cudaStreamGetAttribute(hStream: cudaStream_t, attr: cudaStreamAttr
         cudaStreamGetAttribute(hStream, attr, value_out)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaStreamGetAttribute(hStream: cudaStream_t, attr: cudaLaunchAttributeID, value_out: *mut cudaLaunchAttributeValue) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12241,7 +12750,7 @@ pub unsafe fn cudaStreamGetCaptureInfo(stream: cudaStream_t, pCaptureStatus: *mu
         cudaStreamGetCaptureInfo(stream, pCaptureStatus, pId)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaStreamGetCaptureInfo(stream: cudaStream_t, captureStatus_out: *mut cudaStreamCaptureStatus, id_out: *mut ::core::ffi::c_ulonglong, graph_out: *mut cudaGraph_t, dependencies_out: *mut *const cudaGraphNode_t, edgeData_out: *mut *const cudaGraphEdgeData, numDependencies_out: *mut usize) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12292,7 +12801,7 @@ pub unsafe fn cudaStreamGetCaptureInfo_v3(stream: cudaStream_t, captureStatus_ou
         cudaStreamGetCaptureInfo_v3(stream, captureStatus_out, id_out, graph_out, dependencies_out, edgeData_out, numDependencies_out)
     }
 }
-#[cfg(any(feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaStreamGetDevResource(hStream: cudaStream_t, resource: *mut cudaDevResource, type_: cudaDevResourceType) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12309,7 +12818,7 @@ pub unsafe fn cudaStreamGetDevResource(hStream: cudaStream_t, resource: *mut cud
         cudaStreamGetDevResource(hStream, resource, type_)
     }
 }
-#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaStreamGetDevice(hStream: cudaStream_t, device: *mut ::core::ffi::c_int) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12342,7 +12851,7 @@ pub unsafe fn cudaStreamGetFlags(hStream: cudaStream_t, flags: *mut ::core::ffi:
         cudaStreamGetFlags(hStream, flags)
     }
 }
-#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaStreamGetId(hStream: cudaStream_t, streamId: *mut ::core::ffi::c_ulonglong) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12424,7 +12933,7 @@ pub unsafe fn cudaStreamSetAttribute(hStream: cudaStream_t, attr: cudaStreamAttr
         cudaStreamSetAttribute(hStream, attr, value)
     }
 }
-#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-11080", feature = "cuda-12000", feature = "cuda-12010", feature = "cuda-12020", feature = "cuda-12030", feature = "cuda-12040", feature = "cuda-12050", feature = "cuda-12060", feature = "cuda-12080", feature = "cuda-12090", feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaStreamSetAttribute(hStream: cudaStream_t, attr: cudaLaunchAttributeID, value: *const cudaLaunchAttributeValue) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12474,7 +12983,7 @@ pub unsafe fn cudaStreamUpdateCaptureDependencies(stream: cudaStream_t, dependen
         cudaStreamUpdateCaptureDependencies(stream, dependencies, numDependencies, flags)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaStreamUpdateCaptureDependencies(stream: cudaStream_t, dependencies: *mut cudaGraphNode_t, dependencyData: *const cudaGraphEdgeData, numDependencies: usize, flags: ::core::ffi::c_uint) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {
@@ -12707,7 +13216,7 @@ pub unsafe fn cudaUserObjectRetain(object: cudaUserObject_t, count: ::core::ffi:
         cudaUserObjectRetain(object, count)
     }
 }
-#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020"))]
+#[cfg(any(feature = "cuda-13000", feature = "cuda-13010", feature = "cuda-13020", feature = "cuda-13030"))]
 pub unsafe fn cudaWaitExternalSemaphoresAsync(extSemArray: *const cudaExternalSemaphore_t, paramsArray: *const cudaExternalSemaphoreWaitParams, numExtSems: ::core::ffi::c_uint, stream: cudaStream_t) -> cudaError_t {
     #[cfg(feature = "dynamic-loading")]
     {


### PR DESCRIPTION
Closes #581

NVIDIA renamed the `cuda_cccl` redist module to `cccl` in the 13.3 manifest, which is what made the bindings generator panic. With that handled, the rest is the usual version bump:

- regenerated bindings with `cuda-13030` support
- feature flag, build.rs version table, cfg gates, CI matrix, README
- no safe-wrapper fixups needed this time — 13.3 kept the same struct shapes as 13.2

The generator change in this PR is now the minimum needed for 13.3: match the redist module names on `(major, minor)` so 13.3+ picks up the renamed `cccl` module, plus adding 13.3.0 to the generated version list. The broader generator resilience work (resume support, skip-unneeded downloads, download retries, descriptive manifest errors) has been split out into #588 as requested.

Tested locally against CUDA 13.3 (V13.3.33) on an RTX 4090:

- `cargo build -F cuda-13030` and `-F cuda-version-from-build-system` both build
- full feature set builds (cudnn, nccl, cupti, cusparse, cusolver, cufile, cutensor, cufft, ...)
- examples 01-04 run correctly, including the nvrtc kernel launch
- test suite: 56/57 pass on GPU; the one failure is `test_par_launch`, which fails the same way with `cuda-13020` on a cold GPU (timing-sensitive assert), so unrelated to this change
- `cargo check` still passes for cuda-13020, cuda-12090 and cuda-11040; clippy and fmt clean